### PR TITLE
fix(quay): change http link to https

### DIFF
--- a/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
+++ b/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
@@ -75,7 +75,7 @@ export function QuayRepository(props: RepositoryProps) {
         emptyContent={
           <div className={classes.empty}>
             No data was added yet,&nbsp;
-            <Link to="http://backstage.io/">learn how to add data</Link>.
+            <Link to="https://backstage.io/">learn how to add data</Link>.
           </div>
         }
       />


### PR DESCRIPTION
Sonarcloud is complaining about this as a potential security hotspot.