### PR TITLE
fix(ocm-backend): Reference the correct config during url validation and add tests

### DIFF
--- a/plugins/ocm-backend/src/helpers/config.ts
+++ b/plugins/ocm-backend/src/helpers/config.ts
@@ -71,7 +71,7 @@ export const getHubClusterFromConfig = (
     ? getHubClusterFromKubernetesConfig(id, config, globalConfig)
     : getHubClusterFromOcmConfig(id, config);
 
-  const url = config.getString('url');
+  const url = hub.getString('url');
   if (!isValidUrl(url)) {
     throw new Error(`"${url}" is not a valid url`);
   }


### PR DESCRIPTION
A previous PR added `url` validation however it doesn't work when the k8s ref config is used since it was trying to use the wrong config to get the `url`. This PR should fix this bug.

Also add tests for verify that the `url` validation works correctly now.