### PR TITLE
fixes 155a adding default metadata

### DIFF
--- a/plugins/3scale-backend/package.json
+++ b/plugins/3scale-backend/package.json
@@ -41,5 +41,12 @@
     "dist",
     "config.d.ts"
   ],
-  "configSchema": "config.d.ts"
+  "configSchema": "config.d.ts",
+  "repository": "github:janus-idp/backstage-plugins",
+  "keywords": [
+    "backstage",
+    "plugin"
+  ],
+  "homepage": "https://janus-idp.io/",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/keycloak-backend/package.json
+++ b/plugins/keycloak-backend/package.json
@@ -43,5 +43,12 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "repository": "github:janus-idp/backstage-plugins",
+  "keywords": [
+    "backstage",
+    "plugin"
+  ],
+  "homepage": "https://janus-idp.io/",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -48,5 +48,12 @@
   "files": [
     "dist",
     "schema.d.ts"
-  ]
+  ],
+  "repository": "github:janus-idp/backstage-plugins",
+  "keywords": [
+    "backstage",
+    "plugin"
+  ],
+  "homepage": "https://janus-idp.io/",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/ocm-common/package.json
+++ b/plugins/ocm-common/package.json
@@ -27,5 +27,12 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "repository": "github:janus-idp/backstage-plugins",
+  "keywords": [
+    "backstage",
+    "plugin"
+  ],
+  "homepage": "https://janus-idp.io/",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/ocm/package.json
+++ b/plugins/ocm/package.json
@@ -53,5 +53,12 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "repository": "github:janus-idp/backstage-plugins",
+  "keywords": [
+    "backstage",
+    "plugin"
+  ],
+  "homepage": "https://janus-idp.io/",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/quay/package.json
+++ b/plugins/quay/package.json
@@ -52,5 +52,12 @@
     "dist",
     "config.d.ts"
   ],
-  "configSchema": "config.d.ts"
+  "configSchema": "config.d.ts",
+  "repository": "github:janus-idp/backstage-plugins",
+  "keywords": [
+    "backstage",
+    "plugin"
+  ],
+  "homepage": "https://janus-idp.io/",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/topology/package.json
+++ b/plugins/topology/package.json
@@ -33,7 +33,6 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.45",
-    "react-use": "^17.2.4",
     "@patternfly/patternfly": "4.217.1",
     "@patternfly/react-charts": "6.94.7",
     "@patternfly/react-core": "4.267.6",
@@ -44,7 +43,8 @@
     "classnames": "2.x",
     "lodash": "^4.17.19",
     "mobx": "^5.15.4",
-    "mobx-react": "^6.2.0"
+    "mobx-react": "^6.2.0",
+    "react-use": "^17.2.4"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0"
@@ -64,5 +64,12 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "repository": "github:janus-idp/backstage-plugins",
+  "keywords": [
+    "backstage",
+    "plugin"
+  ],
+  "homepage": "https://janus-idp.io/",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }


### PR DESCRIPTION
fix(metadata): adding default metadata to current plugins

missing metadata we need (#155a): -repository : github:janus-idp/backstage-plugins, -keywords : backstage, plugin,-homepage : janus-idp.io, -bugs : janus-idp/backstage-plugins/issues

PR closes https://github.com/janus-idp/backstage-plugins/issues/155