### PR TITLE
feat(ocm): Add a default owner configuration field

### DIFF
--- a/plugins/ocm-backend/config.d.ts
+++ b/plugins/ocm-backend/config.d.ts
@@ -36,7 +36,12 @@ export interface Config {
         /**
          * Key is reflected as provider ID. Defines and claims plugin instance ownership of entities
          */
-        [key: string]: KubernetesPluginRef | HubClusterConfig;
+        [key: string]: (KubernetesPluginRef | HubClusterConfig) & {
+          /**
+           * Owner reference to created cluster entities in the catalog
+           */
+          owner?: string;
+        };
       };
     };
   };

--- a/plugins/ocm-backend/src/helpers/config.ts
+++ b/plugins/ocm-backend/src/helpers/config.ts
@@ -4,6 +4,7 @@ import { OcmConfig } from '../types';
 const KUBERNETES_PLUGIN_CONFIG = 'kubernetes.clusterLocatorMethods';
 const OCM_PREFIX = 'catalog.providers.ocm';
 const KUBERNETES_PLUGIN_KEY = 'kubernetesPluginRef';
+const OWNER_KEY = 'owner';
 
 const isValidUrl = (url: string): boolean => {
   try {
@@ -83,6 +84,7 @@ export const getHubClusterFromConfig = (
     serviceAccountToken: hub.getOptionalString('serviceAccountToken'),
     skipTLSVerify: hub.getOptionalBoolean('skipTLSVerify') || false,
     caData: hub.getOptionalString('caData'),
+    owner: config.getOptionalString(OWNER_KEY) || 'unknown',
   };
 };
 

--- a/plugins/ocm-backend/src/providers/ManagedClusterProvider.ts
+++ b/plugins/ocm-backend/src/providers/ManagedClusterProvider.ts
@@ -47,6 +47,7 @@ export class ManagedClusterProvider implements EntityProvider {
   protected readonly client: CustomObjectsApi;
   protected readonly hubResourceName: string;
   protected readonly id: string;
+  protected readonly owner: string;
   protected readonly logger: winston.Logger;
   protected connection?: EntityProviderConnection;
 
@@ -55,11 +56,13 @@ export class ManagedClusterProvider implements EntityProvider {
     hubResourceName: string,
     id: string,
     options: { logger: winston.Logger },
+    owner: string,
   ) {
     this.client = client;
     this.hubResourceName = hubResourceName;
     this.id = id;
     this.logger = options.logger;
+    this.owner = owner;
   }
 
   static fromConfig(config: Config, options: { logger: winston.Logger }) {
@@ -70,6 +73,7 @@ export class ManagedClusterProvider implements EntityProvider {
         provider.hubResourceName,
         provider.id,
         options,
+        provider.owner,
       );
     });
   }
@@ -138,7 +142,7 @@ export class ManagedClusterProvider implements EntityProvider {
           ],
         },
         spec: {
-          owner: 'unknown',
+          owner: this.owner,
           type: 'kubernetes-cluster',
         },
       };

--- a/plugins/ocm-backend/src/types.ts
+++ b/plugins/ocm-backend/src/types.ts
@@ -7,6 +7,7 @@ export type OcmConfig = {
   serviceAccountToken?: string;
   skipTLSVerify?: boolean;
   caData?: string;
+  owner: string;
 };
 
 export interface ClusterClaim {

--- a/plugins/ocm/README.md
+++ b/plugins/ocm/README.md
@@ -168,6 +168,17 @@ This plugin is made up of 2 packages:
      }
    ```
 
+6. (Optional) The default owner for the cluster entities in the catalog for a specific env can additionally be configured. The configuration follows the [upstream string references documentation](https://backstage.io/docs/features/software-catalog/references/#string-references). For example to set `foo` as the owner for clusters from `env` in the catalog use:
+
+   ```yaml
+   # app-config.yaml
+   catalog:
+     providers:
+       ocm:
+         env:
+           owner: user:foo
+   ```
+
 ### Setup `@janus-idp/backstage-plugin-ocm`
 
 Install the frontend plugin:


### PR DESCRIPTION
Fixes #140 

Add a configuration option for adding a default owner to the created entities from the cluster discovery. It works by using mimicking the backstage owner references described here: https://backstage.io/docs/features/software-catalog/references/.
