### PR TITLE
fix(sonarqube): Enable release automation

### DIFF
--- a/plugins/sonarqube-actions/package.json
+++ b/plugins/sonarqube-actions/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@janus-idp/backstage-scaffolder-backend-module-sonarqube",
   "description": "The sonarqube module for @backstage/plugin-scaffolder-backend",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",
@@ -25,8 +24,8 @@
   },
   "dependencies": {
     "@backstage/plugin-scaffolder-node": "^0.1.1",
-    "yaml": "^2.2.1",
-    "core-js": "^3.29.1"
+    "core-js": "^3.29.1",
+    "yaml": "^2.2.1"
   },
   "devDependencies": {
     "@backstage/backend-common": "^0.18.0",


### PR DESCRIPTION
Enable [release automation](@janus-idp/backstage-scaffolder-backend-module-sonarqube) for the `@janus-idp/backstage-scaffolder-backend-module-sonarqube` package and set the initial version to 1.0.0

Fixes #219 