### PR TITLE
feat(ocm): Add a frontend indicator for cluster upgrades

### DIFF
--- a/plugins/ocm/src/components/ClusterInfoCard/ClusterInfoCard.tsx
+++ b/plugins/ocm/src/components/ClusterInfoCard/ClusterInfoCard.tsx
@@ -1,14 +1,52 @@
 import React from 'react';
-
+import { Button, Grid, makeStyles, Tooltip } from '@material-ui/core';
+import ArrowUpwardRoundedIcon from '@material-ui/icons/ArrowUpwardRounded';
 import { useCluster } from '../ClusterContext';
 import { TableCardFromData } from '../TableCardFromData';
 
+const useStyles = makeStyles({
+  button: {
+    textTransform: 'none',
+    borderRadius: 16,
+    margin: '0px',
+    paddingLeft: '4px',
+    paddingRight: '4px',
+  },
+});
+
 export const ClusterInfoCard = () => {
   const { data } = useCluster();
+  const classes = useStyles();
 
   if (!data) {
     return null;
   }
+
+  data.openshiftVersion = (
+    <>
+      {data.update?.available ? (
+        <Grid container direction="column" spacing={0}>
+          <Grid item>{data.openshiftVersion}</Grid>
+          <Grid item>
+            <Tooltip title={`Version ${data.update?.version!} available`}>
+              <Button
+                variant="text"
+                color="primary"
+                startIcon={<ArrowUpwardRoundedIcon style={{ fontSize: 22 }} />}
+                className={classes.button}
+                href={data.update?.url}
+                size="small"
+              >
+                Upgrade available
+              </Button>
+            </Tooltip>
+          </Grid>
+        </Grid>
+      ) : (
+        data.openshiftVersion
+      )}
+    </>
+  ) as any;
 
   const nameMap = new Map<string, string>([
     ['name', 'Name'],

--- a/plugins/ocm/src/components/TableCardFromData/TableCardFromData.tsx
+++ b/plugins/ocm/src/components/TableCardFromData/TableCardFromData.tsx
@@ -18,7 +18,7 @@ const valueFormatter = (value: any): any => {
       return <Link to={value}>{value}</Link>;
     }
   }
-  return value.toString();
+  return value;
 };
 
 export const TableCardFromData = ({
@@ -30,12 +30,12 @@ export const TableCardFromData = ({
   title: string;
   nameMap: Map<string, string>;
 }) => {
-  const parsedData: { name: string; value: string }[] = [];
+  const parsedData: { name: string; value: any }[] = [];
   const entries = Object.entries(data);
 
   nameMap.forEach((_, key) => {
     const entry = entries.find(e => e[0] === key)!;
-    // If key of the map doesnt have an prop in the cluster object, continue
+    // If key of the map doesn't have an prop in the cluster object, continue
     if (entry === undefined) {
       return;
     }


### PR DESCRIPTION
Resolves https://github.com/operate-first/service-catalog/issues/179

Add an indicator for displaying whether an upgrade is available. Additionally add a mouse over tooltip showing which version is available linking to the Red Hat Product Erreta.

Since we want to make this look like the ACM indicator (see the comparison bellow) an external icon would have to be used (ACM uses patternfly for icons). This would require us to import an external `svg` which I don't think is very clean.
![image](https://user-images.githubusercontent.com/44006847/213139757-c27ae406-8881-4a21-8fea-17404f8ba21f.png)
![image](https://user-images.githubusercontent.com/44006847/213141955-6445d7c5-c141-44b5-9106-46cb58c0bd71.png)

The closest match I found in the material ui icons is this.
![image](https://user-images.githubusercontent.com/44006847/213140326-46e94a40-0646-428d-b4af-4439172fa41e.png)
