### PR TITLE
fix(ocm-backend): Improve error reporting and check for url

### DIFF
--- a/plugins/ocm-backend/src/helpers/config.ts
+++ b/plugins/ocm-backend/src/helpers/config.ts
@@ -5,6 +5,16 @@ const KUBERNETES_PLUGIN_CONFIG = 'kubernetes.clusterLocatorMethods';
 const OCM_PREFIX = 'catalog.providers.ocm';
 const KUBERNETES_PLUGIN_KEY = 'kubernetesPluginRef';
 
+const isValidUrl = (url: string): boolean => {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url);
+  } catch (error) {
+    return false;
+  }
+  return true;
+};
+
 export const deferToKubernetesPlugin = (config: Config): boolean => {
   if (config.has(KUBERNETES_PLUGIN_KEY)) {
     return true;
@@ -61,9 +71,14 @@ export const getHubClusterFromConfig = (
     ? getHubClusterFromKubernetesConfig(id, config, globalConfig)
     : getHubClusterFromOcmConfig(id, config);
 
+  const url = config.getString('url');
+  if (!isValidUrl(url)) {
+    throw new Error(`"${url}" is not a valid url`);
+  }
+
   return {
     id,
-    url: hub.getString('url'),
+    url,
     hubResourceName: hub.getString('name'),
     serviceAccountToken: hub.getOptionalString('serviceAccountToken'),
     skipTLSVerify: hub.getOptionalBoolean('skipTLSVerify') || false,

--- a/plugins/ocm-backend/src/helpers/kubernetes.ts
+++ b/plugins/ocm-backend/src/helpers/kubernetes.ts
@@ -60,6 +60,13 @@ const kubeApiResponseHandler = <T extends Object>(
       return r.body as T;
     })
     .catch(r => {
+      if (!r.body) {
+        throw Object.assign(new Error(r.message), {
+          // If there is no body, there is not status code, default to 500
+          statusCode: 500,
+          name: r.message,
+        });
+      }
       throw Object.assign(new Error(r.body.reason), {
         statusCode: r.body.code,
         name: r.body.reason,


### PR DESCRIPTION
This PR is related to [this slack thread](https://janus-idp.slack.com/archives/C04EDTPJRK5/p1679181248576309) and might help troubleshoot this and similar issues.

Add an `url` validator before the k8s config is created and add a fallback for the error handler if the response doesn't contain a header (which is the case in the slack thread issue). 