### PR TITLE
chore(deps): downgrade dependency @testing-library/react to v12

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@backstage/test-utils": "1.2.4",
     "@testing-library/jest-dom": "5.16.5",
-    "@testing-library/react": "13.4.0",
+    "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.4.3",
     "@types/node": "18.13.0",
     "@types/react-dom": "17.0.18",

--- a/plugins/ocm/package.json
+++ b/plugins/ocm/package.json
@@ -45,7 +45,7 @@
     "@backstage/dev-utils": "1.0.11",
     "@backstage/test-utils": "1.2.4",
     "@testing-library/jest-dom": "5.16.5",
-    "@testing-library/react": "13.4.0",
+    "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.4.3",
     "@types/node": "18.13.0",
     "cross-fetch": "3.1.5",

--- a/plugins/quay/package.json
+++ b/plugins/quay/package.json
@@ -42,7 +42,7 @@
     "@backstage/dev-utils": "1.0.11",
     "@backstage/test-utils": "1.2.4",
     "@testing-library/jest-dom": "5.16.5",
-    "@testing-library/react": "13.4.0",
+    "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.4.3",
     "@types/node": "18.13.0",
     "cross-fetch": "3.1.5",


### PR DESCRIPTION
Related to: https://github.com/janus-idp/backstage-plugins/pull/138 https://github.com/janus-idp/backstage-plugins/issues/41

Unifies the `@testing-library/react` versions (Topology plugin is already [on this exact version](https://github.com/janus-idp/backstage-plugins/blob/6f1e02ff7c55d32bab4d99afab832dd89d9fa9cf/plugins/topology/package.json#L59)).

This is necessary until we can support React v18. The v13 of `@testing-library/react` [drops](https://github.com/testing-library/react-testing-library/releases/tag/v13.0.0) support for v17.