### PR TITLE
feat(ocm): Add update information to the `/status` API endpoint

### DIFF
--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -33,12 +33,13 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "node-fetch": "^3.0.0",
+    "semver": "^7.3.8",
     "winston": "^3.2.1",
     "yn": "^5.0.0"
   },
   "devDependencies": {
-    "@types/express": "4.17.14",
     "@backstage/cli": "0.21.1",
+    "@types/express": "4.17.14",
     "@types/supertest": "2.0.12",
     "msw": "0.49.1",
     "nock": "13.2.9",

--- a/plugins/ocm-backend/src/helpers/kubernetes.test.ts
+++ b/plugins/ocm-backend/src/helpers/kubernetes.test.ts
@@ -4,6 +4,7 @@ import {
   hubApiClient,
   getManagedCluster,
   getManagedClusters,
+  getManagedClustersInfo,
 } from './kubernetes';
 import { createLogger } from 'winston';
 import transports from 'winston/lib/winston/transports';
@@ -174,5 +175,36 @@ describe('getManagedCluster', () => {
 
     expect(result.statusCode).toBe(404);
     expect(result.name).toBe('NotFound');
+  });
+});
+
+describe('getManagedClustersInfo', () => {
+  it('should return some clusters', async () => {
+    nock(kubeConfig.clusters[0].server)
+      .get(
+        '/apis/internal.open-cluster-management.io/v1beta1/managedclusterinfos',
+      )
+      .reply(200, {
+        body: {
+          items: [
+            {
+              kind: 'ManagedClusterInfo',
+              metadata: {
+                name: 'cluster1',
+              },
+            },
+            {
+              kind: 'ManagedClusterInfo',
+              metadata: {
+                name: 'cluster2',
+              },
+            },
+          ],
+        },
+      });
+
+    const result: any = await getManagedClustersInfo(getApi());
+    expect(result.body.items[0].metadata.name).toBe('cluster1');
+    expect(result.body.items[1].metadata.name).toBe('cluster2');
   });
 });

--- a/plugins/ocm-backend/src/helpers/kubernetes.ts
+++ b/plugins/ocm-backend/src/helpers/kubernetes.ts
@@ -89,3 +89,13 @@ export const getManagedClusters = (api: CustomObjectsApi) => {
     ),
   );
 };
+
+export const getManagedClustersInfo = (api: CustomObjectsApi) => {
+  return kubeApiResponseHandler(
+    api.listClusterCustomObject(
+      'internal.open-cluster-management.io',
+      'v1beta1',
+      'managedclusterinfos',
+    ),
+  );
+};

--- a/plugins/ocm-backend/src/helpers/parser.ts
+++ b/plugins/ocm-backend/src/helpers/parser.ts
@@ -1,5 +1,6 @@
 import { CONSOLE_CLAIM } from '../constants';
 import { ClusterDetails } from '@janus-idp/backstage-plugin-ocm-common';
+import { maxSatisfying } from 'semver';
 
 const convertCpus = (cpus: string | undefined): number | undefined => {
   if (!cpus) {
@@ -56,5 +57,31 @@ export const parseManagedCluster = (cluster: any): ClusterDetails => {
   return {
     ...status,
     ...parsedClusterInfo,
+  };
+};
+
+export const parseUpdateInfo = (clusterInfo: any) => {
+  const { availableUpdates, versionAvailableUpdates } =
+    clusterInfo.status.distributionInfo.ocp;
+  /*
+   * We assume here that if availableUpdates is empty
+   * versionAvailableUpdates also has to be empty
+   */
+  if (!availableUpdates || availableUpdates.length === 0) {
+    return {
+      update: {
+        available: false,
+      },
+    };
+  }
+
+  const version = maxSatisfying(availableUpdates, '*');
+
+  return {
+    update: {
+      available: true,
+      version,
+      url: versionAvailableUpdates[availableUpdates.indexOf(version)].url,
+    },
   };
 };

--- a/plugins/ocm-common/src/index.ts
+++ b/plugins/ocm-common/src/index.ts
@@ -24,6 +24,11 @@ export type ClusterDetails = {
     memorySize?: string;
     numberOfPods?: number;
   };
+  update?: {
+    available?: boolean;
+    version?: string;
+    url?: string;
+  };
   status: {
     available: boolean;
     reason: string;

--- a/plugins/ocm/README.md
+++ b/plugins/ocm/README.md
@@ -22,6 +22,14 @@ This plugin integrates your Backstage instance with Open Cluster Management's Mu
          - get
          - watch
          - list
+     - apiGroups:
+         - internal.open-cluster-management.io
+       resources:
+         - managedclusterinfos
+       verbs:
+         - get
+         - watch
+         - list
    ```
 
 ## Capabilities


### PR DESCRIPTION
Serve as the backend for https://github.com/operate-first/service-catalog/issues/179

Add additional API call to gather information about cluster updates and provide it in the `/status` API endpoint. Also  create tests for newly created functions.

I couldn't find an endpoint that only provides a single cluster, so I have to use the endpoint (`internal.open-cluster-management.io/v1beta1/managedclusterinfos`) even in the `/status/:clusterName` API endpoint.

Example of the new API response on `/status/smaug` (see the `update` section at the end):
```json
{
  "name": "smaug",
  "status": {
    "available": true,
    "reason": "Managed cluster is available"
  },
  "consoleUrl": "https://console-openshift-console.apps.smaug.na.operate-first.cloud",
  "kubernetesVersion": "v1.22.3+fdba464",
  "oauthUrl": "https://oauth-openshift.apps.smaug.na.operate-first.cloud/oauth/token/implicit",
  "openshiftId": "5d448ae7-05f1-42cc-aacc-3122a8ad0184",
  "openshiftVersion": "4.9.21",
  "platform": "BareMetal",
  "allocatableResources": {
    "cpuCores": 1136.5,
    "memorySize": "7469511796Ki",
    "numberOfPods": 7750
  },
  "availableResources": {
    "cpuCores": 1152,
    "memorySize": "7505192052Ki",
    "numberOfPods": 7750
  },
  "update": {
    "available": true,
    "version": "4.9.53",
    "url": "https://access.redhat.com/errata/RHBA-2022:8714"
  }
}
```

