### PR TITLE
fix(topology): fixes pods label overlap with rolling recreate

### DIFF
--- a/plugins/topology/src/components/Graph/BaseNode.tsx
+++ b/plugins/topology/src/components/Graph/BaseNode.tsx
@@ -88,6 +88,7 @@ const BaseNode: React.FC<BaseNodeProps> = ({
           badge={kindData && kindData.kindAbbr}
           badgeColor={kindData && kindData.kindColor}
           showStatusBackground={!showDetails}
+          className={className}
           {...rest}
         >
           <g data-test-id="base-node-handler">


### PR DESCRIPTION
Fixes: https://github.com/janus-idp/backstage-plugins/issues/156

**Description:**
Pod label in case of rolling/recreate overlaps with pod ring

**Before:**

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/5129024/222184263-8e3eeda1-eaf9-4583-b7b4-e6f7f6c65e4d.png">


**After:**

<img width="540" alt="image" src="https://user-images.githubusercontent.com/5129024/222184723-5c9d53cf-1b77-4c93-9c75-3dc7e8e3676d.png">
