### PR TITLE
feat(quay): add quay link to repository

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -59,6 +59,9 @@ proxy:
     # Change to "false" in case of using self hosted quay instance with a self-signed certificate
     secure: true
 
+quay:
+  uiUrl: 'https://quay.io'
+
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs
 # and an external cloud storage when deploying TechDocs for production use-case.

--- a/plugins/quay/README.md
+++ b/plugins/quay/README.md
@@ -24,6 +24,10 @@ This plugin will show you information about your container images within Quay re
        changeOrigin: true
        # Change to "false" in case of using self hosted quay instance with a self-signed certificate
        secure: true
+
+   quay:
+     # The UI url for Quay, used to generate the link to Quay
+     uiUrl: 'https://quay.io'
    ```
 
 3. Enable additional tab on the entity view page

--- a/plugins/quay/config.d.ts
+++ b/plugins/quay/config.d.ts
@@ -2,9 +2,14 @@ export interface Config {
   /** Configurations for the Quay plugin */
   quay?: {
     /**
-     * The base url of the Quay instance.
+     * The proxy path for the Quay instance.
      * @visibility frontend
      */
     proxyPath?: string;
+    /**
+     * The UI url of the Quay instance.
+     * @visibility frontend
+     */
+    uiUrl?: string;
   };
 }

--- a/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
+++ b/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { Link, Progress, Table } from '@backstage/core-components';
 import { columns, useStyles } from './tableHeading';
 import { useRepository, useTags } from '../../hooks';
@@ -8,7 +9,19 @@ type QuayRepositoryProps = Record<never, any>;
 export function QuayRepository(_props: QuayRepositoryProps) {
   const { repository, organization } = useRepository();
   const classes = useStyles();
-  const title = `Quay repository: ${organization}/${repository}`;
+  const configApi = useApi(configApiRef);
+  const quayUiUrl = configApi.getOptionalString('quay.uiUrl');
+
+  const title = quayUiUrl ? (
+    <>
+      {`Quay repository: `}
+      <Link
+        to={`${quayUiUrl}/repository/${organization}/${repository}`}
+      >{`${organization}/${repository}`}</Link>
+    </>
+  ) : (
+    `Quay repository: ${organization}/${repository}`
+  );
   const { loading, data } = useTags(organization, repository);
 
   if (loading) {


### PR DESCRIPTION
Provide a link to the quay hosted repository in the table header.
This enables users of the plugin to navigate into quay and get more insights.

<img width="1904" alt="CleanShot 2023-03-29 at 20 38 08@2x" src="https://user-images.githubusercontent.com/1021324/228635851-003d9d55-cca8-48ad-8bda-2d035b7434e5.png">
