### PR TITLE
feat(tekton): frontend plugin setup for tekton

### DIFF
--- a/plugins/tekton/.eslintrc.js
+++ b/plugins/tekton/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/tekton/README.md
+++ b/plugins/tekton/README.md
@@ -1,0 +1,39 @@
+# Tekton plugin for Backstage
+
+This plugin will help with visualizing the Pipeline Runs and associated Task Runs powering any service on the Kubernetes cluster.
+
+## Prerequisites
+
+1. Install and configure Tekton plugin (only backend plugin) by following https://github.com/jquad-group/backstage-jquad#configuration
+
+## Getting started
+
+1. Install the plugin
+
+   ```bash
+   yarn workspace app add @janus-idp/backstage-plugin-tekton
+   ```
+
+2. Enable an additional tab on the entity view page
+
+   ```ts
+   // packages/app/src/components/catalog/EntityPage.tsx
+   import { TektonPage } from '@janus-idp/backstage-plugin-tekton';
+
+   const serviceEntityPage = (
+     <EntityPageLayout>
+       // ...
+       <EntityLayout.Route path="/pipelines" title="Pipelines">
+         <TektonPage />
+       </EntityLayout.Route>
+     </EntityPageLayout>
+   );
+   ```
+
+## Development
+
+In [Backstage plugin terminology](https://backstage.io/docs/local-dev/cli-build-system#package-roles), this is a `frontend-plugin`. You can start a live dev session from the repository root using below command:
+
+```
+yarn workspace @janus-idp/backstage-plugin-tekton run start
+```

--- a/plugins/tekton/dev/index.tsx
+++ b/plugins/tekton/dev/index.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { Entity } from '@backstage/catalog-model';
+import { createDevApp } from '@backstage/dev-utils';
+import { TestApiProvider } from '@backstage/test-utils';
+import {
+  Cluster,
+  PipelineRun,
+  PipelineRunsByEntityRequest,
+} from '@jquad-group/plugin-tekton-pipelines-common';
+import { tektonPlugin, TektonPage } from '../src/plugin';
+import { TektonApi, tektonApiRef } from '@jquad-group/plugin-tekton-pipelines';
+import { pipelineRunMock } from '../src/__fixtures__/mockPipelinesData';
+
+const mockEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'backstage',
+    description: 'backstage.io',
+    annotations: {
+      'backstage.io/kubernetes-id': 'dice-roller',
+      'tektonci/build-namespace': 'sample-go-application-build',
+    },
+  },
+  spec: {
+    lifecycle: 'production',
+    type: 'service',
+    owner: 'user:guest',
+  },
+};
+
+class MockTektonClient implements TektonApi {
+  getLogs(
+    _baseUrl: string,
+    _authorizationBearerToken: string,
+    _namespace: string,
+    _taskRunPodName: string,
+    _stepContainer: string,
+  ): Promise<string> {
+    const logMock = Promise.resolve('this is example log');
+    return logMock;
+  }
+
+  async getHealth(): Promise<{ status: string }> {
+    return { status: 'ok' };
+  }
+
+  async getPipelineRuns(
+    _request: PipelineRunsByEntityRequest,
+    _name: string,
+    _baseUrl: string,
+    _authorizationBearerToken: string,
+    _namespace: string,
+    _selector: string,
+    _dashboardBaseUrl: string,
+  ): Promise<Cluster[]> {
+    const pipelineRuns: PipelineRun[] = [];
+    pipelineRuns.push(pipelineRunMock);
+    const tempCluster = {} as Cluster;
+    tempCluster.name = 'Cluster1';
+    tempCluster.pipelineRuns = pipelineRuns;
+    const clusters: Cluster[] = [];
+    clusters.push(tempCluster);
+    return clusters;
+  }
+}
+
+createDevApp()
+  .registerPlugin(tektonPlugin)
+  .addPage({
+    element: (
+      <TestApiProvider apis={[[tektonApiRef, new MockTektonClient()]]}>
+        <EntityProvider entity={mockEntity}>
+          <TektonPage />
+        </EntityProvider>
+      </TestApiProvider>
+    ),
+    title: 'Pipelines page',
+    path: '/pipelines',
+  })
+  .render();

--- a/plugins/tekton/package.json
+++ b/plugins/tekton/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@janus-idp/backstage-plugin-tekton",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/catalog-model": "^1.1.5",
+    "@backstage/core-components": "^0.12.3",
+    "@backstage/core-plugin-api": "^1.3.0",
+    "@backstage/plugin-catalog-react": "^1.2.4",
+    "@backstage/theme": "^0.2.16",
+    "@material-ui/core": "^4.9.13",
+    "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.45",
+    "@jquad-group/plugin-tekton-pipelines": "0.3.1",
+    "@jquad-group/plugin-tekton-pipelines-common": "0.3.1",
+    "@patternfly/patternfly": "4.217.1",
+    "@patternfly/react-charts": "6.94.7",
+    "@patternfly/react-core": "4.267.6",
+    "@patternfly/react-icons": "^4.93.3",
+    "@patternfly/react-styles": "^4.92.3",
+    "@patternfly/react-tokens": "4.93.6",
+    "@patternfly/react-topology": "^4.91.9",
+    "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.22.1",
+    "@backstage/core-app-api": "^1.4.0",
+    "@backstage/dev-utils": "1.0.11",
+    "@backstage/test-utils": "^1.2.4",
+    "@testing-library/jest-dom": "5.16.5",
+    "@testing-library/react": "12.1.5",
+    "@testing-library/react-hooks": "8.0.1",
+    "@testing-library/user-event": "14.4.3",
+    "@types/node": "18.13.0",
+    "cross-fetch": "^3.1.5",
+    "msw": "^0.49.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": "github:janus-idp/backstage-plugins",
+  "keywords": [
+    "backstage",
+    "plugin",
+    "tekton"
+  ],
+  "homepage": "https://janus-idp.io",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
+}

--- a/plugins/tekton/src/__fixtures__/mockPipelinesData.ts
+++ b/plugins/tekton/src/__fixtures__/mockPipelinesData.ts
@@ -1,0 +1,131 @@
+import {
+  Label,
+  PipelineRun,
+  TaskRun,
+} from '@jquad-group/plugin-tekton-pipelines-common';
+
+const recordMock: Record<string, Label> = {
+  testKey: { key: 'test-key', value: 'test-value' },
+};
+
+export const taskRunMock1: TaskRun = {
+  metadata: {
+    name: 'taskrun-1',
+    namespace: 'sample-go-application-build',
+    labels: recordMock,
+  },
+  status: {
+    podName: 'taskrun-1-pod',
+    startTime: new Date('2022-10-25T18:42:30Z'),
+    completionTime: new Date('2022-10-25T18:47:30Z'),
+    duration: 5,
+    durationString: '5m',
+    steps: [
+      {
+        container: 'taskrun-container',
+        log: 'some log',
+        name: 'taskrun-name',
+        terminated: {
+          duration: 5,
+          durationString: '5m',
+          finishedAt: new Date('2022-10-25T18:47:30Z'),
+          reason: 'Completed',
+          startedAt: new Date('2022-10-25T18:42:30Z'),
+        },
+      },
+    ],
+    conditions: [
+      {
+        message: 'Tasks Completed: 4 (Failed: 0, Cancelled 0), Skipped: 1',
+        reason: 'Completed',
+        status: 'True',
+        type: 'Succeeded',
+      },
+    ],
+  },
+};
+
+export const taskRunMock2: TaskRun = {
+  metadata: {
+    name: 'taskrun-2',
+    namespace: 'sample-go-application-build',
+    labels: recordMock,
+  },
+  status: {
+    podName: 'taskrun-2-pod',
+    startTime: new Date('2022-10-25T18:42:30Z'),
+    completionTime: new Date('2022-10-25T18:47:30Z'),
+    duration: 5,
+    durationString: '5m',
+    steps: [
+      {
+        container: 'taskrun-clone',
+        log: 'clone',
+        name: 'taskrun-name',
+        terminated: {
+          duration: 5,
+          durationString: '5m',
+          finishedAt: new Date('2022-10-25T18:47:30Z'),
+          reason: 'Completed',
+          startedAt: new Date('2022-10-25T18:42:30Z'),
+        },
+      },
+      {
+        container: 'taskrun-build',
+        log: 'clone',
+        name: 'build',
+        terminated: {
+          duration: 5,
+          durationString: '5m',
+          finishedAt: new Date('2022-10-25T18:47:30Z'),
+          reason: 'Completed',
+          startedAt: new Date('2022-10-25T18:42:30Z'),
+        },
+      },
+      {
+        container: 'taskrun-test',
+        log: 'test',
+        name: 'test',
+        terminated: {
+          duration: 5,
+          durationString: '5m',
+          finishedAt: new Date('2022-10-25T18:47:30Z'),
+          reason: 'Completed',
+          startedAt: new Date('2022-10-25T18:42:30Z'),
+        },
+      },
+    ],
+    conditions: [
+      {
+        message: 'Tasks Completed: 4 (Failed: 0, Cancelled 0), Skipped: 1',
+        reason: 'Completed',
+        status: 'True',
+        type: 'Succeeded',
+      },
+    ],
+  },
+};
+
+export const pipelineRunMock: PipelineRun = {
+  metadata: {
+    labels: recordMock,
+    name: 'feature-added-catalog-info-xdjk9',
+    namespace: 'sample-go-application-build',
+  },
+  pipelineRunDashboardUrl: 'https://mock.dashboard',
+  taskRuns: [taskRunMock1, taskRunMock2],
+  status: {
+    startTime: new Date('2022-10-25T18:42:30Z'),
+    completionTime: new Date('2022-10-25T18:47:30Z'),
+    duration: 5,
+    durationString: '5m',
+    conditions: [
+      {
+        message: 'Tasks Completed: 4 (Failed: 0, Cancelled 0), Skipped: 1',
+        reason: 'Completed',
+        status: 'True',
+        type: 'Succeeded',
+      },
+    ],
+  },
+};

--- a/plugins/tekton/src/api/TektonBackendClient.ts
+++ b/plugins/tekton/src/api/TektonBackendClient.ts
@@ -1,0 +1,91 @@
+import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { TektonApi } from '@jquad-group/plugin-tekton-pipelines';
+import {
+  Cluster,
+  PipelineRunsByEntityRequest,
+} from '@jquad-group/plugin-tekton-pipelines-common';
+import {
+  TEKTON_PIPELINES_BUILD_NAMESPACE,
+  TEKTON_PIPELINES_LABEL_SELECTOR,
+} from './const';
+
+export class TektonBackendClient implements TektonApi {
+  private readonly discoveryApi: DiscoveryApi;
+
+  constructor(options: { discoveryApi: DiscoveryApi }) {
+    this.discoveryApi = options.discoveryApi;
+  }
+
+  private async handleResponse(response: Response): Promise<any> {
+    if (!response.ok) {
+      const payload = await response.text();
+      let message;
+      switch (response.status) {
+        case 404:
+          message =
+            'Could not find the Kubernetes Backend (HTTP 404). Make sure the plugin has been fully installed.';
+          break;
+        default:
+          message = `Request failed with ${response.status} ${response.statusText}, ${payload}`;
+      }
+      throw new Error(message);
+    }
+
+    const contentType = response.headers.get('Content-Type');
+    if (contentType && contentType.indexOf('application/json') !== -1) {
+      return response.json();
+    }
+
+    return response.text();
+  }
+
+  async getHealth(): Promise<{ status: string }> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('tekton-pipelines');
+    const url = `${baseUrl}/health`;
+    const response = await fetch(url, {
+      method: 'GET',
+    });
+    return await this.handleResponse(response);
+  }
+
+  async getPipelineRuns(
+    request: PipelineRunsByEntityRequest,
+    _name: string,
+    _baseUrl: string,
+    _authorizationBearerToken: string,
+    _namespace: string,
+    _selector: string,
+    _dashboardBaseUrl: string,
+  ): Promise<Cluster[]> {
+    const tektonBuildNamespace =
+      request?.entity.metadata.annotations?.[
+        TEKTON_PIPELINES_BUILD_NAMESPACE
+      ] ?? '';
+    const tektonLabelSelector =
+      request?.entity.metadata.annotations?.[TEKTON_PIPELINES_LABEL_SELECTOR] ??
+      '';
+    const baseUrlPath = await this.discoveryApi.getBaseUrl('tekton-pipelines');
+    const url = `${baseUrlPath}/pipelineruns?namespace=${tektonBuildNamespace}&selector=${tektonLabelSelector}`;
+    const response = await fetch(url, {
+      method: 'GET',
+    });
+    return await this.handleResponse(response);
+  }
+
+  async getLogs(
+    _baseUrl: string,
+    _authorizationBearerToken: string,
+    clusterName: string,
+    namespace: string,
+    taskRunPodName: string,
+    stepContainer: string,
+  ): Promise<string> {
+    const baseUrlPath = await this.discoveryApi.getBaseUrl('tekton-pipelines');
+    const url = `${baseUrlPath}/logs?clusterName=${clusterName}&namespace=${namespace}&taskRunPodName=${taskRunPodName}&stepContainer=${stepContainer}`;
+    const response = await fetch(url, {
+      method: 'GET',
+    });
+
+    return await this.handleResponse(response);
+  }
+}

--- a/plugins/tekton/src/api/const.ts
+++ b/plugins/tekton/src/api/const.ts
@@ -1,0 +1,3 @@
+export const TEKTON_PIPELINES_BUILD_NAMESPACE = 'tektonci/build-namespace';
+export const TEKTON_PIPELINES_LABEL_SELECTOR =
+  'tektonci/pipeline-label-selector';

--- a/plugins/tekton/src/api/types.ts
+++ b/plugins/tekton/src/api/types.ts
@@ -1,0 +1,6 @@
+import { createApiRef } from '@backstage/core-plugin-api';
+import { TektonApi } from '@jquad-group/plugin-tekton-pipelines';
+
+export const tektonPluginApiRef = createApiRef<TektonApi>({
+  id: 'plugin.tekton.service',
+});

--- a/plugins/tekton/src/components/Tekton/TektonComponent.test.tsx
+++ b/plugins/tekton/src/components/Tekton/TektonComponent.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { wrapInTestApp } from '@backstage/test-utils';
+import { useTheme } from '@material-ui/core/styles';
+import { TektonComponent } from './TektonComponent';
+
+// mock useEntity
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      metadata: {
+        name: 'test',
+      },
+    },
+  }),
+}));
+
+// mock usePipelineRunObjects
+jest.mock('@jquad-group/plugin-tekton-pipelines', () => ({
+  usePipelineRunObjects: jest.fn(),
+}));
+
+// mocks useTheme
+jest.mock('@material-ui/core/styles', () => {
+  const originalModule = jest.requireActual('@material-ui/core/styles');
+  return {
+    ...originalModule,
+    useTheme: jest.fn(),
+  };
+});
+
+const useThemeMock = useTheme as jest.Mock;
+
+describe('TektonComponent', () => {
+  it('should render TektonComponent', async () => {
+    useThemeMock.mockReturnValue({
+      palette: {
+        type: 'dark',
+      },
+    });
+    const { getByText } = render(wrapInTestApp(<TektonComponent />));
+    await waitFor(() => {
+      expect(getByText(/pipeline visualization/i)).not.toBeNull();
+    });
+  });
+
+  it('should show dark theme', async () => {
+    useThemeMock.mockReturnValue({
+      palette: {
+        type: 'dark',
+      },
+    });
+    render(wrapInTestApp(<TektonComponent />));
+    const htmlTagElement = document.documentElement;
+    await waitFor(() => {
+      expect(htmlTagElement.classList.contains('pf-theme-dark')).toBe(true);
+    });
+  });
+
+  it('should show light theme', async () => {
+    useThemeMock.mockReturnValue({
+      palette: {
+        type: 'light',
+      },
+    });
+    render(wrapInTestApp(<TektonComponent />));
+    const htmlTagElement = document.documentElement;
+    await waitFor(() => {
+      expect(htmlTagElement.classList.contains('pf-theme-dark')).toBe(false);
+    });
+  });
+});

--- a/plugins/tekton/src/components/Tekton/TektonComponent.tsx
+++ b/plugins/tekton/src/components/Tekton/TektonComponent.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import '@patternfly/patternfly/patternfly-charts-theme-dark.css';
+import '@patternfly/react-core/dist/styles/base.css';
+import '@patternfly/patternfly/patternfly-theme-dark.css';
+import '@patternfly/patternfly/utilities/Accessibility/accessibility.css';
+import { Header, Page } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { usePipelineRunObjects } from '@jquad-group/plugin-tekton-pipelines';
+import { useTheme } from '@material-ui/core/styles';
+
+const THEME_DARK = 'dark';
+const THEME_DARK_CLASS = 'pf-theme-dark';
+
+export const TektonComponent = () => {
+  const {
+    palette: { type },
+  } = useTheme();
+
+  React.useEffect(() => {
+    const htmlTagElement = document.documentElement;
+    if (type === THEME_DARK) {
+      htmlTagElement.classList.add(THEME_DARK_CLASS);
+    } else {
+      htmlTagElement.classList.remove(THEME_DARK_CLASS);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [type]);
+
+  const { entity } = useEntity();
+  const data = usePipelineRunObjects(entity);
+  // This is just show the data is being fetched, remove this line when you start working on the component
+  // eslint-disable-next-line no-console
+  console.log('Tekton data', data);
+
+  return (
+    <Page themeId="tool">
+      <Header
+        title="Pipeline Visualization!"
+        subtitle="Visualize PipelineRuns/TaskRuns"
+      />
+    </Page>
+  );
+};

--- a/plugins/tekton/src/components/Tekton/index.ts
+++ b/plugins/tekton/src/components/Tekton/index.ts
@@ -1,0 +1,1 @@
+export { TektonComponent } from './TektonComponent';

--- a/plugins/tekton/src/index.ts
+++ b/plugins/tekton/src/index.ts
@@ -1,0 +1,1 @@
+export { tektonPlugin, TektonPage } from './plugin';

--- a/plugins/tekton/src/plugin.test.ts
+++ b/plugins/tekton/src/plugin.test.ts
@@ -1,0 +1,7 @@
+import { tektonPlugin } from './plugin';
+
+describe('tekton', () => {
+  it('should export plugin', () => {
+    expect(tektonPlugin).toBeDefined();
+  });
+});

--- a/plugins/tekton/src/plugin.ts
+++ b/plugins/tekton/src/plugin.ts
@@ -1,0 +1,33 @@
+import {
+  createApiFactory,
+  createPlugin,
+  createRoutableExtension,
+  discoveryApiRef,
+} from '@backstage/core-plugin-api';
+import { rootRouteRef } from './routes';
+import { TektonBackendClient } from './api/TektonBackendClient';
+import { tektonPluginApiRef } from './api/types';
+
+export const tektonPlugin = createPlugin({
+  id: 'tekton',
+  apis: [
+    createApiFactory({
+      api: tektonPluginApiRef,
+      deps: {
+        discoveryApi: discoveryApiRef,
+      },
+      factory: ({ discoveryApi }) => new TektonBackendClient({ discoveryApi }),
+    }),
+  ],
+  routes: {
+    root: rootRouteRef,
+  },
+});
+
+export const TektonPage = tektonPlugin.provide(
+  createRoutableExtension({
+    name: 'TektonPage',
+    component: () => import('./components/Tekton').then(m => m.TektonComponent),
+    mountPoint: rootRouteRef,
+  }),
+);

--- a/plugins/tekton/src/routes.ts
+++ b/plugins/tekton/src/routes.ts
@@ -1,0 +1,5 @@
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+export const rootRouteRef = createRouteRef({
+  id: 'tekton',
+});

--- a/plugins/tekton/src/setupTests.ts
+++ b/plugins/tekton/src/setupTests.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom';
+import 'cross-fetch/polyfill';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2640,6 +2640,15 @@
     "@backstage/errors" "^1.1.4"
     cross-fetch "^3.1.5"
 
+"@backstage/catalog-client@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-1.4.0.tgz#76a319fb68ab9b5536404265f917788e961b3a47"
+  integrity sha512-45nocuPnLuNO+2hPlNYvyAosZE24C2kMPcujnDLpUEFbwPNEVZ7KqnVLty2WQq9qCRWlwJ1OSeMvpUtgupZOfw==
+  dependencies:
+    "@backstage/catalog-model" "^1.2.1"
+    "@backstage/errors" "^1.1.5"
+    cross-fetch "^3.1.5"
+
 "@backstage/catalog-model@1.1.5", "@backstage/catalog-model@^1.1.5":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@backstage/catalog-model/-/catalog-model-1.1.5.tgz#83203771f2fc04353d0d84e20d354f0cef15403f"
@@ -2647,6 +2656,19 @@
   dependencies:
     "@backstage/config" "^1.0.6"
     "@backstage/errors" "^1.1.4"
+    "@backstage/types" "^1.0.2"
+    ajv "^8.10.0"
+    json-schema "^0.4.0"
+    lodash "^4.17.21"
+    uuid "^8.0.0"
+
+"@backstage/catalog-model@^1.1.2", "@backstage/catalog-model@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-model/-/catalog-model-1.2.1.tgz#ee3fa9ec404cef4a6b639160c7c016fbdd53229f"
+  integrity sha512-pbH67Nov/bgJYIOl78ncjUfCPbjAI+VScfGRhGmcFubqK+w9pygy6Y/sYg10u5NFJxKCoSnbYZehO0451UbqhA==
+  dependencies:
+    "@backstage/config" "^1.0.7"
+    "@backstage/errors" "^1.1.5"
     "@backstage/types" "^1.0.2"
     ajv "^8.10.0"
     json-schema "^0.4.0"
@@ -2898,6 +2920,14 @@
     yaml "^2.0.0"
     yup "^0.32.9"
 
+"@backstage/config@^1.0.3", "@backstage/config@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.0.7.tgz#f6929fb5af80ca36fae8b385f957f9c0a64a72a6"
+  integrity sha512-8Fh3QJl0PltQZ9nCNr9UsYoRNCbfhJQR+1z1JUur7hTgJ/yCVnVPmESrpBWR27NCT7IBNtRv0jZhzj/BYZfFgA==
+  dependencies:
+    "@backstage/types" "^1.0.2"
+    lodash "^4.17.21"
+
 "@backstage/config@^1.0.5", "@backstage/config@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.0.6.tgz#551ffe6793aec29f7d7f9e5ba1bb010ba6ed0b00"
@@ -2920,6 +2950,49 @@
     react-use "^17.2.4"
     zen-observable "^0.10.0"
     zod "~3.18.0"
+
+"@backstage/core-components@^0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@backstage/core-components/-/core-components-0.11.2.tgz#772a3f3e6b7a765a8f619e9e2b93ebeab5a7288a"
+  integrity sha512-ydWRl3rOPxLGYhKojBEW7Z2ImMeG+eN0JIMaYwbsCgxE80zIewtEDTLlmd2jbTWnmP6gKftytt/NAlGM1qtu0g==
+  dependencies:
+    "@backstage/config" "^1.0.3"
+    "@backstage/core-plugin-api" "^1.0.7"
+    "@backstage/errors" "^1.1.2"
+    "@backstage/theme" "^0.2.16"
+    "@backstage/version-bridge" "^1.0.1"
+    "@material-table/core" "^3.1.0"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    "@react-hookz/web" "^15.0.0"
+    "@types/react-sparklines" "^1.7.0"
+    "@types/react-text-truncate" "^0.14.0"
+    ansi-regex "^6.0.1"
+    classnames "^2.2.6"
+    d3-selection "^3.0.0"
+    d3-shape "^3.0.0"
+    d3-zoom "^3.0.0"
+    dagre "^0.8.5"
+    history "^5.0.0"
+    immer "^9.0.1"
+    lodash "^4.17.21"
+    pluralize "^8.0.0"
+    prop-types "^15.7.2"
+    qs "^6.9.4"
+    rc-progress "3.4.0"
+    react-helmet "6.1.0"
+    react-hook-form "^7.12.2"
+    react-markdown "^8.0.0"
+    react-sparklines "^1.7.0"
+    react-syntax-highlighter "^15.4.5"
+    react-text-truncate "^0.19.0"
+    react-use "^17.3.2"
+    react-virtualized-auto-sizer "^1.0.6"
+    react-window "^1.8.6"
+    remark-gfm "^3.0.1"
+    zen-observable "^0.8.15"
+    zod "^3.11.6"
 
 "@backstage/core-components@^0.12.1", "@backstage/core-components@^0.12.3":
   version "0.12.3"
@@ -3007,6 +3080,61 @@
     zen-observable "^0.10.0"
     zod "~3.18.0"
 
+"@backstage/core-components@^0.12.5":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@backstage/core-components/-/core-components-0.12.5.tgz#ea9e5d04845fb031e0f4fb4b764497ee722ad128"
+  integrity sha512-77BBOmJPeyKqKFDZeX5/NUENiklG0+DJMyoyM9fFlzB4wv6Lsx2V6hFbgE6PIsQ2T5EWorzq+BvkTyMXRrU/Pg==
+  dependencies:
+    "@backstage/config" "^1.0.7"
+    "@backstage/core-plugin-api" "^1.5.0"
+    "@backstage/errors" "^1.1.5"
+    "@backstage/theme" "^0.2.18"
+    "@backstage/version-bridge" "^1.0.3"
+    "@material-table/core" "^3.1.0"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    "@react-hookz/web" "^20.0.0"
+    "@types/react-sparklines" "^1.7.0"
+    "@types/react-text-truncate" "^0.14.0"
+    ansi-regex "^6.0.1"
+    classnames "^2.2.6"
+    d3-selection "^3.0.0"
+    d3-shape "^3.0.0"
+    d3-zoom "^3.0.0"
+    dagre "^0.8.5"
+    history "^5.0.0"
+    immer "^9.0.1"
+    lodash "^4.17.21"
+    pluralize "^8.0.0"
+    prop-types "^15.7.2"
+    qs "^6.9.4"
+    rc-progress "3.4.1"
+    react-helmet "6.1.0"
+    react-hook-form "^7.12.2"
+    react-markdown "^8.0.0"
+    react-sparklines "^1.7.0"
+    react-syntax-highlighter "^15.4.5"
+    react-text-truncate "^0.19.0"
+    react-use "^17.3.2"
+    react-virtualized-auto-sizer "^1.0.6"
+    react-window "^1.8.6"
+    remark-gfm "^3.0.1"
+    zen-observable "^0.10.0"
+    zod "~3.18.0"
+
+"@backstage/core-plugin-api@^1.0.7", "@backstage/core-plugin-api@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@backstage/core-plugin-api/-/core-plugin-api-1.5.0.tgz#1188c89d8149b5805645e16bb67f2167da79dd85"
+  integrity sha512-IEbzBk128loMecy+btbMCd9FpVYg/THSRDe2qMpr9b/Ve21PJNRy5CMoX/P/4Nkplifp3nxWBBVusTgWneaG4Q==
+  dependencies:
+    "@backstage/config" "^1.0.7"
+    "@backstage/types" "^1.0.2"
+    "@backstage/version-bridge" "^1.0.3"
+    history "^5.0.0"
+    prop-types "^15.7.2"
+    zen-observable "^0.10.0"
+
 "@backstage/core-plugin-api@^1.2.0", "@backstage/core-plugin-api@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@backstage/core-plugin-api/-/core-plugin-api-1.3.0.tgz#d937fa215d551b85d2d78d209959db1815a17b78"
@@ -3052,6 +3180,15 @@
     "@testing-library/user-event" "^14.0.0"
     react-use "^17.2.4"
     zen-observable "^0.10.0"
+
+"@backstage/errors@^1.1.2", "@backstage/errors@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@backstage/errors/-/errors-1.1.5.tgz#27c0deb040a136f196865d2d6d24e31f1d17f472"
+  integrity sha512-aKkYniwo3dkd8a5dIZhnfoSLqsFzBqzQC2yhw/XfOUbfEkej6XZVsPKws/zZODUAPF1ZKNMUBbt1NTVG14Bahw==
+  dependencies:
+    "@backstage/types" "^1.0.2"
+    cross-fetch "^3.1.5"
+    serialize-error "^8.0.1"
 
 "@backstage/errors@^1.1.4":
   version "1.1.4"
@@ -3105,6 +3242,20 @@
   dependencies:
     "@backstage/config" "^1.0.6"
     "@backstage/errors" "^1.1.4"
+    "@octokit/auth-app" "^4.0.0"
+    "@octokit/rest" "^19.0.3"
+    cross-fetch "^3.1.5"
+    git-url-parse "^13.0.0"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+
+"@backstage/integration@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@backstage/integration/-/integration-1.4.3.tgz#2796ed0fe804f88ec30fdca7942d0c95a388ccac"
+  integrity sha512-1wHBO3xJdm1EhYrxisnU2fpDGy83n4n1YfnUm4xveXbN3/l8Zpmi95+F0p/91t1vq01PD/jVb14Q+yizL5u4Hw==
+  dependencies:
+    "@backstage/config" "^1.0.7"
+    "@backstage/errors" "^1.1.5"
     "@octokit/auth-app" "^4.0.0"
     "@octokit/rest" "^19.0.3"
     cross-fetch "^3.1.5"
@@ -3334,6 +3485,15 @@
     "@backstage/plugin-permission-common" "^0.7.3"
     "@backstage/plugin-search-common" "^1.2.1"
 
+"@backstage/plugin-catalog-common@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-common/-/plugin-catalog-common-1.0.12.tgz#5941088d730372ff9ca8938eff4fbfd7c6286a0f"
+  integrity sha512-Oo8a6hDxveNhMgrJV6x72RoNnJR0qlcta0rsdMxIoEMp2yjOM8VfPoLmF2U3DD55ROzDoSXGOcFkask4DvDkFA==
+  dependencies:
+    "@backstage/catalog-model" "^1.2.1"
+    "@backstage/plugin-permission-common" "^0.7.4"
+    "@backstage/plugin-search-common" "^1.2.2"
+
 "@backstage/plugin-catalog-graph@^0.2.26":
   version "0.2.26"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-graph/-/plugin-catalog-graph-0.2.26.tgz#9f4e79b88dfee1ab178a6207721653f1447c77d6"
@@ -3419,6 +3579,35 @@
     "@backstage/plugin-permission-common" "^0.7.3"
     "@backstage/plugin-permission-react" "^0.4.9"
     "@backstage/theme" "^0.2.16"
+    "@backstage/types" "^1.0.2"
+    "@backstage/version-bridge" "^1.0.3"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    classnames "^2.2.6"
+    jwt-decode "^3.1.0"
+    lodash "^4.17.21"
+    material-ui-popup-state "^1.9.3"
+    qs "^6.9.4"
+    react-use "^17.2.4"
+    yaml "^2.0.0"
+    zen-observable "^0.10.0"
+
+"@backstage/plugin-catalog-react@^1.2.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-react/-/plugin-catalog-react-1.4.0.tgz#bec66344ef9e34977e48382ae3989ba98a518c3d"
+  integrity sha512-dXNE+EMZLWrezqWDoQSF9sfEwSP1iXwPFygp+K6+4WT0nIJoQj4OC+RYsVF1D4ERstPYqOujE0vjrXDygha5eA==
+  dependencies:
+    "@backstage/catalog-client" "^1.4.0"
+    "@backstage/catalog-model" "^1.2.1"
+    "@backstage/core-components" "^0.12.5"
+    "@backstage/core-plugin-api" "^1.5.0"
+    "@backstage/errors" "^1.1.5"
+    "@backstage/integration" "^1.4.3"
+    "@backstage/plugin-catalog-common" "^1.0.12"
+    "@backstage/plugin-permission-common" "^0.7.4"
+    "@backstage/plugin-permission-react" "^0.4.11"
+    "@backstage/theme" "^0.2.18"
     "@backstage/types" "^1.0.2"
     "@backstage/version-bridge" "^1.0.3"
     "@material-ui/core" "^4.12.2"
@@ -3586,6 +3775,18 @@
     uuid "^8.0.0"
     zod "~3.18.0"
 
+"@backstage/plugin-permission-common@^0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.7.4.tgz#3597d5bab7c5d364d66ccf0e789b319581dc28db"
+  integrity sha512-AaErJWBugyDr0PLeszpsvpjb1B4IqzEBqrA0ZVcFg82nnEzxBgqY0YFjnP8St8Ekc67I2FwLem6XC9UKu8IBCw==
+  dependencies:
+    "@backstage/config" "^1.0.7"
+    "@backstage/errors" "^1.1.5"
+    "@backstage/types" "^1.0.2"
+    cross-fetch "^3.1.5"
+    uuid "^8.0.0"
+    zod "~3.18.0"
+
 "@backstage/plugin-permission-node@^0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-node/-/plugin-permission-node-0.7.4.tgz#199e61c7aeeb709bd563d76f196201173f1c6f85"
@@ -3626,6 +3827,18 @@
     "@backstage/config" "^1.0.6"
     "@backstage/core-plugin-api" "^1.4.0"
     "@backstage/plugin-permission-common" "^0.7.3"
+    cross-fetch "^3.1.5"
+    react-use "^17.2.4"
+    swr "^2.0.0"
+
+"@backstage/plugin-permission-react@^0.4.11":
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-react/-/plugin-permission-react-0.4.11.tgz#8c2b69ecad2de316bafb0fb54ac0807942634734"
+  integrity sha512-x4qQb6P8pgngiOYirefNJMXIYLDlNkKR/75Qsxagl8IA6DnG1miieLOumXAZTNT1aQedIjCka4OO9I4CJzPt8g==
+  dependencies:
+    "@backstage/config" "^1.0.7"
+    "@backstage/core-plugin-api" "^1.5.0"
+    "@backstage/plugin-permission-common" "^0.7.4"
     cross-fetch "^3.1.5"
     react-use "^17.2.4"
     swr "^2.0.0"
@@ -3872,6 +4085,14 @@
   integrity sha512-ek8QPVcONoy6pp+jSG9BXGAJKHioRtjutyxWlpxynBZzan1SShBoZ0suNd8EwydTnf5Qz+0Mn8keTkbdxFMiJA==
   dependencies:
     "@backstage/plugin-permission-common" "^0.7.3"
+    "@backstage/types" "^1.0.2"
+
+"@backstage/plugin-search-common@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-search-common/-/plugin-search-common-1.2.2.tgz#cbb462d2a000086aa195be2c911acfdce30390e4"
+  integrity sha512-QcMQBODQDbQpvu9uIBa69RHe6zO3YL6iZJRY6ZNClQIJQKEJC7bS67fXssZGGyQIiWHcq93qqhQp3eLbxAu5DA==
+  dependencies:
+    "@backstage/plugin-permission-common" "^0.7.4"
     "@backstage/types" "^1.0.2"
 
 "@backstage/plugin-search-react@^1.4.0":
@@ -4133,12 +4354,19 @@
   dependencies:
     "@material-ui/core" "^4.12.2"
 
+"@backstage/theme@^0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@backstage/theme/-/theme-0.2.18.tgz#a322577cd6b9498dbff995595c275f2736720f85"
+  integrity sha512-pax/gIQAk3niNbK1b3yd8IsU3nGLJ39GlL+kqTp2dV35DMKcaKp0L+nxS+PxNbxsjwB70TU+2cVQBe+zvtDFZw==
+  dependencies:
+    "@material-ui/core" "^4.12.2"
+
 "@backstage/types@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.0.2.tgz#a12cdc7c1ec7e0d99cb2e30903b9dfd97c1050c9"
   integrity sha512-wE4AAP3je00UlVNV5faIto414aOUNv30CmvNmxgImNKelPRYJsMEicM9slwkrNMyFLqTMITeXJvQvMofUk3Wxg==
 
-"@backstage/version-bridge@^1.0.3":
+"@backstage/version-bridge@^1.0.1", "@backstage/version-bridge@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@backstage/version-bridge/-/version-bridge-1.0.3.tgz#3ee86ac9a99bf031f6cf16f277c712ec581f14cb"
   integrity sha512-b+r0LKjciyVgrw/nrEEqY/zxMwT4GzGjoQUY3YgmtNuUeSheVHf2uwq++nsSfy3ZXZwvyTX0uR3c2YDB3q/Sig==
@@ -4983,6 +5211,28 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
+"@jquad-group/plugin-tekton-pipelines-common@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@jquad-group/plugin-tekton-pipelines-common/-/plugin-tekton-pipelines-common-0.3.1.tgz#8e275ddf338920858050739ac0e8d4d441e14e1f"
+  integrity sha512-8YjnYs4Pe3qB7CaJAevik2wAVHBC1xl5bzIdSOUs5g3KRrgfRNBLXXJsdoyKXc/LVb59WXLXVakvhsSjkAW1Jg==
+
+"@jquad-group/plugin-tekton-pipelines@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@jquad-group/plugin-tekton-pipelines/-/plugin-tekton-pipelines-0.3.1.tgz#99433c5b9aba96a62685542d26eeb4ba844ba4d5"
+  integrity sha512-DuSyHH0i352Jlzk1NwZZa7Z/fV4/zNaT6DFmbiArWGV8PXXaZBNV0YrT9CFEN0HJKD6zhItx82Y0bOVCK22v0Q==
+  dependencies:
+    "@backstage/catalog-model" "^1.1.2"
+    "@backstage/core-components" "^0.11.2"
+    "@backstage/core-plugin-api" "^1.0.7"
+    "@backstage/plugin-catalog-react" "^1.2.0"
+    "@backstage/theme" "^0.2.16"
+    "@material-ui/core" "^4.9.13"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "^4.0.0-alpha.57"
+    "@types/react" "^16.13.1 || ^17.0.0"
+    loglevel "^1.8.1"
+    react-use "^17.2.4"
+
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
@@ -5262,7 +5512,7 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
-"@material-ui/lab@4.0.0-alpha.61", "@material-ui/lab@^4.0.0-alpha.45":
+"@material-ui/lab@4.0.0-alpha.61", "@material-ui/lab@^4.0.0-alpha.45", "@material-ui/lab@^4.0.0-alpha.57":
   version "4.0.0-alpha.61"
   resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz#9bf8eb389c0c26c15e40933cc114d4ad85e3d978"
   integrity sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==
@@ -5996,6 +6246,11 @@
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
 
+"@patternfly/patternfly@4.217.1":
+  version "4.217.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.217.1.tgz#3583aa7216de9255b912fcc67a5af95ff8bd9cb3"
+  integrity sha512-uN7JgfQsyR16YHkuGRCTIcBcnyKIqKjGkB2SGk9x1XXH3yYGenL83kpAavX9Xtozqp17KppOlybJuzcKvZMrgw==
+
 "@patternfly/patternfly@4.224.2":
   version "4.224.2"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.224.2.tgz#9d1b000c3c43457ae47c3556a334412d164fad90"
@@ -6028,6 +6283,46 @@
     victory-voronoi-container "^36.6.7"
     victory-zoom-container "^36.6.7"
 
+"@patternfly/react-charts@6.94.7":
+  version "6.94.7"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.94.7.tgz#1c1ee94fd5256218867b4db0d000ed534e0c3e6e"
+  integrity sha512-ZiZMBGxAiTkYTf6p1Jv3GSgv6bxFbn0WtcYuerfB3gOeRi5JUDysciJai6MT/TFuLQmf3bNy3CJ0/b/x/rER2w==
+  dependencies:
+    "@patternfly/react-styles" "^4.91.6"
+    "@patternfly/react-tokens" "^4.93.6"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.19"
+    tslib "^2.0.0"
+    victory-area "^36.6.7"
+    victory-axis "^36.6.7"
+    victory-bar "^36.6.7"
+    victory-chart "^36.6.7"
+    victory-core "^36.6.7"
+    victory-create-container "^36.6.7"
+    victory-cursor-container "^36.6.7"
+    victory-group "^36.6.7"
+    victory-legend "^36.6.7"
+    victory-line "^36.6.7"
+    victory-pie "^36.6.7"
+    victory-scatter "^36.6.7"
+    victory-stack "^36.6.7"
+    victory-tooltip "^36.6.7"
+    victory-voronoi-container "^36.6.7"
+    victory-zoom-container "^36.6.7"
+
+"@patternfly/react-core@4.267.6":
+  version "4.267.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.267.6.tgz#d9a755e627fa333647ace30c15c400db47046799"
+  integrity sha512-4sb0OeGHLSLfFzrs5Tn3IXHuu6VLb+6v/FG4vcMccnGq7j/Bocns40g5mPkxC9KVbWHq7lT34wfKzS5kyIBHKQ==
+  dependencies:
+    "@patternfly/react-icons" "^4.93.3"
+    "@patternfly/react-styles" "^4.92.3"
+    "@patternfly/react-tokens" "^4.94.3"
+    focus-trap "6.9.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "^2.0.0"
+
 "@patternfly/react-core@4.276.6", "@patternfly/react-core@^4.276.6":
   version "4.276.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.276.6.tgz#fa39aa61022f70bf350b2efc660bdeb096bda447"
@@ -6041,22 +6336,27 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-icons@^4.93.6":
+"@patternfly/react-icons@^4.93.3", "@patternfly/react-icons@^4.93.6":
   version "4.93.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.6.tgz#4aff18724afa30157e3ffd6a6414951dbb39dcb3"
   integrity sha512-ZrXegc/81oiuTIeWvoHb3nG/eZODbB4rYmekBEsrbiysyO7m/sUFoi/RLvgFINrRoh6YCJqL5fj06Jg6d7jX1g==
 
-"@patternfly/react-styles@^4.92.6":
+"@patternfly/react-styles@^4.91.6", "@patternfly/react-styles@^4.92.3", "@patternfly/react-styles@^4.92.6":
   version "4.92.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.6.tgz#a72c5f0b7896ce1c419d1db79f8e39ba6632057d"
   integrity sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw==
 
-"@patternfly/react-tokens@4.94.6", "@patternfly/react-tokens@^4.94.6":
+"@patternfly/react-tokens@4.93.6":
+  version "4.93.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz#b09e8935783dab86f10decd05e357570b2a70aec"
+  integrity sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw==
+
+"@patternfly/react-tokens@4.94.6", "@patternfly/react-tokens@^4.93.6", "@patternfly/react-tokens@^4.94.3", "@patternfly/react-tokens@^4.94.6":
   version "4.94.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz#47c715721ad3dd315a523f352ba1a0de2b03f0bc"
   integrity sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q==
 
-"@patternfly/react-topology@4.91.27":
+"@patternfly/react-topology@4.91.27", "@patternfly/react-topology@^4.91.9":
   version "4.91.27"
   resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.91.27.tgz#ce8be65e545dfa9ab49021ef1ac833bda5370225"
   integrity sha512-CznY1c3ahsij8wuuxEUBLUssh4D7pLsxl9Fbrp7YXm/0Tx2KPgc76xMdyB9Flz4+SPNY1Z8fdsaI+d075i1aMg==
@@ -6170,10 +6470,17 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@react-hookz/deep-equal@^1.0.4":
+"@react-hookz/deep-equal@^1.0.3", "@react-hookz/deep-equal@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@react-hookz/deep-equal/-/deep-equal-1.0.4.tgz#68a71f36cbc88724b3ce6f4036183778b6e7f282"
   integrity sha512-N56fTrAPUDz/R423pag+n6TXWbvlBZDtTehaGFjK0InmN+V2OFWLE/WmORhmn6Ce7dlwH5+tQN1LJFw3ngTJVg==
+
+"@react-hookz/web@^15.0.0":
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/@react-hookz/web/-/web-15.1.0.tgz#62f7cedb98f345a1cdc7437673ea93dfb4d753d1"
+  integrity sha512-AsmqeZDg22JnpQS1hGIjLbue4LPmcsgyoPzgmKt6WDeqIUWFL20cgowiGBMFNLvL5Cc9XdusVY720S+CpLyT4Q==
+  dependencies:
+    "@react-hookz/deep-equal" "^1.0.3"
 
 "@react-hookz/web@^20.0.0":
   version "20.1.0"
@@ -16166,6 +16473,11 @@ logform@^2.3.2, logform@^2.4.0:
     safe-stable-stringify "^2.3.1"
     triple-beam "^1.3.0"
 
+loglevel@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.1.tgz#5c621f83d5b48c54ae93b6156353f555963377b4"
+  integrity sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==
+
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
@@ -17142,7 +17454,7 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-msw@0.49.3:
+msw@0.49.3, msw@^0.49.0:
   version "0.49.3"
   resolved "https://registry.yarnpkg.com/msw/-/msw-0.49.3.tgz#c4ca29eddda3e82ad9e36918dda4a7428eddd7fe"
   integrity sha512-kRCbDNbNnRq5LC1H/NUceZlrPAvSrMH6Or0mirIuH69NY84xwDruPn/hkXTovIK1KwDwbk+ZdoSyJlpiekLxEA==
@@ -19541,6 +19853,15 @@ raw-body@2.5.1, raw-body@^2.4.1:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+rc-progress@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/rc-progress/-/rc-progress-3.4.0.tgz#80a33c25c9675f5836ba25a87cd8dc310aad72b1"
+  integrity sha512-ZuMyOzzTkZnn+EKqGQ7YHzrvGzBtcCCVjx1McC/E/pMTvr6GWVfVRSawDlWsscxsJs7MkqSTwCO6Lu4IeoY2zQ==
+  dependencies:
+    "@babel/runtime" "^7.10.1"
+    classnames "^2.2.6"
+    rc-util "^5.16.1"
 
 rc-progress@3.4.1:
   version "3.4.1"
@@ -23683,6 +24004,11 @@ zen-observable@^0.10.0:
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.10.0.tgz#ee10eba75272897dbee5f152ab26bb5e0107f0c8"
   integrity sha512-iI3lT0iojZhKwT5DaFy2Ce42n3yFcLdFyOh01G7H0flMY60P8MJuVFEoJoNwXlmAyQ45GrjL6AcZmmlv8A5rbw==
 
+zen-observable@^0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
 zenscroll@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/zenscroll/-/zenscroll-4.0.2.tgz#e8d5774d1c0738a47bcfa8729f3712e2deddeb25"
@@ -23701,6 +24027,11 @@ zod-to-json-schema@~3.18.0:
   version "3.18.2"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.18.2.tgz#ce540062c6b57e5cc170aae57dad5eeb76d64f7b"
   integrity sha512-Vv1emSad6nJGRJUD/cdVxSgxtT3PnaUiHHZ+PxDU5vx+klM9eDekuIj6lO+tZTbATK+6ktJfY2C+WXn2mMX3Jw==
+
+zod@^3.11.6:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==
 
 zod@~3.18.0:
   version "3.18.0"


### PR DESCRIPTION
Tracks: https://github.com/janus-idp/backstage-plugins/issues/201

**Description:** 
Setup a frontend plugin for tekton with dev setup

**Test Setup**

- For Dev test

```
yarn install
yarn workspace @janus-idp/backstage-plugin-tekton run start

```

- For normal test

1. Install and configure Tekton plugin by following https://github.com/jquad-group/backstage-jquad#configuration
2. Enable an additional tab on the entity view page

   ```ts
   // packages/app/src/components/catalog/EntityPage.tsx
   import { TektonPage } from '@janus-idp/backstage-plugin-tekton';

   const serviceEntityPage = (
     <EntityPageLayout>
       // ...
       <EntityLayout.Route path="/pipelines" title="Pipelines">
         <TektonPage />
       </EntityLayout.Route>
     </EntityPageLayout>
   );
   ```
   
**Todo**

- [x]  Setup a frontend plugin for tekton with dev setup
- [x]  Fetch data from upstream tekton
- [x]  Adds patternfly dependencies
- [x]  Adds React testing library dependencies
- [x]  Supports dark theme