### PR TITLE
chore(ci): Add tsc before build step

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -23,6 +23,10 @@ runs:
       shell: bash
       run: yarn --prefer-offline --frozen-lockfile
 
+    - name: Compile all packages
+      shell: bash
+      run: yarn tsc
+
     - name: Build all packages
       shell: bash
       run: yarn build ${{ inputs.args }}


### PR DESCRIPTION
`tsc` step was missing from the build step. See logs at:

https://github.com/janus-idp/backstage-plugins/actions/runs/3623692907/jobs/6109842475