### PR TITLE
feat(ocm): Add an option to decouple ocm config from k8s plugin

### DIFF
--- a/plugins/ocm-backend/README.md
+++ b/plugins/ocm-backend/README.md
@@ -2,4 +2,4 @@
 
 This plugin integrates your Backstage instance with Open Cluster Management.
 
-This is just a part of the plugin, for documentation please refer to [`@janus-idp/backstage-plugin-ocm` documentation](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm-backend).
+This is just a part of the plugin, for documentation please refer to [`@janus-idp/backstage-plugin-ocm` documentation](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm).

--- a/plugins/ocm-backend/schema.d.ts
+++ b/plugins/ocm-backend/schema.d.ts
@@ -9,17 +9,17 @@ export interface Config {
     };
     hub?: {
       /**
-       * Url of the hub cluster API endpoint, applies if name is not defined
+       * Url of the hub cluster API endpoint
        * @visibility frontend
        */
       url: string;
       /**
-       * Name of the cluster endpoint
+       * Name of the cluster
        * @visibility frontend
        */
       name: string;
       /**
-       * Service Account Token for the SA which is used for querying data from the hub
+       * Service Account Token which is used for querying data from the hub
        * @visibility secret
        */
       serviceAccountToken?: string;

--- a/plugins/ocm-backend/schema.d.ts
+++ b/plugins/ocm-backend/schema.d.ts
@@ -1,9 +1,38 @@
 export interface Config {
   ocm: {
-    /**
-     * Name of the cluster where the Open Cluster Management operator is installed
-     * @visiblity frontend
-     */
-    hub: string;
+    cluster?: {
+      /**
+       * Match cluster name where the Open Cluster Management operator is installed from the kubernetes plugin configuration
+       * @visibility frontend
+       */
+      name: string;
+    };
+    hub?: {
+      /**
+       * Url of the hub cluster API endpoint, applies if name is not defined
+       * @visibility frontend
+       */
+      url: string;
+      /**
+       * Name of the cluster endpoint
+       * @visibility frontend
+       */
+      name: string;
+      /**
+       * Service Account Token for the SA which is used for querying data from the hub
+       * @visibility secret
+       */
+      serviceAccountToken?: string;
+      /**
+       * Skip TLS certificate verification presented by the API server, defaults to false
+       * @visibility frontend
+       */
+      skipTLSVerify?: boolean;
+      /**
+       * Base64-encoded CA bundle in PEM format used for verifying the TLS cert presented by the API server
+       * @visibility backend
+       */
+      caData?: string;
+    };
   };
 }

--- a/plugins/ocm-backend/schema.d.ts
+++ b/plugins/ocm-backend/schema.d.ts
@@ -1,12 +1,10 @@
 export interface Config {
   ocm: {
-    cluster?: {
-      /**
-       * Match cluster name where the Open Cluster Management operator is installed from the kubernetes plugin configuration
-       * @visibility frontend
-       */
-      name: string;
-    };
+    /**
+     * Match cluster name where the Open Cluster Management operator is installed from the kubernetes plugin configuration
+     * @visibility frontend
+     */
+    cluster?: string;
     hub?: {
       /**
        * Url of the hub cluster API endpoint

--- a/plugins/ocm-backend/src/helpers/config.test.ts
+++ b/plugins/ocm-backend/src/helpers/config.test.ts
@@ -1,110 +1,403 @@
 import { ConfigReader } from '@backstage/config';
-import { getHubClusterFromConfig } from './config';
+import { createLogger, transports } from 'winston';
+import {
+  getHubClusterFromKubernetesConfig,
+  getHubClusterFromConfig,
+  getHubClusterName,
+  getHubClusterFromOcmConfig,
+  getConfigVariantPath,
+} from './config';
 
-const createConfig = (clusters: any[]) => ({
-  kubernetes: {
-    clusterLocatorMethods: [
-      {
-        type: 'config',
-        clusters: clusters,
-      },
-    ],
-  },
-  ocm: {
-    hub: 'cluster2',
-  },
+const logger = createLogger({
+  transports: [new transports.Console({ silent: true })],
 });
 
-const createConfigParseResult = (name: string) => ({
-  data: { name: name },
+const createConfigParseResult = (data: object, prefix: string) => ({
+  data: data,
   context: 'mock-config',
-  prefix: 'kubernetes.clusterLocatorMethods[0].clusters[1]',
+  prefix: prefix,
   fallback: undefined,
   filteredKeys: undefined,
   notifiedFilteredKeys: new Set(),
 });
 
-describe('getHubClusterFromConfig', () => {
-  it('should get the correct hub cluster from multiple configured clusters', () => {
-    const config = new ConfigReader(
-      createConfig([
-        {
-          name: 'cluster1',
-        },
-        {
-          name: 'cluster2',
-        },
-        {
-          name: 'cluster3',
-        },
-      ]),
-    );
-
-    const result = getHubClusterFromConfig(config);
-
-    expect(result).toEqual(createConfigParseResult('cluster2'));
-  });
-
-  it('should throw an error when the hub cluster is not found', () => {
-    const config = new ConfigReader(
-      createConfig([
-        {
-          name: 'cluster4',
-        },
-      ]),
-    );
-
-    const result = () => getHubClusterFromConfig(config);
-
-    expect(result).toThrow('Hub cluster not defined in kubernetes config');
-  });
-
-  it('should throw an error when there are no cluster configured', () => {
-    const config = new ConfigReader(createConfig([]));
-
-    const result = () => {
-      getHubClusterFromConfig(config);
-    };
-
-    expect(result).toThrow('Hub cluster not defined in kubernetes config');
-  });
-
-  it('should throw an error when locator methods are empty', () => {
+describe('getConfigVariantPath', () => {
+  it('should only get the hub config path if the cluster config is also present', () => {
     const config = new ConfigReader({
-      kubernetes: {
-        clusterLocatorMethods: [],
-      },
       ocm: {
-        hub: 'cluster2',
+        cluster: {},
+        hub: {},
       },
     });
 
-    const result = () => getHubClusterFromConfig(config);
+    const result = getConfigVariantPath(config);
 
-    expect(result).toThrow('Hub cluster not defined in kubernetes config');
+    expect(result).toEqual('ocm.hub');
   });
 
-  it('should throw an error when there is to hub cluster configured', () => {
+  it('should get the cluster config path if its the only one configured', () => {
+    const config = new ConfigReader({
+      ocm: {
+        cluster: {},
+      },
+    });
+
+    const result = getConfigVariantPath(config);
+
+    expect(result).toEqual('ocm.cluster');
+  });
+
+  it('should throw if neither cluster or hub are configured', () => {
     const config = new ConfigReader({});
 
-    const result = () => getHubClusterFromConfig(config);
+    const result = () => getConfigVariantPath(config);
 
     expect(result).toThrow(
-      "Hub cluster must be specified in config at 'ocm.hub'",
+      "Neither hub or cluster configuration were specified at 'ocm.' config",
     );
   });
 });
 
 describe('getHubClusterName', () => {
-  it('should get the hub cluster name from config', () => {
+  it('should get the hub cluster name from ocm cluster config', () => {
     const config = new ConfigReader({
       ocm: {
-        hub: 'cluster2',
+        cluster: {
+          name: 'cluster2',
+        },
       },
     });
 
-    const result = config.getString('ocm.hub');
+    const result = getHubClusterName(config);
 
     expect(result).toBe('cluster2');
+  });
+
+  it('should get the hub cluster name from ocm hub config', () => {
+    const config = new ConfigReader({
+      ocm: {
+        hub: {
+          name: 'cluster2',
+        },
+      },
+    });
+
+    const result = getHubClusterName(config);
+
+    expect(result).toBe('cluster2');
+  });
+
+  it('should throw an error if neither hub or cluster are configured', () => {
+    const config = new ConfigReader({});
+
+    const result = () => getHubClusterName(config);
+
+    expect(result).toThrow(
+      "Neither hub or cluster configuration were specified at 'ocm.' config",
+    );
+  });
+
+  it('should throw an error if name is not configured', () => {
+    const config = new ConfigReader({
+      ocm: {
+        hub: {
+          url: 'http://example.com',
+        },
+      },
+    });
+
+    const result = () => getHubClusterName(config);
+
+    expect(result).toThrow("'ocm.hub.name' must be specified in hub config");
+  });
+});
+
+describe('getHubClusterFromKubernetesConfig', () => {
+  it('should get the correct hub cluster from multiple configured clusters', () => {
+    const config = new ConfigReader({
+      kubernetes: {
+        clusterLocatorMethods: [
+          {
+            type: 'config',
+            clusters: [
+              {
+                name: 'cluster1',
+              },
+              {
+                name: 'cluster2',
+              },
+              {
+                name: 'cluster3',
+              },
+            ],
+          },
+        ],
+      },
+      ocm: {
+        cluster: {
+          name: 'cluster2',
+        },
+      },
+    });
+
+    const result = getHubClusterFromKubernetesConfig(config);
+
+    expect(result).toEqual(
+      createConfigParseResult(
+        {
+          name: 'cluster2',
+        },
+        'kubernetes.clusterLocatorMethods[0].clusters[1]',
+      ),
+    );
+  });
+
+  it('should throw an error when the hub cluster is not found in kubernetes config', () => {
+    const config = new ConfigReader({
+      kubernetes: {
+        clusterLocatorMethods: [
+          {
+            type: 'config',
+            clusters: [
+              {
+                name: 'cluster4',
+              },
+            ],
+          },
+        ],
+      },
+      ocm: {
+        cluster: {
+          name: 'cluster2',
+        },
+      },
+    });
+
+    const result = () => getHubClusterFromKubernetesConfig(config);
+
+    expect(result).toThrow('Hub cluster not defined in kubernetes config');
+  });
+
+  it('should throw an error when there are no cluster configured', () => {
+    const config = new ConfigReader({
+      kubernetes: {
+        clusterLocatorMethods: [
+          {
+            type: 'config',
+          },
+        ],
+      },
+      ocm: {
+        cluster: {
+          name: 'cluster2',
+        },
+      },
+    });
+
+    const result = () => {
+      getHubClusterFromKubernetesConfig(config);
+    };
+
+    expect(result).toThrow('Hub cluster not defined in kubernetes config');
+  });
+
+  it('should throw an error when there is no kubernetes config', () => {
+    const config = new ConfigReader({
+      ocm: {
+        cluster: {
+          name: 'cluster2',
+        },
+      },
+    });
+
+    const result = () => getHubClusterFromKubernetesConfig(config);
+
+    expect(result).toThrow(
+      "Missing required config value at 'kubernetes.clusterLocatorMethods'",
+    );
+  });
+
+  it('should throw an error when there is no ocm cluster name configured', () => {
+    const config = new ConfigReader({
+      kubernetes: {
+        clusterLocatorMethods: [
+          {
+            type: 'config',
+          },
+        ],
+      },
+      ocm: {
+        cluster: {
+          key: 'value',
+        },
+      },
+    });
+
+    const result = () => getHubClusterFromKubernetesConfig(config);
+
+    expect(result).toThrow('Hub cluster not defined in kubernetes config');
+  });
+});
+
+describe('getHubClusterFromOcmConfig', () => {
+  it('should correctly return an ocm hub config', () => {
+    const config = new ConfigReader({
+      ocm: {
+        hub: {
+          name: 'cluster2',
+          url: 'http://example.com',
+        },
+      },
+    });
+
+    const result = getHubClusterFromOcmConfig(config);
+
+    expect(result).toEqual(
+      createConfigParseResult(
+        {
+          name: 'cluster2',
+          url: 'http://example.com',
+        },
+        'ocm.hub',
+      ),
+    );
+  });
+
+  it("should throw an error when url isn't specified in the hub config", () => {
+    const config = new ConfigReader({
+      ocm: {
+        hub: {
+          name: 'cluster2',
+        },
+      },
+    });
+
+    const result = () => getHubClusterFromOcmConfig(config);
+
+    expect(result).toThrow(
+      "Hub cluster url must be specified in config at 'ocm.hub.url'",
+    );
+  });
+
+  it("should throw an error when name isn't specified in the hub config", () => {
+    const config = new ConfigReader({
+      ocm: {
+        hub: {
+          url: 'http://example.com',
+        },
+      },
+    });
+
+    const result = () => getHubClusterFromOcmConfig(config);
+
+    expect(result).toThrow(
+      "Hub cluster name must be specified in config at 'ocm.hub.name'",
+    );
+  });
+});
+
+describe('getHubClusterFromConfig', () => {
+  it('should parse only the hub config if the kubernetes config is also present', () => {
+    const config = new ConfigReader({
+      kubernetes: {
+        clusterLocatorMethods: [
+          {
+            type: 'config',
+            clusters: [
+              {
+                name: 'cluster1',
+              },
+            ],
+          },
+        ],
+      },
+      ocm: {
+        hub: {
+          url: 'https://example.com',
+          name: 'cluster2',
+        },
+      },
+    });
+
+    const result = getHubClusterFromConfig(config, logger);
+
+    expect(result).toEqual(
+      createConfigParseResult(
+        { url: 'https://example.com', name: 'cluster2' },
+        'ocm.hub',
+      ),
+    );
+  });
+
+  it('should parse the ocm cluster config and get the correct kubernetes cluster configuration', () => {
+    const config = new ConfigReader({
+      kubernetes: {
+        clusterLocatorMethods: [
+          {
+            type: 'config',
+            clusters: [
+              {
+                name: 'cluster1',
+              },
+              {
+                name: 'cluster2',
+              },
+            ],
+          },
+        ],
+      },
+      ocm: {
+        cluster: {
+          name: 'cluster1',
+        },
+      },
+    });
+
+    const result = getHubClusterFromConfig(config, logger);
+
+    expect(result).toEqual(
+      createConfigParseResult(
+        { name: 'cluster1' },
+        'kubernetes.clusterLocatorMethods[0].clusters[0]',
+      ),
+    );
+  });
+
+  it('should prefer the hub configuration over the cluster configuration', () => {
+    const config = new ConfigReader({
+      kubernetes: {
+        clusterLocatorMethods: [
+          {
+            type: 'config',
+            clusters: [
+              {
+                name: 'cluster3',
+              },
+              {
+                name: 'cluster2',
+              },
+            ],
+          },
+        ],
+      },
+      ocm: {
+        cluster: {
+          name: 'cluster3',
+        },
+        hub: {
+          url: 'https://example.com',
+          name: 'cluster1',
+        },
+      },
+    });
+
+    const result = getHubClusterFromConfig(config, logger);
+
+    expect(result).toEqual(
+      createConfigParseResult(
+        { url: 'https://example.com', name: 'cluster1' },
+        'ocm.hub',
+      ),
+    );
   });
 });

--- a/plugins/ocm-backend/src/helpers/config.test.ts
+++ b/plugins/ocm-backend/src/helpers/config.test.ts
@@ -44,7 +44,7 @@ describe('getConfigVariantPath', () => {
 
     const result = getConfigVariantPath(config);
 
-    expect(result).toEqual('ocm.cluster');
+    expect(result).toEqual('ocm');
   });
 
   it('should throw if neither cluster or hub are configured', () => {
@@ -62,9 +62,7 @@ describe('getHubClusterName', () => {
   it('should get the hub cluster name from ocm cluster config', () => {
     const config = new ConfigReader({
       ocm: {
-        cluster: {
-          name: 'cluster2',
-        },
+        cluster: 'cluster2',
       },
     });
 
@@ -108,7 +106,9 @@ describe('getHubClusterName', () => {
 
     const result = () => getHubClusterName(config);
 
-    expect(result).toThrow("'ocm.hub.name' must be specified in hub config");
+    expect(result).toThrow(
+      "'ocm.hub.name' or 'ocm.cluster' must be specified in ocm config",
+    );
   });
 });
 
@@ -134,9 +134,7 @@ describe('getHubClusterFromKubernetesConfig', () => {
         ],
       },
       ocm: {
-        cluster: {
-          name: 'cluster2',
-        },
+        cluster: 'cluster2',
       },
     });
 
@@ -167,9 +165,7 @@ describe('getHubClusterFromKubernetesConfig', () => {
         ],
       },
       ocm: {
-        cluster: {
-          name: 'cluster2',
-        },
+        cluster: 'cluster2',
       },
     });
 
@@ -347,9 +343,7 @@ describe('getHubClusterFromConfig', () => {
         ],
       },
       ocm: {
-        cluster: {
-          name: 'cluster1',
-        },
+        cluster: 'cluster1',
       },
     });
 

--- a/plugins/ocm-backend/src/helpers/config.ts
+++ b/plugins/ocm-backend/src/helpers/config.ts
@@ -1,29 +1,78 @@
 import { Config } from '@backstage/config';
+import { Logger } from 'winston';
 
 const CLUSTERS_PATH = 'kubernetes.clusterLocatorMethods';
-const HUB_CLUSTER_CONFIG_PATH = 'ocm.hub';
+const OCM_PREFIX = 'ocm';
+const CLUSTER_CONFIG_PATH = `${OCM_PREFIX}.cluster`;
+const HUB_CONFIG_PATH = `${OCM_PREFIX}.hub`;
 
-export const getHubClusterName = (config: Config) =>
-  config.getString(HUB_CLUSTER_CONFIG_PATH);
+export const getConfigVariantPath = (config: Config): string => {
+  const hubConfig = config.has(HUB_CONFIG_PATH);
 
-export const getHubClusterFromConfig = (config: Config) => {
-  try {
-    getHubClusterName(config);
-  } catch (err) {
+  if (!hubConfig && !config.has(CLUSTER_CONFIG_PATH)) {
     throw new Error(
-      `Hub cluster must be specified in config at '${HUB_CLUSTER_CONFIG_PATH}'`,
+      `Neither hub or cluster configuration were specified at '${OCM_PREFIX}.' config`,
     );
   }
 
+  return hubConfig ? HUB_CONFIG_PATH : CLUSTER_CONFIG_PATH;
+};
+
+export const getHubClusterName = (config: Config): string => {
+  const path = `${getConfigVariantPath(config)}.name`;
+  try {
+    return config.getString(path);
+  } catch (err) {
+    throw new Error(`'${path}' must be specified in hub config`);
+  }
+};
+
+export const getHubClusterFromKubernetesConfig = (config: Config): Config => {
   const hub = config
     .getConfigArray(CLUSTERS_PATH)
     .flatMap(method => method.getOptionalConfigArray('clusters') || [])
     .find(
       cluster =>
-        cluster.getString('name') === config.getString(HUB_CLUSTER_CONFIG_PATH),
+        cluster.getString('name') ===
+        config.getOptionalString(`${CLUSTER_CONFIG_PATH}.name`),
     );
   if (!hub) {
     throw new Error('Hub cluster not defined in kubernetes config');
   }
   return hub;
+};
+
+export const getHubClusterFromOcmConfig = (config: Config): Config => {
+  const hub = config.getConfig(HUB_CONFIG_PATH);
+  // Check if required values are valid
+  const requiredValues = ['name', 'url'];
+  requiredValues.forEach(key => {
+    if (!config.has(`${HUB_CONFIG_PATH}.${key}`)) {
+      throw new Error(
+        `Hub cluster ${key} must be specified in config at '${HUB_CONFIG_PATH}.${key}'`,
+      );
+    }
+  });
+  return hub;
+};
+
+export const getHubClusterFromConfig = (
+  config: Config,
+  logger: Logger,
+): Config => {
+  // If no configuration is found an error is thrown
+  const path = getConfigVariantPath(config);
+
+  if (path === HUB_CONFIG_PATH) {
+    logger.info(`Loading config from ${HUB_CONFIG_PATH} config`);
+    return getHubClusterFromOcmConfig(config);
+  }
+  if (path === CLUSTER_CONFIG_PATH) {
+    logger.info(`Loading config from ${CLUSTER_CONFIG_PATH} config`);
+    return getHubClusterFromKubernetesConfig(config);
+  }
+
+  throw new Error(
+    'An unknown error occurred while getting the OCM configuration',
+  );
 };

--- a/plugins/ocm-backend/src/helpers/kubernetes.test.ts
+++ b/plugins/ocm-backend/src/helpers/kubernetes.test.ts
@@ -49,7 +49,7 @@ describe('getCustomObjectsApi', () => {
 });
 
 describe('hubApiClient', () => {
-  it('should return an api client configured with the hub cluster', () => {
+  it('should return an api client configured with the hub cluster from kubernetes config', () => {
     const config = new ConfigReader({
       kubernetes: {
         clusterLocatorMethods: [
@@ -66,7 +66,28 @@ describe('hubApiClient', () => {
         ],
       },
       ocm: {
-        hub: 'cluster2',
+        cluster: {
+          name: 'cluster2',
+        },
+      },
+    });
+
+    const result = hubApiClient(config, logger);
+
+    expect(result.basePath).toBe('http://cluster2.com');
+    // These fields aren't on the type but are there
+    const auth = (result as any).authentications.default;
+    expect(auth.clusters[0].name).toBe('cluster2');
+  });
+
+  it('should return an api client configured with the hub cluster from the ocm config', () => {
+    const config = new ConfigReader({
+      ocm: {
+        hub: {
+          name: 'cluster2',
+          url: 'http://cluster2.com',
+          serviceAccountToken: 'TOKEN',
+        },
       },
     });
 

--- a/plugins/ocm-backend/src/helpers/kubernetes.test.ts
+++ b/plugins/ocm-backend/src/helpers/kubernetes.test.ts
@@ -66,9 +66,7 @@ describe('hubApiClient', () => {
         ],
       },
       ocm: {
-        cluster: {
-          name: 'cluster2',
-        },
+        cluster: 'cluster2',
       },
     });
 

--- a/plugins/ocm-backend/src/helpers/kubernetes.ts
+++ b/plugins/ocm-backend/src/helpers/kubernetes.ts
@@ -46,7 +46,7 @@ export const getCustomObjectsApi = (
 };
 
 export const hubApiClient = (config: Config, logger: Logger) => {
-  const hubClusterConfig = getHubClusterFromConfig(config);
+  const hubClusterConfig = getHubClusterFromConfig(config, logger);
   return getCustomObjectsApi(hubClusterConfig, logger);
 };
 

--- a/plugins/ocm/README.md
+++ b/plugins/ocm/README.md
@@ -59,25 +59,40 @@ This plugin is made up of 2 packages:
    yarn workspace backend add @janus-idp/backstage-plugin-ocm-backend
    ```
 
-2. Next, you need to configure it. Please add following to your `app-config.yaml` file:
+2. Next, you need to configure it. There are two possible configurations.
 
-   ```diff
-   # app-config.yaml
-   kubernetes:
-     serviceLocatorMethod:
-       type: "multiTenant"
-     clusterLocatorMethods:
-       - type: "config"
-         clusters:
-           - name: <cluster-name>
-           ...
-           ...
+   1. The information about your hub is provided purely by the OCM configuration. In order to use this configuration please add the following to your `app-config.yaml` file:
 
-   + ocm:
-   +   hub: <cluster-name> # Match the cluster name in kubernetes plugin config
-   ```
+      ```diff
+      # app-config.yaml
+      + ocm:
+      +   hub:
+      +     name: # Name of the cluster
+      +     url: # Url of the hub cluster API endpoint
+      +     serviceAccountToken: # Token used for querying data from the hub
+      +     skipTLSVerify: # Skip TLS certificate verification, defaults to false
+      +     caData: # Base64-encoded CA bundle in PEM format
+      ```
 
-   Please consult the documentation to [Backstage Kubernetes plugin](https://backstage.io/docs/features/kubernetes/configuration#configuring-kubernetes-clusters) for details on its configuration. Hub cluster must be connected via Service Account.
+   2. The hub configuration is tied to the kubernetes plugin configuration by providing the name of the hub. This is useful when you already use a kubernetes plugin in your backstage instance. Please add following to your `app-config.yaml` file:
+
+      ```diff
+      # app-config.yaml
+      kubernetes:
+        serviceLocatorMethod:
+          type: "multiTenant"
+        clusterLocatorMethods:
+          - type: "config"
+            clusters:
+              - name: <cluster-name>
+              ...
+              ...
+
+      + ocm:
+      +   cluster: <cluster-name> # Match the cluster name in kubernetes plugin config
+      ```
+
+      Please consult the documentation to [Backstage Kubernetes plugin](https://backstage.io/docs/features/kubernetes/configuration#configuring-kubernetes-clusters) for details on its configuration. Hub cluster must be connected via Service Account.
 
 3. Create new plugin instance in `packages/backend/src/plugins/ocm.ts`:
 


### PR DESCRIPTION
Resolves #48 

Change the `ocm-backend` config schema to allow for an explicit configuration of the ocm plugin without a requirement for the Kubernetes plugin configuration.

Add `serviceAccountToken` field to the hub configuration scheme since we don't have any other way to access the hub. We can then remove this in the future when we have proper RBAC.

Update/create tests for additional functions that are created in order to parse the configuration file.

Options like `skipMetricsLookup` and `caFile` are omitted since we don't even support these options in the code.

Update: Update documentation for standalone OCM configuration