### PR TITLE
fix(sonarqube): Add comment to avoid getting a false positive flagged by rh-gitleaks

### DIFF
--- a/plugins/sonarqube-actions/src/actions/createSonarQubeProject.test.ts
+++ b/plugins/sonarqube-actions/src/actions/createSonarQubeProject.test.ts
@@ -210,7 +210,7 @@ describe('sonarqube:create-project', () => {
           baseUrl: 'http://localhost:9090',
           token: '',
           username: '',
-          password: 'super-sEkRiT', // gitleaks:allow
+          password: 'super-sEkRiT', // gitleaks:allow NOSONAR
           name: 'test-project',
           key: 'test-project',
           branch: '',


### PR DESCRIPTION
Comment added to avoid getting flagged by rh-gitleaks for a false positive password leak

Fixes: #221