### PR TITLE
fix: typo in keycloak annotations

### DIFF
--- a/plugins/keycloak-backend/src/lib/constants.ts
+++ b/plugins/keycloak-backend/src/lib/constants.ts
@@ -15,5 +15,5 @@
  */
 
 export const KEYCLOAK_HOST_ANNOTATION = 'keycloak.org/host';
-export const KEYCLOAK_ID_ANNOTATION = 'backstage.org/id';
-export const KEYCLOAK_REALM_ANNOTATION = 'backstage.org/realm';
+export const KEYCLOAK_ID_ANNOTATION = 'keycloak.org/id';
+export const KEYCLOAK_REALM_ANNOTATION = 'keycloak.org/realm';


### PR DESCRIPTION
I missed that when reviewing #1 .

I think you've meant to use `keycloak.org` everywhere when changing it from `backstage.io`