### PR TITLE
feat(topology): Add topology workload node sidebar

### DIFF
--- a/plugins/topology/src/__fixtures__/1-deployments.ts
+++ b/plugins/topology/src/__fixtures__/1-deployments.ts
@@ -1685,6 +1685,7 @@ export const mockKubernetesResponse = {
         uid: '17094219-d12e-431c-bb3f-ee0876f11b04',
         resourceVersion: '42259',
         generation: 1,
+        ownerReferences: [{ name: 'app', uid: 1 }],
         labels: {
           'backstage.io/kubernetes-id': 'backstage',
         },
@@ -1703,7 +1704,7 @@ export const mockKubernetesResponse = {
           metadata: {
             creationTimestamp: null,
             labels: {
-              app: 'hello-world',
+              app: 'name',
               'backstage.io/kubernetes-id': 'backstage',
             },
           },

--- a/plugins/topology/src/__fixtures__/1-deployments.ts
+++ b/plugins/topology/src/__fixtures__/1-deployments.ts
@@ -1703,7 +1703,7 @@ export const mockKubernetesResponse = {
           metadata: {
             creationTimestamp: null,
             labels: {
-              app: 'name',
+              app: 'hello-world',
               'backstage.io/kubernetes-id': 'backstage',
             },
           },
@@ -1878,6 +1878,44 @@ export const mockKubernetesResponse = {
         ],
         selector: {
           app: 'name',
+        },
+        clusterIP: '10.110.148.168',
+        clusterIPs: ['10.110.148.168'],
+        type: 'NodePort',
+        sessionAffinity: 'None',
+        externalTrafficPolicy: 'Cluster',
+        ipFamilies: ['IPv4'],
+        ipFamilyPolicy: 'SingleStack',
+        internalTrafficPolicy: 'Cluster',
+      },
+      status: {
+        loadBalancer: {},
+      },
+    },
+    {
+      kind: 'Service',
+      apiVersion: 'v1',
+      metadata: {
+        name: 'hello-world-2',
+        namespace: 'test-app',
+        uid: 'e5112e42-d7d5-476b-a2fd-ba10e722e2f2',
+        resourceVersion: '325221',
+        creationTimestamp: '2023-03-01T08:13:39Z',
+        labels: {
+          'backstage.io/kubernetes-id': 'backstage',
+        },
+      },
+      spec: {
+        ports: [
+          {
+            protocol: 'TCP',
+            port: 8080,
+            targetPort: 8080,
+            nodePort: 30497,
+          },
+        ],
+        selector: {
+          app: 'hello-world',
         },
         clusterIP: '10.110.148.168',
         clusterIPs: ['10.110.148.168'],

--- a/plugins/topology/src/__fixtures__/workloadNodeData.ts
+++ b/plugins/topology/src/__fixtures__/workloadNodeData.ts
@@ -1,0 +1,724 @@
+export const workloadNodeData = {
+  data: {
+    resource: {
+      metadata: {
+        name: 'hello-minikube2',
+        namespace: 'div',
+        uid: 'bfb6932f-64c6-4fe3-b283-16ecec8628c0',
+        resourceVersion: '417930',
+        generation: 6,
+        creationTimestamp: '2023-02-13T14:49:49Z',
+        ownerReferences: [{ name: 'app' }],
+        labels: {
+          app: 'hello-minikube2',
+          'app.kubernetes.io/part-of': 'nationalparks-py',
+          'backstage.io/kubernetes-id': 'nationalparks-py',
+        },
+        annotations: {
+          'app.openshift.io/connects-to': 'hello-minikube3',
+          'deployment.kubernetes.io/revision': '2',
+        },
+      },
+      spec: {
+        replicas: 1,
+        selector: {
+          matchLabels: {
+            app: 'hello-minikube2',
+          },
+        },
+        template: {
+          metadata: {
+            creationTimestamp: null,
+            labels: {
+              app: 'hello-minikube2',
+              'backstage.io/kubernetes-id': 'nationalparks-py',
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: 'echo-server',
+                image: 'kicbase/echo-server:1.0',
+                resources: {},
+                terminationMessagePath: '/dev/termination-log',
+                terminationMessagePolicy: 'File',
+                imagePullPolicy: 'IfNotPresent',
+              },
+            ],
+            restartPolicy: 'Always',
+            terminationGracePeriodSeconds: 30,
+            dnsPolicy: 'ClusterFirst',
+            securityContext: {},
+            schedulerName: 'default-scheduler',
+          },
+        },
+        strategy: {
+          type: 'RollingUpdate',
+          rollingUpdate: {
+            maxUnavailable: '25%',
+            maxSurge: '25%',
+          },
+        },
+        revisionHistoryLimit: 10,
+        progressDeadlineSeconds: 600,
+      },
+      status: {
+        observedGeneration: 6,
+        replicas: 1,
+        updatedReplicas: 1,
+        readyReplicas: 1,
+        availableReplicas: 1,
+        conditions: [
+          {
+            type: 'Progressing',
+            status: 'True',
+            lastUpdateTime: '2023-03-23T13:14:51Z',
+            lastTransitionTime: '2023-02-13T14:49:49Z',
+            reason: 'NewReplicaSetAvailable',
+            message:
+              'ReplicaSet "hello-minikube2-848cf77669" has successfully progressed.',
+          },
+          {
+            type: 'Available',
+            status: 'True',
+            lastUpdateTime: '2023-04-07T15:03:02Z',
+            lastTransitionTime: '2023-04-07T15:03:02Z',
+            reason: 'MinimumReplicasAvailable',
+            message: 'Deployment has minimum availability.',
+          },
+        ],
+      },
+      kind: 'Deployment',
+      apiVersion: 'apps/v1',
+    },
+    data: {
+      kind: 'Deployment',
+      builderImage: 'default image',
+      url: 'http://div/minikube',
+      podsData: {
+        obj: {
+          metadata: {
+            name: 'hello-minikube2',
+            namespace: 'div',
+            uid: 'bfb6932f-64c6-4fe3-b283-16ecec8628c0',
+            resourceVersion: '417930',
+            generation: 6,
+            creationTimestamp: '2023-02-13T14:49:49Z',
+            labels: {
+              app: 'hello-minikube2',
+              'app.kubernetes.io/part-of': 'nationalparks-py',
+              'backstage.io/kubernetes-id': 'nationalparks-py',
+            },
+            annotations: {
+              'app.openshift.io/connects-to': 'hello-minikube3',
+              'deployment.kubernetes.io/revision': '2',
+            },
+          },
+          spec: {
+            replicas: 1,
+            selector: {
+              matchLabels: {
+                app: 'hello-minikube2',
+              },
+            },
+            template: {
+              metadata: {
+                creationTimestamp: null,
+                labels: {
+                  app: 'hello-minikube2',
+                  'backstage.io/kubernetes-id': 'nationalparks-py',
+                },
+              },
+              spec: {
+                containers: [
+                  {
+                    name: 'echo-server',
+                    image: 'kicbase/echo-server:1.0',
+                    resources: {},
+                    terminationMessagePath: '/dev/termination-log',
+                    terminationMessagePolicy: 'File',
+                    imagePullPolicy: 'IfNotPresent',
+                  },
+                ],
+                restartPolicy: 'Always',
+                terminationGracePeriodSeconds: 30,
+                dnsPolicy: 'ClusterFirst',
+                securityContext: {},
+                schedulerName: 'default-scheduler',
+              },
+            },
+            strategy: {
+              type: 'RollingUpdate',
+              rollingUpdate: {
+                maxUnavailable: '25%',
+                maxSurge: '25%',
+              },
+            },
+            revisionHistoryLimit: 10,
+            progressDeadlineSeconds: 600,
+          },
+          status: {
+            observedGeneration: 6,
+            replicas: 1,
+            updatedReplicas: 1,
+            readyReplicas: 1,
+            availableReplicas: 1,
+            conditions: [
+              {
+                type: 'Progressing',
+                status: 'True',
+                lastUpdateTime: '2023-03-23T13:14:51Z',
+                lastTransitionTime: '2023-02-13T14:49:49Z',
+                reason: 'NewReplicaSetAvailable',
+                message:
+                  'ReplicaSet "hello-minikube2-848cf77669" has successfully progressed.',
+              },
+              {
+                type: 'Available',
+                status: 'True',
+                lastUpdateTime: '2023-04-07T15:03:02Z',
+                lastTransitionTime: '2023-04-07T15:03:02Z',
+                reason: 'MinimumReplicasAvailable',
+                message: 'Deployment has minimum availability.',
+              },
+            ],
+          },
+          kind: 'Deployment',
+          apiVersion: 'apps/v1',
+        },
+        current: {
+          alerts: {},
+          obj: {
+            metadata: {
+              name: 'hello-minikube2-848cf77669',
+              namespace: 'div',
+              uid: '06d5c182-5135-4676-9ceb-6b5cc52b9519',
+              resourceVersion: '417928',
+              generation: 3,
+              creationTimestamp: '2023-03-23T13:14:49Z',
+              labels: {
+                app: 'hello-minikube2',
+                'backstage.io/kubernetes-id': 'nationalparks-py',
+                'pod-template-hash': '848cf77669',
+              },
+              annotations: {
+                'app.openshift.io/connects-to': 'hello-minikube3',
+                'deployment.kubernetes.io/desired-replicas': '4',
+                'deployment.kubernetes.io/max-replicas': '5',
+                'deployment.kubernetes.io/revision': '2',
+              },
+              ownerReferences: [
+                {
+                  apiVersion: 'apps/v1',
+                  kind: 'Deployment',
+                  name: 'hello-minikube2',
+                  uid: 'bfb6932f-64c6-4fe3-b283-16ecec8628c0',
+                  controller: true,
+                  blockOwnerDeletion: true,
+                },
+              ],
+            },
+            spec: {
+              replicas: 1,
+              selector: {
+                matchLabels: {
+                  app: 'hello-minikube2',
+                  'pod-template-hash': '848cf77669',
+                },
+              },
+              template: {
+                metadata: {
+                  creationTimestamp: null,
+                  labels: {
+                    app: 'hello-minikube2',
+                    'backstage.io/kubernetes-id': 'nationalparks-py',
+                    'pod-template-hash': '848cf77669',
+                  },
+                },
+                spec: {
+                  containers: [
+                    {
+                      name: 'echo-server',
+                      image: 'kicbase/echo-server:1.0',
+                      resources: {},
+                      terminationMessagePath: '/dev/termination-log',
+                      terminationMessagePolicy: 'File',
+                      imagePullPolicy: 'IfNotPresent',
+                    },
+                  ],
+                  restartPolicy: 'Always',
+                  terminationGracePeriodSeconds: 30,
+                  dnsPolicy: 'ClusterFirst',
+                  securityContext: {},
+                  schedulerName: 'default-scheduler',
+                },
+              },
+            },
+            status: {
+              replicas: 1,
+              fullyLabeledReplicas: 1,
+              readyReplicas: 1,
+              availableReplicas: 1,
+              observedGeneration: 3,
+            },
+            kind: 'ReplicaSet',
+            apiVersion: 'apps/v1',
+          },
+          pods: [
+            {
+              metadata: {
+                name: 'hello-minikube2-848cf77669-5fqtp',
+                generateName: 'hello-minikube2-848cf77669-',
+                namespace: 'div',
+                uid: 'ef2848f6-bdfd-4ae4-bba7-fac8d93e8dc5',
+                resourceVersion: '417920',
+                creationTimestamp: '2023-03-23T13:14:50Z',
+                labels: {
+                  app: 'hello-minikube2',
+                  'backstage.io/kubernetes-id': 'nationalparks-py',
+                  'pod-template-hash': '848cf77669',
+                },
+                ownerReferences: [
+                  {
+                    apiVersion: 'apps/v1',
+                    kind: 'ReplicaSet',
+                    name: 'hello-minikube2-848cf77669',
+                    uid: '06d5c182-5135-4676-9ceb-6b5cc52b9519',
+                    controller: true,
+                    blockOwnerDeletion: true,
+                  },
+                ],
+              },
+              spec: {
+                volumes: [
+                  {
+                    name: 'kube-api-access-lb9mh',
+                    projected: {
+                      sources: [
+                        {
+                          serviceAccountToken: {
+                            expirationSeconds: 3607,
+                            path: 'token',
+                          },
+                        },
+                        {
+                          configMap: {
+                            name: 'kube-root-ca.crt',
+                            items: [
+                              {
+                                key: 'ca.crt',
+                                path: 'ca.crt',
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          downwardAPI: {
+                            items: [
+                              {
+                                path: 'namespace',
+                                fieldRef: {
+                                  apiVersion: 'v1',
+                                  fieldPath: 'metadata.namespace',
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                      defaultMode: 420,
+                    },
+                  },
+                ],
+                containers: [
+                  {
+                    name: 'echo-server',
+                    image: 'kicbase/echo-server:1.0',
+                    resources: {},
+                    volumeMounts: [
+                      {
+                        name: 'kube-api-access-lb9mh',
+                        readOnly: true,
+                        mountPath:
+                          '/var/run/secrets/kubernetes.io/serviceaccount',
+                      },
+                    ],
+                    terminationMessagePath: '/dev/termination-log',
+                    terminationMessagePolicy: 'File',
+                    imagePullPolicy: 'IfNotPresent',
+                  },
+                ],
+                restartPolicy: 'Always',
+                terminationGracePeriodSeconds: 30,
+                dnsPolicy: 'ClusterFirst',
+                serviceAccountName: 'default',
+                serviceAccount: 'default',
+                nodeName: 'minikube',
+                securityContext: {},
+                schedulerName: 'default-scheduler',
+                tolerations: [
+                  {
+                    key: 'node.kubernetes.io/not-ready',
+                    operator: 'Exists',
+                    effect: 'NoExecute',
+                    tolerationSeconds: 300,
+                  },
+                  {
+                    key: 'node.kubernetes.io/unreachable',
+                    operator: 'Exists',
+                    effect: 'NoExecute',
+                    tolerationSeconds: 300,
+                  },
+                ],
+                priority: 0,
+                enableServiceLinks: true,
+                preemptionPolicy: 'PreemptLowerPriority',
+              },
+              status: {
+                phase: 'Running',
+                conditions: [
+                  {
+                    type: 'Initialized',
+                    status: 'True',
+                    lastProbeTime: null,
+                    lastTransitionTime: '2023-03-23T13:14:50Z',
+                  },
+                  {
+                    type: 'Ready',
+                    status: 'True',
+                    lastProbeTime: null,
+                    lastTransitionTime: '2023-03-23T13:14:51Z',
+                  },
+                  {
+                    type: 'ContainersReady',
+                    status: 'True',
+                    lastProbeTime: null,
+                    lastTransitionTime: '2023-03-23T13:14:51Z',
+                  },
+                  {
+                    type: 'PodScheduled',
+                    status: 'True',
+                    lastProbeTime: null,
+                    lastTransitionTime: '2023-03-23T13:14:50Z',
+                  },
+                ],
+                hostIP: '192.168.49.2',
+                podIP: '10.244.0.23',
+                podIPs: [
+                  {
+                    ip: '10.244.0.23',
+                  },
+                ],
+                startTime: '2023-03-23T13:14:50Z',
+                containerStatuses: [
+                  {
+                    name: 'echo-server',
+                    state: {
+                      running: {
+                        startedAt: '2023-03-23T13:14:51Z',
+                      },
+                    },
+                    lastState: {},
+                    ready: true,
+                    restartCount: 0,
+                    image: 'kicbase/echo-server:1.0',
+                    imageID:
+                      'docker-pullable://kicbase/echo-server@sha256:127ac38a2bb9537b7f252addff209ea6801edcac8a92c8b1104dacd66a583ed6',
+                    containerID:
+                      'docker://44fa417ec9454b56491eb143d5914c12712f48732282f26eb224029f1a013cf6',
+                    started: true,
+                  },
+                ],
+                qosClass: 'BestEffort',
+              },
+              kind: 'Pod',
+              apiVersion: 'v1',
+            },
+          ],
+          revision: 2,
+        },
+        isRollingOut: false,
+        pods: [
+          {
+            metadata: {
+              name: 'hello-minikube2-848cf77669-5fqtp',
+              generateName: 'hello-minikube2-848cf77669-',
+              namespace: 'div',
+              uid: 'ef2848f6-bdfd-4ae4-bba7-fac8d93e8dc5',
+              resourceVersion: '417920',
+              creationTimestamp: '2023-03-23T13:14:50Z',
+              labels: {
+                app: 'hello-minikube2',
+                'backstage.io/kubernetes-id': 'nationalparks-py',
+                'pod-template-hash': '848cf77669',
+              },
+              ownerReferences: [
+                {
+                  apiVersion: 'apps/v1',
+                  kind: 'ReplicaSet',
+                  name: 'hello-minikube2-848cf77669',
+                  uid: '06d5c182-5135-4676-9ceb-6b5cc52b9519',
+                  controller: true,
+                  blockOwnerDeletion: true,
+                },
+              ],
+            },
+            spec: {
+              volumes: [
+                {
+                  name: 'kube-api-access-lb9mh',
+                  projected: {
+                    sources: [
+                      {
+                        serviceAccountToken: {
+                          expirationSeconds: 3607,
+                          path: 'token',
+                        },
+                      },
+                      {
+                        configMap: {
+                          name: 'kube-root-ca.crt',
+                          items: [
+                            {
+                              key: 'ca.crt',
+                              path: 'ca.crt',
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        downwardAPI: {
+                          items: [
+                            {
+                              path: 'namespace',
+                              fieldRef: {
+                                apiVersion: 'v1',
+                                fieldPath: 'metadata.namespace',
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                    defaultMode: 420,
+                  },
+                },
+              ],
+              containers: [
+                {
+                  name: 'echo-server',
+                  image: 'kicbase/echo-server:1.0',
+                  resources: {},
+                  volumeMounts: [
+                    {
+                      name: 'kube-api-access-lb9mh',
+                      readOnly: true,
+                      mountPath:
+                        '/var/run/secrets/kubernetes.io/serviceaccount',
+                    },
+                  ],
+                  terminationMessagePath: '/dev/termination-log',
+                  terminationMessagePolicy: 'File',
+                  imagePullPolicy: 'IfNotPresent',
+                },
+              ],
+              restartPolicy: 'Always',
+              terminationGracePeriodSeconds: 30,
+              dnsPolicy: 'ClusterFirst',
+              serviceAccountName: 'default',
+              serviceAccount: 'default',
+              nodeName: 'minikube',
+              securityContext: {},
+              schedulerName: 'default-scheduler',
+              tolerations: [
+                {
+                  key: 'node.kubernetes.io/not-ready',
+                  operator: 'Exists',
+                  effect: 'NoExecute',
+                  tolerationSeconds: 300,
+                },
+                {
+                  key: 'node.kubernetes.io/unreachable',
+                  operator: 'Exists',
+                  effect: 'NoExecute',
+                  tolerationSeconds: 300,
+                },
+              ],
+              priority: 0,
+              enableServiceLinks: true,
+              preemptionPolicy: 'PreemptLowerPriority',
+            },
+            status: {
+              phase: 'Running',
+              conditions: [
+                {
+                  type: 'Initialized',
+                  status: 'True',
+                  lastProbeTime: null,
+                  lastTransitionTime: '2023-03-23T13:14:50Z',
+                },
+                {
+                  type: 'Ready',
+                  status: 'True',
+                  lastProbeTime: null,
+                  lastTransitionTime: '2023-03-23T13:14:51Z',
+                },
+                {
+                  type: 'ContainersReady',
+                  status: 'True',
+                  lastProbeTime: null,
+                  lastTransitionTime: '2023-03-23T13:14:51Z',
+                },
+                {
+                  type: 'PodScheduled',
+                  status: 'True',
+                  lastProbeTime: null,
+                  lastTransitionTime: '2023-03-23T13:14:50Z',
+                },
+              ],
+              hostIP: '192.168.49.2',
+              podIP: '10.244.0.23',
+              podIPs: [
+                {
+                  ip: '10.244.0.23',
+                },
+              ],
+              startTime: '2023-03-23T13:14:50Z',
+              containerStatuses: [
+                {
+                  name: 'echo-server',
+                  state: {
+                    running: {
+                      startedAt: '2023-03-23T13:14:51Z',
+                    },
+                  },
+                  lastState: {},
+                  ready: true,
+                  restartCount: 0,
+                  image: 'kicbase/echo-server:1.0',
+                  imageID:
+                    'docker-pullable://kicbase/echo-server@sha256:127ac38a2bb9537b7f252addff209ea6801edcac8a92c8b1104dacd66a583ed6',
+                  containerID:
+                    'docker://44fa417ec9454b56491eb143d5914c12712f48732282f26eb224029f1a013cf6',
+                  started: true,
+                },
+              ],
+              qosClass: 'BestEffort',
+            },
+            kind: 'Pod',
+            apiVersion: 'v1',
+          },
+        ],
+      },
+      services: [
+        {
+          metadata: {
+            name: 'hello-minikube2',
+            namespace: 'div',
+            uid: '465a9db1-b30c-4636-949b-c9bc9a000f56',
+            resourceVersion: '3825',
+            creationTimestamp: '2023-02-13T14:52:24Z',
+            labels: {
+              app: 'hello-minikube2',
+              'backstage.io/kubernetes-id': 'nationalparks-py',
+            },
+          },
+          spec: {
+            ports: [
+              {
+                protocol: 'TCP',
+                port: 8081,
+                targetPort: 8081,
+                nodePort: 30179,
+              },
+            ],
+            selector: {
+              app: 'hello-minikube2',
+            },
+            clusterIP: '10.101.77.157',
+            clusterIPs: ['10.101.77.157'],
+            type: 'NodePort',
+            sessionAffinity: 'None',
+            externalTrafficPolicy: 'Cluster',
+            ipFamilies: ['IPv4'],
+            ipFamilyPolicy: 'SingleStack',
+            internalTrafficPolicy: 'Cluster',
+          },
+          status: {
+            loadBalancer: {},
+          },
+          kind: 'Service',
+          apiVersion: 'v1',
+        },
+      ],
+      ingressesData: [
+        {
+          ingress: {
+            metadata: {
+              name: 'hello-minikube2-ingress',
+              namespace: 'div',
+              uid: 'a2ea87d9-6ab5-4c4c-883f-cb8eb0d6f272',
+              resourceVersion: '345759',
+              generation: 2,
+              creationTimestamp: '2023-02-13T15:00:22Z',
+              labels: {
+                'backstage.io/kubernetes-id': 'nationalparks-py',
+              },
+              annotations: {
+                'kubectl.kubernetes.io/last-applied-configuration':
+                  '{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","metadata":{"annotations":{},"name":"hello-minikube2-ingress","namespace":"div"},"spec":{"rules":[{"http":{"paths":[{"backend":{"service":{"name":"hello-minikube2","port":{"number":8081}}},"path":"/minikube","pathType":"Prefix"}]}}]}}\n',
+              },
+            },
+            spec: {
+              rules: [
+                {
+                  host: 'div',
+                  http: {
+                    paths: [
+                      {
+                        path: '/minikube',
+                        pathType: 'Prefix',
+                        backend: {
+                          service: {
+                            name: 'hello-minikube2',
+                            port: {
+                              number: 8081,
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            status: {
+              loadBalancer: {},
+            },
+            kind: 'Ingress',
+            apiVersion: 'networking.k8s.io/v1',
+          },
+          url: 'http://div/minikube',
+        },
+      ],
+    },
+  },
+  width: 104,
+  height: 104,
+};
+
+export const workloadNode = {
+  getDimensions: () => ({
+    width: workloadNodeData.width,
+    height: workloadNodeData.height,
+  }),
+  getData: () => workloadNodeData.data,
+};
+
+export const workloadNode2 = {
+  getDimensions: () => ({
+    width: workloadNodeData.width,
+    height: workloadNodeData.height,
+  }),
+  getData: () => ({ resource: {}, data: {} }),
+};

--- a/plugins/topology/src/components/Graph/WorkloadNode.tsx
+++ b/plugins/topology/src/components/Graph/WorkloadNode.tsx
@@ -58,7 +58,7 @@ type InnerWorkloadNodeProps = {
 } & Partial<WithSelectionProps & WithDragNodeProps>;
 
 const InnerWorkloadNode: React.FC<InnerWorkloadNodeProps> = observer(
-  ({ element, ...rest }) => {
+  ({ element, onSelect, ...rest }) => {
     const data = element.getData();
     const { width, height } = element.getDimensions();
     const workloadData = data.data;
@@ -71,6 +71,12 @@ const InnerWorkloadNode: React.FC<InnerWorkloadNodeProps> = observer(
     const controller = useVisualizationController();
     const detailsLevel = controller.getGraph().getDetailsLevel();
     const showDetails = hover || detailsLevel !== ScaleDetailsLevel.low;
+    const onNodeSelect = (e: React.MouseEvent) => {
+      const params = new URLSearchParams(window.location.search);
+      params.set('selectedId', element.getId());
+      history.replaceState(null, '', `?${params.toString()}`);
+      if (onSelect) onSelect(e);
+    };
 
     const urlDecorator = React.useMemo(() => {
       if (!workloadData?.url) {
@@ -103,6 +109,7 @@ const InnerWorkloadNode: React.FC<InnerWorkloadNodeProps> = observer(
             !showDetails ? getAggregateStatus(donutStatus) : undefined
           }
           attachments={showDetails && urlDecorator}
+          onSelect={onNodeSelect}
           {...rest}
         >
           {donutStatus && showDetails ? (

--- a/plugins/topology/src/components/Pods/PodSet.tsx
+++ b/plugins/topology/src/components/Pods/PodSet.tsx
@@ -14,6 +14,7 @@ type PodSetProps = {
   showPodCount?: boolean;
   x?: number;
   y?: number;
+  standalone?: boolean;
 };
 
 type InnerPodStatusRadius = {
@@ -65,6 +66,7 @@ const PodSet: React.FC<PodSetProps> = React.memo(function PodSet({
   x = 0,
   y = 0,
   showPodCount,
+  standalone,
 }) {
   const { podStatusOuterRadius, podStatusInnerRadius, podStatusStrokeWidth } =
     calculateRadius(size);
@@ -92,6 +94,7 @@ const PodSet: React.FC<PodSetProps> = React.memo(function PodSet({
         subTitle={showPodCount ? subTitle : undefined}
         title={showPodCount ? title : undefined}
         titleComponent={showPodCount ? titleComponent : undefined}
+        standalone={standalone}
       />
       {inProgressDeploymentData && (
         <PodStatus

--- a/plugins/topology/src/components/Pods/PodStatus.css
+++ b/plugins/topology/src/components/Pods/PodStatus.css
@@ -10,3 +10,13 @@
 .tp-pod-status-tooltip__status-count {
   margin-right: var(--pf-global--spacer--xs);
 }
+
+.pod-ring__center-text tspan {
+  font-size: 14px !important;
+  fill: var(--pf-global--Color--200) !important;
+}
+
+.pod-ring__center-text:not(.pod-ring__long-text) tspan:first-of-type {
+  font-size: 14px !important;
+  fill: var(--pf-global--Color--100) !important;
+}

--- a/plugins/topology/src/components/Topology/TopologyComponent.css
+++ b/plugins/topology/src/components/Topology/TopologyComponent.css
@@ -4,3 +4,11 @@
   flex-direction: column;
   overflow: hidden;
 }
+
+.topology-text-muted {
+  color: var(--pf-global--Color--200);
+}
+
+.pf-topology-side-bar-resizable {
+  flex: 1 1 0;
+}

--- a/plugins/topology/src/components/Topology/TopologyComponent.css
+++ b/plugins/topology/src/components/Topology/TopologyComponent.css
@@ -8,7 +8,3 @@
 .topology-text-muted {
   color: var(--pf-global--Color--200);
 }
-
-.pf-topology-side-bar-resizable {
-  flex: 1 1 0;
-}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDeploymentDetails.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDeploymentDetails.css
@@ -1,0 +1,4 @@
+.topology-deployment-details {
+  flex: 1;
+  min-width: 200px;
+}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDeploymentDetails.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDeploymentDetails.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { V1Deployment } from '@kubernetes/client-node';
+import TopologySideBarDetailsItem from './TopologySideBarDetailsItem';
+
+import './TopologyDeploymentDetails.css';
+
+const TopologyDeploymentDetails: React.FC<{ resource: V1Deployment }> = ({
+  resource,
+}) => {
+  return (
+    <div className="topology-deployment-details">
+      <TopologySideBarDetailsItem label="Status">
+        {resource.status?.availableReplicas ===
+        resource.status?.updatedReplicas ? (
+          'Active'
+        ) : (
+          <div>Updating</div>
+        )}
+      </TopologySideBarDetailsItem>
+      <TopologySideBarDetailsItem label="Update strategy">
+        {resource.spec?.strategy?.type}
+      </TopologySideBarDetailsItem>
+      <TopologySideBarDetailsItem label="Max unavailable">
+        {`${resource.spec?.strategy?.rollingUpdate?.maxUnavailable ?? 1} of ${
+          resource.spec?.replicas
+        } pod`}
+      </TopologySideBarDetailsItem>
+      <TopologySideBarDetailsItem label="Max surge">
+        {`${
+          resource.spec?.strategy?.rollingUpdate?.maxSurge ?? 1
+        } greater than ${resource.spec?.replicas} pod`}
+      </TopologySideBarDetailsItem>
+      <TopologySideBarDetailsItem label="Progress deadline seconds">
+        {resource.spec?.progressDeadlineSeconds
+          ? `${resource.spec.progressDeadlineSeconds} seconds`
+          : 'Not configured'}
+      </TopologySideBarDetailsItem>
+      <TopologySideBarDetailsItem label="Min ready seconds">
+        {resource.spec?.minReadySeconds
+          ? `${resource.spec.minReadySeconds} seconds`
+          : 'Not configured'}
+      </TopologySideBarDetailsItem>
+    </div>
+  );
+};
+
+export default TopologyDeploymentDetails;

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDeploymentDetails.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDeploymentDetails.tsx
@@ -8,7 +8,10 @@ const TopologyDeploymentDetails: React.FC<{ resource: V1Deployment }> = ({
   resource,
 }) => {
   return (
-    <div className="topology-deployment-details">
+    <div
+      className="topology-deployment-details"
+      data-testid="deployment-details"
+    >
       <TopologySideBarDetailsItem label="Status">
         {resource.status?.availableReplicas ===
         resource.status?.updatedReplicas ? (

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.css
@@ -9,10 +9,6 @@
   min-width: 200px;
 }
 
-.topology-workload-details .no-owner {
-  color: var(--pf-global--Color--200);
-}
-
 .topology-side-bar-pod-ring {
   width: 100%;
 }

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.css
@@ -1,0 +1,23 @@
+.topology-details-tab {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pf-global--spacer--lg);
+}
+
+.topology-workload-details {
+  flex: 1;
+  min-width: 200px;
+}
+
+.topology-workload-details .no-owner {
+  color: var(--pf-global--Color--200);
+}
+
+.topology-side-bar-pod-ring {
+  width: 100%;
+}
+
+.topology-side-bar-pod-ring svg {
+  overflow: visible !important;
+  max-width: 130px;
+}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.test.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  workloadNode,
+  workloadNode2,
+} from '../../../__fixtures__/workloadNodeData';
+import TopologyDetailsTabPanel from './TopologyDetailsTabPanel';
+import { BaseNode } from '@patternfly/react-topology';
+
+describe('TopologyDetailsTabPanel', () => {
+  it('Should render workload node details', () => {
+    const { queryByTestId } = render(
+      <TopologyDetailsTabPanel node={workloadNode as BaseNode} />,
+    );
+    expect(queryByTestId('details-tab')).not.toBeNull();
+  });
+
+  it('Should show pod ring if pods data is available', () => {
+    const { rerender, queryByRole } = render(
+      <TopologyDetailsTabPanel node={workloadNode as BaseNode} />,
+    );
+    expect(
+      queryByRole('img', {
+        name: /1 pod/i,
+      }),
+    ).not.toBeNull();
+    rerender(<TopologyDetailsTabPanel node={workloadNode2 as BaseNode} />);
+    expect(
+      queryByRole('img', {
+        name: /1 pods/i,
+      }),
+    ).toBeNull();
+  });
+
+  it('Should show labels if available and empty state otherwise', () => {
+    const { queryByTestId, getByText, rerender } = render(
+      <TopologyDetailsTabPanel node={workloadNode as BaseNode} />,
+    );
+    expect(queryByTestId('label-list')).not.toBeNull();
+    rerender(<TopologyDetailsTabPanel node={workloadNode2 as BaseNode} />);
+    getByText(/no labels/i);
+  });
+
+  it('Should show annotations if available and empty state otherwise', () => {
+    const { queryByTestId, getByText, rerender } = render(
+      <TopologyDetailsTabPanel node={workloadNode as BaseNode} />,
+    );
+    expect(queryByTestId('annotation-list')).not.toBeNull();
+    rerender(<TopologyDetailsTabPanel node={workloadNode2 as BaseNode} />);
+    getByText(/no annotations/i);
+  });
+
+  it('Should show owners if available and empty state otherwise', () => {
+    const { queryByTestId, getByText, rerender } = render(
+      <TopologyDetailsTabPanel node={workloadNode as BaseNode} />,
+    );
+    expect(queryByTestId('owner-list')).not.toBeNull();
+    rerender(<TopologyDetailsTabPanel node={workloadNode2 as BaseNode} />);
+    getByText(/no owner/i);
+  });
+
+  it('Should show more details if workload is a deployment', () => {
+    const { queryByTestId, rerender } = render(
+      <TopologyDetailsTabPanel node={workloadNode as BaseNode} />,
+    );
+    expect(queryByTestId('deployment-details')).not.toBeNull();
+    rerender(<TopologyDetailsTabPanel node={workloadNode2 as BaseNode} />);
+    expect(queryByTestId('deployment-details')).toBeNull();
+  });
+});

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import {
+  Split,
+  SplitItem,
+  Timestamp,
+  TimestampFormat,
+} from '@patternfly/react-core';
+import PodSet from '../../Pods/PodSet';
+import TopologySideBarDetailsItem from './TopologySideBarDetailsItem';
+import { DeploymentModel } from '../../../models';
+import TopologyDeploymentDetails from './TopologyDeploymentDetails';
+import { V1Deployment } from '@kubernetes/client-node';
+import { BaseNode } from '@patternfly/react-topology';
+
+import './TopologyDetailsTabPanel.css';
+import TopologyResourceLabels from './TopologyResourceLabels';
+
+const TopologyDetailsTabPanel: React.FC<{ node: BaseNode }> = ({ node }) => {
+  const { width, height } = node.getDimensions();
+  const data = node.getData();
+  const resource = data.resource;
+  const resourceKind = resource.kind;
+  const size = Math.min(width, height);
+  const donutStatus = data?.data?.podsData;
+  const cx = width / 2;
+  const cy = height / 2;
+
+  return (
+    <div className="topology-details-tab">
+      {donutStatus && (
+        <Split className="topology-side-bar-pod-ring">
+          <SplitItem>
+            <PodSet
+              size={size}
+              x={cx}
+              y={cy}
+              data={donutStatus}
+              showPodCount
+              standalone
+            />
+          </SplitItem>
+          <SplitItem isFilled />
+        </Split>
+      )}
+      <div className="topology-workload-details">
+        <dl>
+          <TopologySideBarDetailsItem label="Name">
+            {data?.name}
+          </TopologySideBarDetailsItem>
+          <TopologySideBarDetailsItem label="Namespace">
+            {resource.metadata?.namespace}
+          </TopologySideBarDetailsItem>
+          {resource.metadata.labels ? (
+            <TopologySideBarDetailsItem label="Labels">
+              <TopologyResourceLabels labels={resource.metadata.labels} />
+            </TopologySideBarDetailsItem>
+          ) : null}
+          {resource.metadata.annotations ? (
+            <TopologySideBarDetailsItem label="Annotations">
+              <TopologyResourceLabels labels={resource.metadata.annotations} />
+            </TopologySideBarDetailsItem>
+          ) : null}
+          <TopologySideBarDetailsItem label="Created at">
+            <Timestamp
+              date={resource?.metadata?.creationTimestamp}
+              dateFormat={TimestampFormat.medium}
+              timeFormat={TimestampFormat.short}
+            />
+          </TopologySideBarDetailsItem>
+          <TopologySideBarDetailsItem label="Owner">
+            {resource.metadata?.ownerReferences ? (
+              <ul>
+                <div>
+                  {(Object.keys(resource.metadata.ownerReferences) ?? []).map(
+                    (o: any) => (
+                      <li>{o.name}</li>
+                    ),
+                  )}
+                </div>
+              </ul>
+            ) : (
+              <span className="no-owner">No owner</span>
+            )}
+          </TopologySideBarDetailsItem>
+        </dl>
+      </div>
+      {resourceKind === DeploymentModel.kind ? (
+        <TopologyDeploymentDetails resource={resource as V1Deployment} />
+      ) : null}
+    </div>
+  );
+};
+
+export default TopologyDetailsTabPanel;

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.tsx
@@ -9,11 +9,11 @@ import PodSet from '../../Pods/PodSet';
 import TopologySideBarDetailsItem from './TopologySideBarDetailsItem';
 import { DeploymentModel } from '../../../models';
 import TopologyDeploymentDetails from './TopologyDeploymentDetails';
-import { V1Deployment } from '@kubernetes/client-node';
+import { V1Deployment, V1OwnerReference } from '@kubernetes/client-node';
 import { BaseNode } from '@patternfly/react-topology';
+import TopologyResourceLabels from './TopologyResourceLabels';
 
 import './TopologyDetailsTabPanel.css';
-import TopologyResourceLabels from './TopologyResourceLabels';
 
 const TopologyDetailsTabPanel: React.FC<{ node: BaseNode }> = ({ node }) => {
   const { width, height } = node.getDimensions();
@@ -21,12 +21,12 @@ const TopologyDetailsTabPanel: React.FC<{ node: BaseNode }> = ({ node }) => {
   const resource = data.resource;
   const resourceKind = resource.kind;
   const size = Math.min(width, height);
-  const donutStatus = data?.data?.podsData;
+  const donutStatus = data.data?.podsData;
   const cx = width / 2;
   const cy = height / 2;
 
   return (
-    <div className="topology-details-tab">
+    <div className="topology-details-tab" data-testid="details-tab">
       {donutStatus && (
         <Split className="topology-side-bar-pod-ring">
           <SplitItem>
@@ -45,41 +45,48 @@ const TopologyDetailsTabPanel: React.FC<{ node: BaseNode }> = ({ node }) => {
       <div className="topology-workload-details">
         <dl>
           <TopologySideBarDetailsItem label="Name">
-            {data?.name}
+            {resource.metadata?.name}
           </TopologySideBarDetailsItem>
           <TopologySideBarDetailsItem label="Namespace">
             {resource.metadata?.namespace}
           </TopologySideBarDetailsItem>
-          {resource.metadata.labels ? (
-            <TopologySideBarDetailsItem label="Labels">
-              <TopologyResourceLabels labels={resource.metadata.labels} />
-            </TopologySideBarDetailsItem>
-          ) : null}
-          {resource.metadata.annotations ? (
-            <TopologySideBarDetailsItem label="Annotations">
-              <TopologyResourceLabels labels={resource.metadata.annotations} />
-            </TopologySideBarDetailsItem>
-          ) : null}
+          <TopologySideBarDetailsItem label="Labels" emptyText="No labels">
+            {resource.metadata?.labels && (
+              <TopologyResourceLabels
+                labels={resource.metadata.labels}
+                dataTest="label-list"
+              />
+            )}
+          </TopologySideBarDetailsItem>
+          <TopologySideBarDetailsItem
+            label="Annotations"
+            emptyText="No annotations"
+          >
+            {resource.metadata?.annotations && (
+              <TopologyResourceLabels
+                labels={resource.metadata.annotations}
+                dataTest="annotation-list"
+              />
+            )}
+          </TopologySideBarDetailsItem>
           <TopologySideBarDetailsItem label="Created at">
             <Timestamp
-              date={resource?.metadata?.creationTimestamp}
+              date={resource.metadata?.creationTimestamp}
               dateFormat={TimestampFormat.medium}
               timeFormat={TimestampFormat.short}
             />
           </TopologySideBarDetailsItem>
-          <TopologySideBarDetailsItem label="Owner">
-            {resource.metadata?.ownerReferences ? (
-              <ul>
+          <TopologySideBarDetailsItem label="Owner" emptyText="No owner">
+            {resource.metadata?.ownerReferences && (
+              <ul data-testid="owner-list">
                 <div>
-                  {(Object.keys(resource.metadata.ownerReferences) ?? []).map(
-                    (o: any) => (
-                      <li>{o.name}</li>
+                  {(resource.metadata.ownerReferences ?? []).map(
+                    (o: V1OwnerReference) => (
+                      <li key={o.uid}>{o.name}</li>
                     ),
                   )}
                 </div>
               </ul>
-            ) : (
-              <span className="no-owner">No owner</span>
             )}
           </TopologySideBarDetailsItem>
         </dl>

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourceLabels.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourceLabels.css
@@ -1,0 +1,28 @@
+.topology-resource-labels-list {
+  border: 1px solid var(--pf-global--BorderColor--300);
+  margin: var(--pf-global--spacer--xs) 0px 0px 0px;
+  padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--xs) 0px;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.topology-resource-labels-list li {
+  min-width: 0px;
+}
+
+.topology-resource-labels-list-item {
+  margin: 0 0 var(--pf-global--spacer--xs) 0 !important;
+  display: flex !important;
+  justify-content: flex-start !important;
+}
+
+.topology-resource-labels-list-item .label-key,
+.label-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pf-c-label__content {
+  font-size: 13px;
+}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourceLabels.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourceLabels.tsx
@@ -5,11 +5,12 @@ import './TopologyResourceLabels.css';
 
 const TopologyResourceLabels: React.FC<{
   labels: { [key: string]: string };
-}> = ({ labels }) => {
+  dataTest?: string;
+}> = ({ labels, dataTest }) => {
   return (
-    <ul className="topology-resource-labels-list">
-      {(Object.keys(labels ?? {}) ?? []).map((key: string, index) => (
-        <li key={index}>
+    <ul className="topology-resource-labels-list" data-testid={dataTest}>
+      {Object.keys(labels ?? {}).map((key: string) => (
+        <li key={key}>
           <Label className="topology-resource-labels-list-item" color="blue">
             <span className="pf-c-label__content">
               <span className="label-key">{key}</span>

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourceLabels.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourceLabels.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Label } from '@patternfly/react-core';
+
+import './TopologyResourceLabels.css';
+
+const TopologyResourceLabels: React.FC<{
+  labels: { [key: string]: string };
+}> = ({ labels }) => {
+  return (
+    <ul className="topology-resource-labels-list">
+      {(Object.keys(labels ?? {}) ?? []).map((key: string, index) => (
+        <li key={index}>
+          <Label className="topology-resource-labels-list-item" color="blue">
+            <span className="pf-c-label__content">
+              <span className="label-key">{key}</span>
+              <span>=</span>
+              <span className="label-value">{labels[key]}</span>
+            </span>
+          </Label>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default TopologyResourceLabels;

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.test.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  workloadNode,
+  workloadNode2,
+} from '../../../__fixtures__/workloadNodeData';
+import { BaseNode } from '@patternfly/react-topology';
+import TopologyResourcesTabPanel from './TopologyResourcesTabPanel';
+
+describe('TopologyResourcesTabPanel', () => {
+  it('Should render workload resources', () => {
+    const { queryByTestId } = render(
+      <TopologyResourcesTabPanel node={workloadNode as BaseNode} />,
+    );
+    expect(queryByTestId('resources-tab')).not.toBeNull();
+  });
+
+  it('Should show pods if available and empty state otherwise', () => {
+    const { queryByTestId, getByText, rerender } = render(
+      <TopologyResourcesTabPanel node={workloadNode as BaseNode} />,
+    );
+    expect(queryByTestId('pod-list')).not.toBeNull();
+    rerender(<TopologyResourcesTabPanel node={workloadNode2 as BaseNode} />);
+    getByText(/no pods found for this resource/i);
+  });
+
+  it('Should show services if available and empty state otherwise', () => {
+    const { queryByTestId, getByText, rerender } = render(
+      <TopologyResourcesTabPanel node={workloadNode as BaseNode} />,
+    );
+    expect(queryByTestId('service-list')).not.toBeNull();
+    rerender(<TopologyResourcesTabPanel node={workloadNode2 as BaseNode} />);
+    getByText(/no services found for this resource/i);
+  });
+
+  it('Should show ingresses if available and empty state otherwise', () => {
+    const { queryByTestId, getByText, rerender } = render(
+      <TopologyResourcesTabPanel node={workloadNode as BaseNode} />,
+    );
+    expect(queryByTestId('ingress-list')).not.toBeNull();
+    rerender(<TopologyResourcesTabPanel node={workloadNode2 as BaseNode} />);
+    getByText(/no ingresses found for this resource/i);
+  });
+});

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
@@ -1,31 +1,42 @@
-import { V1Pod, V1Service } from '@kubernetes/client-node';
+import * as React from 'react';
+import { V1Pod, V1Service, V1ServicePort } from '@kubernetes/client-node';
 import { LongArrowAltRightIcon } from '@patternfly/react-icons';
 import { BaseNode } from '@patternfly/react-topology';
-import * as React from 'react';
 import { IngressModel, PodModel, ServiceModel } from '../../../models';
+import { IngressData } from '../../../types/ingresses';
 import TopologyResourcesTabPanelItem from './TopologyResourcesTabPaneltem';
 
 const TopologyResourcesTabPanel: React.FC<{ node: BaseNode }> = ({ node }) => {
   const nodeData = node.getData()?.data;
   return (
-    <>
-      <TopologyResourcesTabPanelItem resourceLabel={PodModel.labelPlural}>
+    <div data-testid="resources-tab">
+      <TopologyResourcesTabPanelItem
+        resourceLabel={PodModel.labelPlural}
+        dataTest="pod-list"
+      >
         {nodeData?.podsData?.pods?.length &&
           nodeData.podsData.pods.map((pod: V1Pod) => (
-            <li className="item">
+            <li className="item" key={pod.metadata?.uid}>
               <span style={{ flex: '1' }}>{pod.metadata?.name}</span>
               <span style={{ flex: '1' }}>{pod.status?.phase}</span>
             </li>
           ))}
       </TopologyResourcesTabPanelItem>
-      <TopologyResourcesTabPanelItem resourceLabel={ServiceModel.labelPlural}>
+      <TopologyResourcesTabPanelItem
+        resourceLabel={ServiceModel.labelPlural}
+        dataTest="service-list"
+      >
         {nodeData?.services?.length &&
           nodeData.services.map((service: V1Service) => (
-            <li className="item" style={{ flexDirection: 'column' }}>
+            <li
+              className="item"
+              style={{ flexDirection: 'column' }}
+              key={service.metadata?.uid}
+            >
               <span>{service.metadata?.name}</span>
               <ul>
                 {(service.spec?.ports ?? []).map(
-                  ({ name, port, protocol, targetPort }: any) => (
+                  ({ name, port, protocol, targetPort }: V1ServicePort) => (
                     <li key={name || `${port}-${protocol}`}>
                       <span className="topology-text-muted">Service port:</span>{' '}
                       {name || `${port}-${protocol}`}
@@ -43,27 +54,34 @@ const TopologyResourcesTabPanel: React.FC<{ node: BaseNode }> = ({ node }) => {
             </li>
           ))}
       </TopologyResourcesTabPanelItem>
-      <TopologyResourcesTabPanelItem resourceLabel={IngressModel.labelPlural}>
+      <TopologyResourcesTabPanelItem
+        resourceLabel={IngressModel.labelPlural}
+        dataTest="ingress-list"
+      >
         {nodeData?.ingressesData?.length &&
-          nodeData.ingressesData.map((ingressData: any) => (
-            <li className="item" style={{ flexDirection: 'column' }}>
-              <span>{ingressData?.ingress?.metadata?.name}</span>
-              {ingressData?.url && (
+          nodeData.ingressesData.map((ingressData: IngressData) => (
+            <li
+              className="item"
+              style={{ flexDirection: 'column' }}
+              key={ingressData.ingress.metadata?.uid}
+            >
+              <span>{ingressData.ingress.metadata?.name}</span>
+              {ingressData.url && (
                 <>
                   <span className="topology-text-muted">Location:</span>
                   <a
-                    href={ingressData?.url}
+                    href={ingressData.url}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    {ingressData?.url}
+                    {ingressData.url}
                   </a>
                 </>
               )}
             </li>
           ))}
       </TopologyResourcesTabPanelItem>
-    </>
+    </div>
   );
 };
 

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
@@ -1,0 +1,70 @@
+import { V1Pod, V1Service } from '@kubernetes/client-node';
+import { LongArrowAltRightIcon } from '@patternfly/react-icons';
+import { BaseNode } from '@patternfly/react-topology';
+import * as React from 'react';
+import { IngressModel, PodModel, ServiceModel } from '../../../models';
+import TopologyResourcesTabPanelItem from './TopologyResourcesTabPaneltem';
+
+const TopologyResourcesTabPanel: React.FC<{ node: BaseNode }> = ({ node }) => {
+  const nodeData = node.getData()?.data;
+  return (
+    <>
+      <TopologyResourcesTabPanelItem resourceLabel={PodModel.labelPlural}>
+        {nodeData?.podsData?.pods?.length &&
+          nodeData.podsData.pods.map((pod: V1Pod) => (
+            <li className="item">
+              <span style={{ flex: '1' }}>{pod.metadata?.name}</span>
+              <span style={{ flex: '1' }}>{pod.status?.phase}</span>
+            </li>
+          ))}
+      </TopologyResourcesTabPanelItem>
+      <TopologyResourcesTabPanelItem resourceLabel={ServiceModel.labelPlural}>
+        {nodeData?.services?.length &&
+          nodeData.services.map((service: V1Service) => (
+            <li className="item" style={{ flexDirection: 'column' }}>
+              <span>{service.metadata?.name}</span>
+              <ul>
+                {(service.spec?.ports ?? []).map(
+                  ({ name, port, protocol, targetPort }: any) => (
+                    <li key={name || `${port}-${protocol}`}>
+                      <span className="topology-text-muted">Service port:</span>{' '}
+                      {name || `${port}-${protocol}`}
+                      &nbsp;
+                      <LongArrowAltRightIcon />
+                      &nbsp;
+                      <span className="topology-text-muted">
+                        Pod port:
+                      </span>{' '}
+                      {targetPort}
+                    </li>
+                  ),
+                )}
+              </ul>
+            </li>
+          ))}
+      </TopologyResourcesTabPanelItem>
+      <TopologyResourcesTabPanelItem resourceLabel={IngressModel.labelPlural}>
+        {nodeData?.ingressesData?.length &&
+          nodeData.ingressesData.map((ingressData: any) => (
+            <li className="item" style={{ flexDirection: 'column' }}>
+              <span>{ingressData?.ingress?.metadata?.name}</span>
+              {ingressData?.url && (
+                <>
+                  <span className="topology-text-muted">Location:</span>
+                  <a
+                    href={ingressData?.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {ingressData?.url}
+                  </a>
+                </>
+              )}
+            </li>
+          ))}
+      </TopologyResourcesTabPanelItem>
+    </>
+  );
+};
+
+export default TopologyResourcesTabPanel;

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanelItem.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanelItem.css
@@ -1,0 +1,23 @@
+.topology-resources-tab-item-title {
+  font-size: 18px;
+  font-weight: bold;
+  margin: 30px 0 10px;
+}
+
+.topology-resources-tab-item-list {
+  font-size: 14px;
+}
+
+.topology-resources-tab-item-list .item {
+  display: flex;
+  padding: 10px 15px;
+  margin-bottom: -1px;
+  background-color: var(--pf-global--BackgroundColor--100);
+  border: 1px solid var(--pf-global--BorderColor--100);
+}
+
+.topology-resources-tab-item-list .item a {
+  font-weight: var(--pf-global--link--FontWeight);
+  color: var(--pf-global--link--Color);
+  text-decoration: var(--pf-global--link--TextDecoration);
+}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPaneltem.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPaneltem.tsx
@@ -2,17 +2,17 @@ import * as React from 'react';
 
 import './TopologyResourcesTabPanelItem.css';
 
-const TopologyResourcesTabPanelItem: React.FC<{ resourceLabel: string }> = ({
-  resourceLabel,
-  children,
-}) => {
+const TopologyResourcesTabPanelItem: React.FC<{
+  resourceLabel: string;
+  dataTest?: string;
+}> = ({ resourceLabel, children, dataTest }) => {
   const emptyState = (
     <span className="topology-text-muted">{`No ${resourceLabel} found for this resource.`}</span>
   );
   return (
     <>
       <h2 className="topology-resources-tab-item-title">{resourceLabel}</h2>
-      <ul className="topology-resources-tab-item-list">
+      <ul className="topology-resources-tab-item-list" data-testid={dataTest}>
         {children ? children : emptyState}
       </ul>
     </>

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPaneltem.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPaneltem.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import './TopologyResourcesTabPanelItem.css';
+
+const TopologyResourcesTabPanelItem: React.FC<{ resourceLabel: string }> = ({
+  resourceLabel,
+  children,
+}) => {
+  const emptyState = (
+    <span className="topology-text-muted">{`No ${resourceLabel} found for this resource.`}</span>
+  );
+  return (
+    <>
+      <h2 className="topology-resources-tab-item-title">{resourceLabel}</h2>
+      <ul className="topology-resources-tab-item-list">
+        {children ? children : emptyState}
+      </ul>
+    </>
+  );
+};
+
+export default TopologyResourcesTabPanelItem;

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBar.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBar.css
@@ -1,0 +1,8 @@
+.pf-topology-resizable-side-bar {
+  flex: 1 1 0;
+}
+
+.pf-topology-side-bar__dismiss.pf-c-button {
+  position: relative !important;
+  float: right;
+}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBar.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBar.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import {
+  BaseNode,
+  TopologySideBar as PFTopologySideBar,
+} from '@patternfly/react-topology';
+import TopologySideBarContent from './TopologySideBarContent';
+
+type TopologySideBarProps = {
+  node: BaseNode;
+  onClose: () => void;
+};
+
+const TopologySideBar: React.FC<TopologySideBarProps> = ({ onClose, node }) => {
+  return (
+    <PFTopologySideBar
+      resizable
+      className="pf-topology-side-bar-resizable"
+      onClose={onClose}
+    >
+      <div className="pf-topology-side-bar__body">
+        <TopologySideBarContent node={node} />
+      </div>
+    </PFTopologySideBar>
+  );
+};
+
+export default TopologySideBar;

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBar.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBar.tsx
@@ -5,6 +5,8 @@ import {
 } from '@patternfly/react-topology';
 import TopologySideBarContent from './TopologySideBarContent';
 
+import './TopologySideBar.css';
+
 type TopologySideBarProps = {
   node: BaseNode;
   onClose: () => void;
@@ -12,11 +14,7 @@ type TopologySideBarProps = {
 
 const TopologySideBar: React.FC<TopologySideBarProps> = ({ onClose, node }) => {
   return (
-    <PFTopologySideBar
-      resizable
-      className="pf-topology-side-bar-resizable"
-      onClose={onClose}
-    >
+    <PFTopologySideBar resizable onClose={onClose}>
       <div className="pf-topology-side-bar__body">
         <TopologySideBarContent node={node} />
       </div>

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.css
@@ -2,6 +2,10 @@
   margin: 0 0 24px;
 }
 
+.topology-side-bar-tabs .tab-button {
+  background: transparent !important;
+}
+
 .topology-side-bar-tab-panel {
   padding: 0 20px;
 }

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.css
@@ -1,0 +1,7 @@
+.topology-side-bar-tabs {
+  margin: 0 0 24px;
+}
+
+.topology-side-bar-tab-panel {
+  padding: 0 20px;
+}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.tsx
@@ -34,8 +34,8 @@ const TopologySideBarBody: React.FC<{ node: BaseNode }> = ({ node }) => {
     <div>
       <div className="topology-side-bar-tabs">
         <Tabs value={value} onChange={handleChange} indicatorColor="primary">
-          <Tab label="Details" />
-          <Tab label="Resources" />
+          <Tab label="Details" className="tab-button" />
+          <Tab label="Resources" className="tab-button" />
         </Tabs>
         <Divider />
       </div>

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Tabs, Tab, Divider } from '@material-ui/core';
+import TopologyDetailsTabPanel from './TopologyDetailsTabPanel';
+import TopologyResourcesTabPanel from './TopologyResourcesTabPanel';
+import { BaseNode } from '@patternfly/react-topology';
+
+import './TopologySideBarBody.css';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+const TabPanel = (props: TabPanelProps) => {
+  const { children, value, index } = props;
+
+  return (
+    <div role="tabpanel" hidden={value !== index}>
+      {value === index && (
+        <div className="topology-side-bar-tab-panel">{children}</div>
+      )}
+    </div>
+  );
+};
+
+const TopologySideBarBody: React.FC<{ node: BaseNode }> = ({ node }) => {
+  const [value, setValue] = React.useState(0);
+  const handleChange = (_event: React.ChangeEvent<{}>, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+    <div>
+      <div className="topology-side-bar-tabs">
+        <Tabs value={value} onChange={handleChange} indicatorColor="primary">
+          <Tab label="Details" />
+          <Tab label="Resources" />
+        </Tabs>
+        <Divider />
+      </div>
+      <TabPanel value={value} index={0}>
+        <TopologyDetailsTabPanel node={node} />
+      </TabPanel>
+      <TabPanel value={value} index={1}>
+        <TopologyResourcesTabPanel node={node} />
+      </TabPanel>
+    </div>
+  );
+};
+
+export default TopologySideBarBody;

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarContent.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarContent.css
@@ -1,0 +1,3 @@
+.topology-side-bar-content {
+  padding-bottom: 30px;
+}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarContent.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarContent.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { Divider } from '@material-ui/core';
+import { BaseNode } from '@patternfly/react-topology';
+import TopologySideBarBody from './TopologySideBarBody';
+import TopologySideBarHeading from './TopologySideBarHeading';
+
+import './TopologySideBarContent.css';
+
+const TopologySideBarContent: React.FC<{ node: BaseNode }> = ({ node }) => {
+  return (
+    <div className="topology-side-bar-content">
+      <TopologySideBarHeading resource={node.getData().resource} />
+      <Divider />
+      <TopologySideBarBody node={node} />
+    </div>
+  );
+};
+
+export default TopologySideBarContent;

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarDetailsItem.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarDetailsItem.css
@@ -1,0 +1,16 @@
+.topology-side-bar-details-item {
+  margin-bottom: var(--pf-global--spacer--lg);
+}
+
+.topology-side-bar-details-item:last-child {
+  margin-bottom: 0;
+}
+
+.topology-side-bar-details-item dt {
+  font-weight: bold;
+  font-size: 14px;
+}
+
+.topology-side-bar-details-item dd {
+  font-size: 14px;
+}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarDetailsItem.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarDetailsItem.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import './TopologySideBarDetailsItem.css';
+
+const TopologySideBarDetailsItem: React.FC<{
+  label: string;
+}> = ({ label, children }) => {
+  return (
+    <div className="topology-side-bar-details-item">
+      <dt>{label}</dt>
+      <dd>{children}</dd>
+    </div>
+  );
+};
+
+export default TopologySideBarDetailsItem;

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarDetailsItem.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarDetailsItem.tsx
@@ -4,11 +4,23 @@ import './TopologySideBarDetailsItem.css';
 
 const TopologySideBarDetailsItem: React.FC<{
   label: string;
-}> = ({ label, children }) => {
+  emptyText?: string;
+}> = ({ label, children, emptyText }) => {
   return (
     <div className="topology-side-bar-details-item">
       <dt>{label}</dt>
-      <dd>{children}</dd>
+      <dd>
+        {children ? (
+          children
+        ) : (
+          <span
+            className="topology-text-muted"
+            data-testid="detail-item-empty-state"
+          >
+            {emptyText}
+          </span>
+        )}
+      </dd>
     </div>
   );
 };

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarHeading.css
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarHeading.css
@@ -1,0 +1,24 @@
+.topology-side-bar-heading {
+  padding: 30px 0 20px 24px;
+}
+
+.topology-side-bar-heading-label {
+  align-items: baseline;
+}
+
+.topology-side-bar-heading-label .badge {
+  font-size: 17px;
+  font-weight: bold;
+  border-radius: 20px;
+  color: var(--pf-global--palette--white);
+  display: inline-block;
+  flex-shrink: 0;
+  line-height: 16px;
+  margin-right: 4px;
+  min-width: 18px;
+  padding: 1px 4px;
+  text-align: center;
+  white-space: nowrap;
+  background-color: #004080;
+  width: 100%;
+}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarHeading.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarHeading.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Typography } from '@material-ui/core';
 import { Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
-import { models } from '../../../models';
+import { resourceModels } from '../../../models';
 import { K8sWorkloadResource } from '../../../types/types';
 
 import './TopologySideBarHeading.css';
@@ -15,9 +15,9 @@ const TopologySideBarHeading: React.FC<{ resource: K8sWorkloadResource }> = ({
     <Stack className="topology-side-bar-heading">
       <StackItem>
         <Split className="topology-side-bar-heading-label">
-          {models[resourceKind] && (
+          {resourceModels[resourceKind] && (
             <SplitItem style={{ marginRight: 'var(--pf-global--spacer--sm)' }}>
-              <span className="badge">{`${models[resourceKind].abbr}`}</span>
+              <span className="badge">{`${resourceModels[resourceKind].abbr}`}</span>
             </SplitItem>
           )}
           <SplitItem>
@@ -25,7 +25,7 @@ const TopologySideBarHeading: React.FC<{ resource: K8sWorkloadResource }> = ({
           </SplitItem>
         </Split>
       </StackItem>
-      {!models[resourceKind] && (
+      {!resourceModels[resourceKind] && (
         <StackItem>
           <Typography color="textSecondary" variant="body1">
             {resourceKind}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarHeading.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarHeading.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Typography } from '@material-ui/core';
+import { Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
+import { models } from '../../../models';
+import { K8sWorkloadResource } from '../../../types/types';
+
+import './TopologySideBarHeading.css';
+
+const TopologySideBarHeading: React.FC<{ resource: K8sWorkloadResource }> = ({
+  resource,
+}) => {
+  const resourceName = resource.metadata?.name;
+  const resourceKind = resource.kind ?? '';
+  return (
+    <Stack className="topology-side-bar-heading">
+      <StackItem>
+        <Split className="topology-side-bar-heading-label">
+          {models[resourceKind] && (
+            <SplitItem style={{ marginRight: 'var(--pf-global--spacer--sm)' }}>
+              <span className="badge">{`${models[resourceKind].abbr}`}</span>
+            </SplitItem>
+          )}
+          <SplitItem>
+            <Typography variant="h6">{resourceName}</Typography>
+          </SplitItem>
+        </Split>
+      </StackItem>
+      {!models[resourceKind] && (
+        <StackItem>
+          <Typography color="textSecondary" variant="body1">
+            {resourceKind}
+          </Typography>
+        </StackItem>
+      )}
+    </Stack>
+  );
+};
+
+export default TopologySideBarHeading;

--- a/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
+++ b/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
@@ -15,6 +15,7 @@ import TopologyToolbar from './TopologyToolbar';
 import { K8sResourcesContext } from '../../hooks/K8sResourcesContext';
 import TopologyErrorPanel from './TopologyErrorPanel';
 import { ClusterErrors } from '../../types/types';
+import { useSideBar } from '../../hooks/useSideBar';
 
 import './TopologyToolbar.css';
 
@@ -31,6 +32,7 @@ const TopologyViewWorkloadComponent: React.FC<
   const { loaded, dataModel } = useWorkloadsWatcher();
   const { clusters, selectedClusterErrors, responseError } =
     React.useContext(K8sResourcesContext);
+  const [sideBar, sideBarOpen] = useSideBar(selectedIds, controller);
 
   const allErrors: ClusterErrors = [
     ...(responseError ? [{ message: responseError }] : []),
@@ -78,6 +80,10 @@ const TopologyViewWorkloadComponent: React.FC<
             )
           }
           viewToolbar={useToolbar && <TopologyToolbar />}
+          sideBar={sideBar}
+          sideBarResizable
+          sideBarOpen={sideBarOpen}
+          minSideBarSize="400px"
         >
           {loaded && dataModel?.nodes?.length === 0 ? (
             <TopologyEmptyState />

--- a/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
+++ b/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  BaseNode,
   SelectionEventListener,
   SELECTION_EVENT,
   TopologyView,
@@ -16,6 +17,7 @@ import { K8sResourcesContext } from '../../hooks/K8sResourcesContext';
 import TopologyErrorPanel from './TopologyErrorPanel';
 import { ClusterErrors } from '../../types/types';
 import { useSideBar } from '../../hooks/useSideBar';
+import { TYPE_WORKLOAD } from '../../const';
 
 import './TopologyToolbar.css';
 
@@ -32,7 +34,8 @@ const TopologyViewWorkloadComponent: React.FC<
   const { loaded, dataModel } = useWorkloadsWatcher();
   const { clusters, selectedClusterErrors, responseError } =
     React.useContext(K8sResourcesContext);
-  const [sideBar, sideBarOpen] = useSideBar(selectedIds, controller);
+  const [sideBar, sideBarOpen, selectedId, setSideBarOpen, setSelectedNode] =
+    useSideBar(selectedIds);
 
   const allErrors: ClusterErrors = [
     ...(responseError ? [{ message: responseError }] : []),
@@ -52,6 +55,27 @@ const TopologyViewWorkloadComponent: React.FC<
       controller.fromModel(model, false);
     }
   }, [layout, loaded, dataModel, controller]);
+
+  React.useEffect(() => {
+    if (loaded && dataModel) {
+      const selectedNode: BaseNode | null = selectedId
+        ? (controller.getElementById(selectedId) as BaseNode)
+        : null;
+      setSelectedNode(selectedNode);
+      if (selectedNode && selectedNode.getType() === TYPE_WORKLOAD)
+        setSideBarOpen(true);
+      else {
+        setSideBarOpen(false);
+      }
+    }
+  }, [
+    controller,
+    dataModel,
+    loaded,
+    selectedId,
+    setSelectedNode,
+    setSideBarOpen,
+  ]);
 
   useEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
     setSelectedIds(ids);

--- a/plugins/topology/src/data-transforms/data-transformer.ts
+++ b/plugins/topology/src/data-transforms/data-transformer.ts
@@ -3,7 +3,9 @@ import { TYPE_APPLICATION_GROUP, TYPE_WORKLOAD } from '../const';
 import { K8sWorkloadResource, K8sResponseData } from '../types/types';
 import {
   createOverviewItemForType,
+  getIngressesDataForResourceServices,
   getIngressURLForResource,
+  getServicesForResource,
 } from '../utils/resource-utils';
 import {
   createTopologyNodeData,
@@ -18,6 +20,7 @@ import {
   WorkloadModelProps,
 } from '../utils/transform-utils';
 import { getPodsDataForResource } from '../utils/pod-resource-utils';
+import { V1Service } from '@kubernetes/client-node';
 
 export const getBaseTopologyDataModel = (resources: K8sResponseData): Model => {
   const baseDataModel: Model = {
@@ -42,6 +45,11 @@ export const getBaseTopologyDataModel = (resources: K8sResponseData): Model => {
             'default image',
             getIngressURLForResource(resources, resource),
             getPodsDataForResource(resource, resources),
+            getServicesForResource(
+              resource,
+              resources.services?.data as V1Service[],
+            ),
+            getIngressesDataForResourceServices(resources, resource),
           );
           typedDataModel.nodes?.push(
             getTopologyNodeItem(

--- a/plugins/topology/src/data-transforms/data-transformer.ts
+++ b/plugins/topology/src/data-transforms/data-transformer.ts
@@ -44,12 +44,17 @@ export const getBaseTopologyDataModel = (resources: K8sResponseData): Model => {
             TYPE_WORKLOAD,
             'default image',
             getIngressURLForResource(resources, resource),
-            getPodsDataForResource(resource, resources),
-            getServicesForResource(
-              resource,
-              resources.services?.data as V1Service[],
-            ),
-            getIngressesDataForResourceServices(resources, resource),
+            {
+              podsData: getPodsDataForResource(resource, resources),
+              services: getServicesForResource(
+                resource,
+                resources.services?.data as V1Service[],
+              ),
+              ingressesData: getIngressesDataForResourceServices(
+                resources,
+                resource,
+              ),
+            },
           );
           typedDataModel.nodes?.push(
             getTopologyNodeItem(

--- a/plugins/topology/src/hooks/useSideBar.tsx
+++ b/plugins/topology/src/hooks/useSideBar.tsx
@@ -1,14 +1,20 @@
 import * as React from 'react';
-import { BaseNode, Controller } from '@patternfly/react-topology';
+import { BaseNode } from '@patternfly/react-topology';
 import { TYPE_WORKLOAD } from '../const';
 import TopologySideBar from '../components/Topology/TopologySideBar/TopologySideBar';
 
 export const useSideBar = (
   selectedIds: string[],
-  controller: Controller,
-): [React.ReactNode, boolean] => {
+): [
+  React.ReactNode,
+  boolean,
+  string,
+  React.Dispatch<React.SetStateAction<boolean>>,
+  React.Dispatch<React.SetStateAction<BaseNode | null>>,
+] => {
   const { search } = window.location;
   const [sideBarOpen, setSideBarOpen] = React.useState<boolean>(false);
+  const [selectedNode, setSelectedNode] = React.useState<BaseNode | null>(null);
 
   const params = React.useMemo(() => new URLSearchParams(search), [search]);
 
@@ -31,19 +37,6 @@ export const useSideBar = (
     return '';
   }, [params, removeSelectedIdParam, selectedIds]);
 
-  const selectedNode: BaseNode | null = React.useMemo(() => {
-    if (selectedId) return controller.getElementById(selectedId) as BaseNode;
-    return null;
-  }, [controller, selectedId]);
-
-  React.useEffect(() => {
-    if (selectedNode && selectedNode.getType() === TYPE_WORKLOAD)
-      setSideBarOpen(true);
-    else {
-      setSideBarOpen(false);
-    }
-  }, [params, selectedNode]);
-
   const sideBar = selectedNode && selectedNode.getType() === TYPE_WORKLOAD && (
     <TopologySideBar
       onClose={() => {
@@ -54,5 +47,5 @@ export const useSideBar = (
     />
   );
 
-  return [sideBar, sideBarOpen];
+  return [sideBar, sideBarOpen, selectedId, setSideBarOpen, setSelectedNode];
 };

--- a/plugins/topology/src/hooks/useSideBar.tsx
+++ b/plugins/topology/src/hooks/useSideBar.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { BaseNode, Controller } from '@patternfly/react-topology';
+import { TYPE_WORKLOAD } from '../const';
+import TopologySideBar from '../components/Topology/TopologySideBar/TopologySideBar';
+
+export const useSideBar = (
+  selectedIds: string[],
+  controller: Controller,
+): [React.ReactNode, boolean] => {
+  const { search } = window.location;
+  const [sideBarOpen, setSideBarOpen] = React.useState<boolean>(false);
+
+  const params = React.useMemo(() => new URLSearchParams(search), [search]);
+
+  const removeSelectedIdParam = React.useCallback(() => {
+    params.delete('selectedId');
+    const url = new URL(window.location.href);
+    history.replaceState(
+      null,
+      '',
+      `${url.pathname}${params.toString()}${url.hash}`,
+    );
+  }, [params]);
+
+  const selectedId = React.useMemo((): string => {
+    const id = params.get('selectedId') ?? '';
+    if (selectedIds?.length && selectedIds.includes(id)) {
+      return id;
+    }
+    removeSelectedIdParam();
+    return '';
+  }, [params, removeSelectedIdParam, selectedIds]);
+
+  const selectedNode: BaseNode | null = React.useMemo(() => {
+    if (selectedId) return controller.getElementById(selectedId) as BaseNode;
+    return null;
+  }, [controller, selectedId]);
+
+  React.useEffect(() => {
+    if (selectedNode && selectedNode.getType() === TYPE_WORKLOAD)
+      setSideBarOpen(true);
+    else {
+      setSideBarOpen(false);
+    }
+  }, [params, selectedNode]);
+
+  const sideBar = selectedNode && selectedNode.getType() === TYPE_WORKLOAD && (
+    <TopologySideBar
+      onClose={() => {
+        setSideBarOpen(false);
+        removeSelectedIdParam();
+      }}
+      node={selectedNode}
+    />
+  );
+
+  return [sideBar, sideBarOpen];
+};

--- a/plugins/topology/src/models.ts
+++ b/plugins/topology/src/models.ts
@@ -63,7 +63,7 @@ export enum ModelsPlural {
   statefulsets = 'statefulsets',
 }
 
-export const resourceModels: { [key: string]: GroupVersionKind } = {
+export const resourceGVKs: { [key: string]: GroupVersionKind } = {
   [ModelsPlural.deployments]: DeploymentGVK,
   [ModelsPlural.pods]: PodGVK,
   [ModelsPlural.replicasets]: ReplicaSetGVK,
@@ -77,56 +77,59 @@ export const resourceModels: { [key: string]: GroupVersionKind } = {
 
 export const DeploymentModel = {
   ...DeploymentGVK,
-  label: 'Deployment',
-  labelKey: 'Deployment',
-  plural: 'deployments',
   abbr: 'D',
-  namespaced: true,
-  propagationPolicy: 'Foreground',
-  id: 'deployment',
   labelPlural: 'Deployments',
-  labelPluralKey: 'Deployments',
 };
 
 export const PodModel = {
   ...PodGVK,
-  label: 'Pod',
-  labelKey: 'Pod',
-  plural: 'pods',
   abbr: 'P',
-  namespaced: true,
-  id: 'pod',
   labelPlural: 'Pods',
-  labelPluralKey: 'Pods',
 };
 
 export const ServiceModel = {
   ...ServiceGVK,
-  label: 'Service',
-  labelKey: 'Service',
-  plural: 'services',
   abbr: 'S',
-  namespaced: true,
-  id: 'service',
   labelPlural: 'Services',
-  labelPluralKey: 'Services',
 };
 
 export const IngressModel = {
   ...IngressesGVK,
-  label: 'Ingress',
-  labelKey: 'Ingress',
   labelPlural: 'Ingresses',
-  labelPluralKey: 'Ingresses',
-  plural: 'ingresses',
   abbr: 'I',
-  namespaced: true,
-  id: 'ingress',
 };
 
-export const models = {
+export const DaemonSetModel = {
+  ...DaemonSetGVK,
+  abbr: 'DS',
+  labelPlural: 'DaemonSets',
+};
+
+export const StatefulSetModel = {
+  ...StatefulSetGVK,
+  abbr: 'SS',
+  labelPlural: 'StatefulSets',
+};
+
+export const CronJobModel = {
+  ...CronJobGVK,
+  abbr: 'CJ',
+  labelPlural: 'CronJobs',
+};
+
+export const JobModel = {
+  ...JobGVK,
+  abbr: 'J',
+  labelPlural: 'Jobs',
+};
+
+export const resourceModels = {
   [DeploymentModel.kind]: DeploymentModel,
   [PodModel.kind]: PodModel,
   [ServiceModel.kind]: ServiceModel,
   [IngressModel.kind]: IngressModel,
+  [StatefulSetModel.kind]: StatefulSetModel,
+  [DaemonSetModel.kind]: DaemonSetModel,
+  [CronJobModel.kind]: CronJobModel,
+  [JobModel.kind]: JobModel,
 };

--- a/plugins/topology/src/models.ts
+++ b/plugins/topology/src/models.ts
@@ -74,3 +74,59 @@ export const resourceModels: { [key: string]: GroupVersionKind } = {
   [ModelsPlural.jobs]: JobGVK,
   [ModelsPlural.statefulsets]: StatefulSetGVK,
 };
+
+export const DeploymentModel = {
+  ...DeploymentGVK,
+  label: 'Deployment',
+  labelKey: 'Deployment',
+  plural: 'deployments',
+  abbr: 'D',
+  namespaced: true,
+  propagationPolicy: 'Foreground',
+  id: 'deployment',
+  labelPlural: 'Deployments',
+  labelPluralKey: 'Deployments',
+};
+
+export const PodModel = {
+  ...PodGVK,
+  label: 'Pod',
+  labelKey: 'Pod',
+  plural: 'pods',
+  abbr: 'P',
+  namespaced: true,
+  id: 'pod',
+  labelPlural: 'Pods',
+  labelPluralKey: 'Pods',
+};
+
+export const ServiceModel = {
+  ...ServiceGVK,
+  label: 'Service',
+  labelKey: 'Service',
+  plural: 'services',
+  abbr: 'S',
+  namespaced: true,
+  id: 'service',
+  labelPlural: 'Services',
+  labelPluralKey: 'Services',
+};
+
+export const IngressModel = {
+  ...IngressesGVK,
+  label: 'Ingress',
+  labelKey: 'Ingress',
+  labelPlural: 'Ingresses',
+  labelPluralKey: 'Ingresses',
+  plural: 'ingresses',
+  abbr: 'I',
+  namespaced: true,
+  id: 'ingress',
+};
+
+export const models = {
+  [DeploymentModel.kind]: DeploymentModel,
+  [PodModel.kind]: PodModel,
+  [ServiceModel.kind]: ServiceModel,
+  [IngressModel.kind]: IngressModel,
+};

--- a/plugins/topology/src/types/ingresses.ts
+++ b/plugins/topology/src/types/ingresses.ts
@@ -1,0 +1,8 @@
+import { V1Ingress } from '@kubernetes/client-node';
+
+export type IngressData = {
+  ingress: V1Ingress;
+  url?: string;
+};
+
+export type IngressesData = IngressData[];

--- a/plugins/topology/src/utils/resource-utils.test.ts
+++ b/plugins/topology/src/utils/resource-utils.test.ts
@@ -26,7 +26,7 @@ describe('ResourceUtils:: ingress', () => {
   it('should return no ingresses for associated service name for no match', () => {
     const ingressesData = getIngressesDataForResourceServices(
       mockK8sResourcesData.watchResourcesData as any,
-      mockKubernetesResponse.deployments[1] as any,
+      mockKubernetesResponse.deployments[2] as any,
     );
     expect(ingressesData).toEqual([]);
   });

--- a/plugins/topology/src/utils/resource-utils.test.ts
+++ b/plugins/topology/src/utils/resource-utils.test.ts
@@ -3,7 +3,7 @@ import {
   mockKubernetesResponse,
 } from '../__fixtures__/1-deployments';
 import {
-  getIngressesRulesForServices,
+  getIngressesDataForResourceServices,
   getIngressURLForResource,
   getIngressWebURL,
   getServicesForResource,
@@ -11,69 +11,24 @@ import {
 
 describe('ResourceUtils:: ingress', () => {
   it('should return ingresses for associated service names', () => {
-    const mockIngressData = [
-      {
-        ...mockKubernetesResponse.ingresses[0],
-        spec: {
-          ...mockKubernetesResponse.ingresses[0].spec,
-          rules: [
-            ...mockKubernetesResponse.ingresses[0].spec.rules,
-            {
-              host: 'hello-world-app.info',
-              http: {
-                paths: [
-                  {
-                    path: '/',
-                    pathType: 'Prefix',
-                    backend: {
-                      service: {
-                        name: 'hello-world-new',
-                        port: {
-                          number: 8080,
-                        },
-                      },
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        },
-      },
-      {
-        apiVersion: 'networking.k8s.io/v1',
-        kind: 'Ingress',
-        metadata: {
-          name: 'ingress-resource-backend',
-        },
-        spec: {
-          defaultBackend: {
-            resource: {
-              apiGroup: 'k8s.example.com',
-              kind: 'StorageBucket',
-              name: 'static-assets',
-            },
-          },
-        },
-      },
-    ];
-
-    const ingressesRulesData = getIngressesRulesForServices(
-      ['hello-world', 'hello-app'],
-      mockIngressData as any,
+    const ingressesData = getIngressesDataForResourceServices(
+      mockK8sResourcesData.watchResourcesData as any,
+      mockKubernetesResponse.deployments[0] as any,
     );
-    expect(ingressesRulesData).toHaveLength(1);
-    expect(ingressesRulesData).toEqual([
-      { schema: 'http', rules: mockKubernetesResponse.ingresses[0].spec.rules },
+    expect(ingressesData).toEqual([
+      {
+        ingress: mockKubernetesResponse.ingresses[0],
+        url: 'http://hello-world-app.info/',
+      },
     ]);
   });
 
   it('should return no ingresses for associated service name for no match', () => {
-    const ingressesRulesData = getIngressesRulesForServices(
-      ['hello-world-123'],
-      mockKubernetesResponse.ingresses as any,
+    const ingressesData = getIngressesDataForResourceServices(
+      mockK8sResourcesData.watchResourcesData as any,
+      mockKubernetesResponse.deployments[1] as any,
     );
-    expect(ingressesRulesData).toEqual([]);
+    expect(ingressesData).toEqual([]);
   });
 
   it('should return services for associated resource', () => {
@@ -82,7 +37,7 @@ describe('ResourceUtils:: ingress', () => {
       mockKubernetesResponse.services as any,
     );
     expect(servicesData).toHaveLength(1);
-    expect(servicesData).toEqual(mockKubernetesResponse.services);
+    expect(servicesData).toEqual([mockKubernetesResponse.services[0]]);
   });
 
   it('should not return services for associated resource if no services exits', () => {
@@ -127,7 +82,7 @@ describe('ResourceUtils:: ingress', () => {
       rules: [],
     };
     const ingressData = getIngressWebURL(mockIngressRule as any);
-    expect(ingressData).toBeNull();
+    expect(ingressData).toBeUndefined();
   });
 
   it('should not return URL for provided ingress if host has wildcards', () => {
@@ -141,7 +96,7 @@ describe('ResourceUtils:: ingress', () => {
       ],
     };
     const ingressData = getIngressWebURL(mockIngressRule as any);
-    expect(ingressData).toBeNull();
+    expect(ingressData).toBeUndefined();
   });
 
   it('should return URL for provided ingress with https', () => {
@@ -156,7 +111,7 @@ describe('ResourceUtils:: ingress', () => {
 
   it('should not return URL for provided ingress if does not exists', () => {
     const ingressData = getIngressWebURL({} as any);
-    expect(ingressData).toBeNull();
+    expect(ingressData).toBeUndefined();
   });
 
   it('should return URL for provided resource', () => {

--- a/plugins/topology/src/utils/resource-utils.ts
+++ b/plugins/topology/src/utils/resource-utils.ts
@@ -17,6 +17,7 @@ import {
 } from '../types/types';
 import { WORKLOAD_TYPES } from './topology-utils';
 import { LabelSelector } from './label-selector';
+import { IngressesData } from '../types/ingresses';
 
 const validPod = (pod: V1Pod) => {
   const owners = pod?.metadata?.ownerReferences;
@@ -123,7 +124,7 @@ const validUrl = (url?: string | null) =>
 export const getIngressesDataForResourceServices = (
   resources: K8sResponseData,
   resource: K8sWorkloadResource,
-) => {
+): IngressesData => {
   const services = getServicesForResource(
     resource,
     resources.services?.data as V1Service[],
@@ -132,7 +133,7 @@ export const getIngressesDataForResourceServices = (
 
   const ingressesData = (
     (resources.ingresses?.data as V1Ingress[]) ?? []
-  ).reduce((acc, ingress) => {
+  ).reduce((acc: IngressesData, ingress: V1Ingress) => {
     const rules = ingress.spec?.rules?.filter(rule => {
       return rule.http?.paths?.some(path => {
         return (
@@ -152,7 +153,7 @@ export const getIngressesDataForResourceServices = (
       });
     }
     return acc;
-  }, [] as { ingress: V1Ingress; url: string | undefined }[]);
+  }, []);
 
   return ingressesData;
 };

--- a/plugins/topology/src/utils/topology-utils.ts
+++ b/plugins/topology/src/utils/topology-utils.ts
@@ -1,7 +1,8 @@
 import { ObjectsByEntityResponse } from '@backstage/plugin-kubernetes-common';
 import { V1Service } from '@kubernetes/client-node';
 import { INSTANCE_LABEL } from '../const';
-import { ModelsPlural, resourceModels } from '../models';
+import { ModelsPlural, resourceGVKs } from '../models';
+import { IngressesData } from '../types/ingresses';
 import { PodRCData } from '../types/pods';
 import { OverviewItem, TopologyDataObject } from '../types/topology-types';
 import {
@@ -20,13 +21,13 @@ export const WORKLOAD_TYPES: string[] = [
 ];
 
 const apiVersionForWorkloadType = (type: string) => {
-  return resourceModels[type]?.apiGroup
-    ? `${resourceModels[type].apiGroup}/${resourceModels[type].apiVersion}`
-    : resourceModels[type]?.apiVersion;
+  return resourceGVKs[type]?.apiGroup
+    ? `${resourceGVKs[type].apiGroup}/${resourceGVKs[type].apiVersion}`
+    : resourceGVKs[type]?.apiVersion;
 };
 
 const workloadKind = (type: string) => {
-  return resourceModels[type].kind;
+  return resourceGVKs[type].kind;
 };
 
 export const getClusters = (k8sObjects: ObjectsByEntityResponse) => {
@@ -48,7 +49,7 @@ export const getK8sResources = (
       ...acc,
       [res.type]: {
         data:
-          (resourceModels[res.type] &&
+          (resourceGVKs[res.type] &&
             res.resources.map((rval: K8sWorkloadResource) => ({
               ...rval,
               kind: workloadKind(res.type),
@@ -69,9 +70,11 @@ export const createTopologyNodeData = (
   type: string,
   defaultIcon: string,
   url?: string | null,
-  podsData?: PodRCData,
-  services?: V1Service[],
-  ingressesData?: any,
+  resourcesData?: {
+    podsData?: PodRCData;
+    services?: V1Service[];
+    ingressesData?: IngressesData;
+  },
 ): TopologyDataObject => {
   const dcUID = resource.metadata?.uid;
   const deploymentsLabels = resource.metadata?.labels ?? {};
@@ -88,9 +91,7 @@ export const createTopologyNodeData = (
       kind: resource?.kind,
       builderImage: defaultIcon,
       url,
-      podsData,
-      services,
-      ingressesData,
+      ...resourcesData,
     },
   };
 };

--- a/plugins/topology/src/utils/topology-utils.ts
+++ b/plugins/topology/src/utils/topology-utils.ts
@@ -1,4 +1,5 @@
 import { ObjectsByEntityResponse } from '@backstage/plugin-kubernetes-common';
+import { V1Service } from '@kubernetes/client-node';
 import { INSTANCE_LABEL } from '../const';
 import { ModelsPlural, resourceModels } from '../models';
 import { PodRCData } from '../types/pods';
@@ -69,6 +70,8 @@ export const createTopologyNodeData = (
   defaultIcon: string,
   url?: string | null,
   podsData?: PodRCData,
+  services?: V1Service[],
+  ingressesData?: any,
 ): TopologyDataObject => {
   const dcUID = resource.metadata?.uid;
   const deploymentsLabels = resource.metadata?.labels ?? {};
@@ -86,6 +89,8 @@ export const createTopologyNodeData = (
       builderImage: defaultIcon,
       url,
       podsData,
+      services,
+      ingressesData,
     },
   };
 };

--- a/plugins/topology/src/utils/workload-node-utils.ts
+++ b/plugins/topology/src/utils/workload-node-utils.ts
@@ -9,7 +9,7 @@ import {
   DeploymentStrategy,
   podColor,
 } from '../components/Pods/pod';
-import { resourceModels } from '../models';
+import { resourceGVKs } from '../models';
 import { PodControllerOverviewItem, PodRCData } from '../types/pods';
 import { ResKindAbbrColor } from '../types/topology-types';
 import { GroupVersionKind, K8sWorkloadResource } from '../types/types';
@@ -207,7 +207,7 @@ const kindToAbbr = (kind: string): string =>
   (kind.replace(/[^A-Z]/g, '') || kind.toUpperCase()).slice(0, 4);
 
 const getAssociatedModel = (kind: string): GroupVersionKind | undefined => {
-  const resourcesModelsList = Object.values(resourceModels);
+  const resourcesModelsList = Object.values(resourceGVKs);
   return resourcesModelsList.find(resModel => resModel.kind === kind);
 };
 


### PR DESCRIPTION
**Story:**  https://github.com/janus-idp/backstage-plugins/issues/122

This PR adds a topology workload node sidebar. The sidebar consists of two tabs Details and Resources.
Details tab shows the details of the workloads such as pods status, name, namespace etc. Resources tab shows the resources connected to it such as pods, services , ingresses. Currently the details panel shows specific details for deployments only as other workloads are not yet supported. Once other workloads are added the sidebar will work for these as well but will show common details only and for showing specific details sidebar will need to be updated.


Light Theme

https://user-images.githubusercontent.com/20724543/230070180-992aa7c8-4012-4fb0-a81e-1d5f1875c455.mov

Dark Theme

https://user-images.githubusercontent.com/20724543/230070215-0c9b1252-87c3-4e8a-b653-777737e63b75.mov
