### PR TITLE
chore(ci): Fix release pipeline [attempt 2]

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -33,7 +33,9 @@ jobs:
         uses: ./.github/actions/build
 
       - name: Release via semantic-release
-        run: yarn release --ignore-private-packages || true
+        run: |
+          npm config set workspaces-update false
+          yarn release --ignore-private-packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
As per https://github.com/dhoulb/multi-semantic-release#npm-v85-npm-err-notarget-no-matching-version-found-for and https://github.com/dhoulb/multi-semantic-release/issues/129

I think this might be it. This is my last attempt to fix the `semantic-release` if this doesn't work I'll experiment with some other releasers like [intuit/auto](https://intuit.github.io/auto/)...