### PR TITLE
feat(quay-actions): create action to create quay repository

### DIFF
--- a/plugins/quay-actions/.eslintrc.js
+++ b/plugins/quay-actions/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/quay-actions/README.md
+++ b/plugins/quay-actions/README.md
@@ -1,0 +1,127 @@
+# Quay actions for Backstage
+
+This module provides [Backstage](https://backstage.io/) template [actions](https://backstage.io/docs/features/software-templates/builtin-actions) for [Quay](https://docs.quay.io/).
+
+The following actions are currently supported in this module:
+
+- Create a Quay repository
+
+## Getting started
+
+1. Install the action package in your Backstage project
+
+   ```bash
+   yarn workspace backend add @janus-idp/backstage-scaffolder-backend-module-quay
+   ```
+
+2. [Register](https://backstage.io/docs/features/software-templates/writing-custom-actions#registering-custom-actions) the Quay actions by modifying the `packages/backend/src/plugins/scaffolder.ts` file from your project with the following changes:
+
+   ```ts
+   import { CatalogClient } from '@backstage/catalog-client';
+   import {
+     createBuiltinActions,
+     createRouter,
+   } from '@backstage/plugin-scaffolder-backend';
+   import { ScmIntegrations } from '@backstage/integration';
+   import { Router } from 'express';
+   import type { PluginEnvironment } from '../types';
+   import { createQuayRepositoryAction } from '@janus-idp/backstage-scaffolder-backend-module-quay';
+
+   export default async function createPlugin(
+     env: PluginEnvironment,
+   ): Promise<Router> {
+     const catalogClient = new CatalogClient({
+       discoveryApi: env.discovery,
+     });
+
+     const integrations = ScmIntegrations.fromConfig(env.config);
+
+     const builtInActions = createBuiltinActions({
+       integrations,
+       catalogClient,
+       config: env.config,
+       reader: env.reader,
+     });
+
+     const actions = [...builtInActions, createQuayRepositoryAction()];
+
+     return await createRouter({
+       actions,
+       logger: env.logger,
+       config: env.config,
+       database: env.database,
+       reader: env.reader,
+       catalogClient,
+       identity: env.identity,
+     });
+   }
+   ```
+
+3. **Optional**: If you are doing the previous step for the first time, you also have to install the `@backstage/integration` package
+
+   ```bash
+   yarn workspace backend add @backstage/integration
+   ```
+
+4. Add the Quay actions to your templates, see the [example](./examples/templates/01-quay-template.yaml) file in this repository for complete usage examples
+
+   ```yaml
+   action: quay:create-repository
+   id: create-quay-repo
+   name: Create quay repo
+   input:
+     baseUrl: https://quay.io
+     token: UW1dLVdCTj8uZWNuIW97K1k0XiBkSmppVU9MYzFT
+     name: foo
+     visibility: public
+     description: This is a foo repository
+     namespace: bar
+     repoKind: image
+   ```
+
+## Usage
+
+### Action: quay:create-repository
+
+#### Input
+
+| Parameter Name |  Type  | Required | Description                                                                       | Example                                  |
+| -------------- | :----: | :------: | --------------------------------------------------------------------------------- | ---------------------------------------- |
+| name           | string |   Yes    | Quay repository name                                                              | foo                                      |
+| visibility     | string |   Yes    | Visibility setting for the created repository, either public or private           | public                                   |
+| description    | string |   Yes    | Description for the created repository                                            | This if foo repository                   |
+| token          | string |   Yes    | Authentication token, see [docs](https://docs.quay.io/api/)                       | UW1dLVdCTj8uZWNuIW97K1k0XiBkSmppVU9MYzFT |
+| baseUrl        | string |    No    | Base url of a quay instance, defaults to <https://quay.io>                        | <https://foo.quay.io>                    |
+| namespace      | string |    No    | Namespace to create repository in, defaults to the namespace the token belongs to | bar                                      |
+| repoKind       | string |    No    | Created repository kind, either image or application, if empty defaults to image  | image                                    |
+
+#### Output
+
+| Name          |  Type  | Description                                |
+| ------------- | :----: | ------------------------------------------ |
+| repositoryUrl | string | Quay repository URL created by this action |
+
+## Development
+
+1. Add the local package dependency to the Backstage instance
+
+   ```shell
+   yarn workspace backend add file:./plugins/quay-actions
+   ```
+
+2. [Register](#getting-started) the Quay actions in your Backstage project
+3. **Optional**: You can use the sample template from this repository and add it as `locations` in your `app-config.yaml` file
+
+   ```yaml
+   ---
+   catalog:
+     locations:
+       - type: file
+         target: ../../plugins/quay-actions/examples/templates/01-quay-template.yaml
+         rules:
+           - allow: [Template]
+   ```
+
+4. Run `yarn dev`
+5. If you don't have a Quay account created yet you can create one for free on the [quay](https://quay.io) website
+6. Start using the Quay actions in your templates

--- a/plugins/quay-actions/examples/templates/01-quay-template.yaml
+++ b/plugins/quay-actions/examples/templates/01-quay-template.yaml
@@ -1,0 +1,64 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-quay-repo
+  title: Create a Quay repository
+  description: Create a Quay repository
+
+spec:
+  type: service
+  parameters:
+    - title: Repository information
+      required: ['name', 'visibility', 'description', 'token']
+      properties:
+        name:
+          title: Repository name
+          type: string
+          description: Name of the repository to be created
+        token:
+          title: Token
+          type: string
+          description: Bearer token used for authorization
+          ui:widget: password
+        visibility:
+          title: Visiblity
+          type: string
+          description: Visibility setting for the created repository, either public or private
+          ui:widget: select
+          enum: ['public', 'private']
+        repoKind:
+          title: Repository kind
+          type: string
+          description: The created repository kind either image, application or none
+          ui:widget: select
+          enum: ['image', 'application']
+        description:
+          title: Description
+          type: string
+          description: The repository desription
+        namespace:
+          title: Namespace
+          type: string
+          description: The users namespace is used by default
+        baseUrl:
+          title: Base URL
+          type: string
+          description: URL of your quay instance, set to "https://quay.io" by default
+
+  steps:
+    - id: create-quay-repo
+      name: Create quay repo
+      action: quay:create-repository
+      input:
+        baseUrl: ${{ parameters.baseUrl }}
+        token: ${{ parameters.token }}
+        name: ${{ parameters.name }}
+        visibility: ${{ parameters.visibility }}
+        description: ${{ parameters.description }}
+        namespace: ${{ parameters.namespace }}
+        repoKind: ${{ parameters.repoKind }}
+
+  output:
+    links:
+      - title: Quay repository link
+        url: ${{ steps['create-quay-repo'].output.repositoryUrl }}

--- a/plugins/quay-actions/package.json
+++ b/plugins/quay-actions/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@janus-idp/backstage-scaffolder-backend-module-quay",
+  "description": "The quay-actions module for @backstage/plugin-scaffolder-backend",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin-module"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/plugin-scaffolder-node": "^0.1.1"
+  },
+  "devDependencies": {
+    "@backstage/backend-common": "^0.18.0",
+    "@backstage/cli": "^0.22.1"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/quay-actions/src/actions/createQuayRepository.test.ts
+++ b/plugins/quay-actions/src/actions/createQuayRepository.test.ts
@@ -1,0 +1,173 @@
+import os from 'os';
+import {
+  ResponseBody,
+  ResponseErrorBody,
+  createQuayRepositoryAction,
+} from './createQuayRepository';
+import { getVoidLogger } from '@backstage/backend-common';
+import { PassThrough } from 'stream';
+
+describe('quay:create-repository', () => {
+  const action = createQuayRepositoryAction();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const mockContext = {
+    workspacePath: os.tmpdir(),
+    logger: getVoidLogger(),
+    logStream: new PassThrough(),
+    output: jest.fn(),
+    createTemporaryDirectory: jest.fn(),
+  };
+
+  it('should create a quay repository', async () => {
+    const body: ResponseBody = {
+      name: 'foo',
+      kind: 'image',
+      namespace: 'bar',
+    };
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(new Blob([JSON.stringify(body)]), {
+          status: 200,
+        }),
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        baseUrl: 'http://localhost:9090',
+        token: 'TOKEN',
+        name: 'foo',
+        visibility: 'public',
+        description: 'bar',
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'repositoryUrl',
+      'http://localhost:9090/repository/bar/foo',
+    );
+  });
+
+  it("should use the default url if it isn't provider", async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(new Blob(['{}']), {
+          status: 200,
+        }),
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        token: 'TOKEN',
+        name: 'foo',
+        visibility: 'public',
+        description: 'bar',
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://quay.io/api/v1/repository',
+      {
+        body: '{"description":"bar","repository":"foo","visibility":"public"}',
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Bearer TOKEN',
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      },
+    );
+  });
+
+  it('should handle and format errors correctly', async () => {
+    const body: ResponseErrorBody = {
+      detail: 'Repository already exists',
+      error_message: 'Repository already exists',
+      error_type: 'invalid_request',
+      status: 400,
+      title: 'invalid_request',
+      type: 'https://quay.io/api/v1/error/invalid_request',
+    };
+
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(new Blob([JSON.stringify(body)]), {
+          status: 400,
+        }),
+      ),
+    );
+
+    await expect(async () => {
+      await action.handler({
+        ...mockContext,
+        input: {
+          baseUrl: 'http://localhost:9090',
+          token: 'TOKEN',
+          name: 'foo',
+          visibility: 'public',
+          description: 'bar',
+        },
+      });
+    }).rejects.toThrow(
+      'Failed to create Quay repository, 400 -- Repository already exists',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      input: {
+        baseUrl: 'baz',
+        token: 'TOKEN',
+        name: 'foo',
+        visibility: 'public',
+        description: 'bar',
+      },
+      error: '"baseUrl" is invalid',
+      name: 'url',
+    },
+    {
+      input: {
+        baseUrl: 'http://example.com',
+        token: 'TOKEN',
+        name: 'foo',
+        visibility: 'baz',
+        description: 'bar',
+      },
+      error:
+        'For the "visibility" parameter "baz" is not a valid option, available options are: public, private',
+      name: 'visibility',
+    },
+    {
+      input: {
+        baseUrl: 'http://example.com',
+        token: 'TOKEN',
+        name: 'foo',
+        visibility: 'public',
+        description: 'bar',
+        repoKind: 'baz',
+      },
+      error:
+        'For the "repository kind" parameter "baz" is not a valid option, available options are: application, image, none',
+      name: 'repoKind',
+    },
+  ])(
+    'should throw an error on invalid $name input',
+    async ({ input, error }) => {
+      await expect(async () => {
+        await action.handler({
+          ...mockContext,
+          input,
+        });
+      }).rejects.toThrow(error);
+    },
+  );
+});

--- a/plugins/quay-actions/src/actions/createQuayRepository.ts
+++ b/plugins/quay-actions/src/actions/createQuayRepository.ts
@@ -1,0 +1,169 @@
+import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+
+export interface ResponseBody {
+  namespace: string;
+  name: string;
+  kind: string;
+}
+export interface ResponseErrorBody {
+  detail: string;
+  error_message: string;
+  error_type: string;
+  title: string;
+  type: string;
+  status: number;
+}
+interface RequestBody {
+  repository: string;
+  visibility: string;
+  namespace?: string;
+  description: string;
+  repo_kind?: string;
+}
+
+type TemplateActionParameters = {
+  name: string;
+  visibility: string;
+  description: string;
+  token: string;
+  baseUrl?: string;
+  namespace?: string;
+  repoKind?: string;
+};
+
+const getUrl = (url: string | undefined): string => {
+  if (!url) {
+    return 'https://quay.io';
+  }
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url);
+  } catch (error) {
+    throw new Error('"baseUrl" is invalid');
+  }
+  return url;
+};
+
+const isValueValid = (
+  value: string | undefined,
+  valueName: string,
+  valueOpts: Array<string | undefined>,
+) => {
+  if (valueOpts.includes(value)) {
+    return;
+  }
+  throw new Error(
+    `For the "${valueName}" parameter "${value}" is not a valid option,` +
+      ` available options are: ${valueOpts.map(v => v || 'none').join(', ')}`,
+  );
+};
+
+export function createQuayRepositoryAction() {
+  return createTemplateAction<TemplateActionParameters>({
+    id: 'quay:create-repository',
+    description: 'Create an quay image repository',
+    schema: {
+      input: {
+        type: 'object',
+        required: ['name', 'visibility', 'description', 'token'],
+        properties: {
+          name: {
+            title: 'Repository name',
+            description: 'Name of the repository to be created',
+            type: 'string',
+          },
+          visibility: {
+            title: 'Visibility setting',
+            description:
+              'Visibility setting for the created repository, either public or private',
+            type: 'string',
+          },
+          description: {
+            title: 'Repository description',
+            description: 'The repository desription',
+            type: 'string',
+          },
+          token: {
+            title: 'Token',
+            description: 'Bearer token used for authorization',
+            type: 'string',
+          },
+          baseUrl: {
+            title: 'Base URL',
+            description:
+              'URL of your quay instance, set to "https://quay.io" by default',
+            type: 'string',
+          },
+          namespace: {
+            title: 'Namespace',
+            description:
+              'Namespace in which to create the repository, by default the users namespace',
+            type: 'string',
+          },
+          repoKind: {
+            title: 'Repository kind',
+            description:
+              'The crated repository type either image or an application, if empty image will be used',
+            type: 'string',
+          },
+        },
+      },
+      output: {
+        type: 'object',
+        properties: {
+          repositoryUrl: {
+            title: 'Quay image repository URL',
+            type: 'string',
+            description: 'Created repository URL link',
+          },
+        },
+      },
+    },
+    async handler(ctx) {
+      const { token, name, visibility, namespace, description, repoKind } =
+        ctx.input;
+      const baseUrl = getUrl(ctx.input.baseUrl);
+      isValueValid(visibility, 'visibility', ['public', 'private']);
+      isValueValid(repoKind, 'repository kind', [
+        'application',
+        'image',
+        undefined,
+      ]);
+
+      const params: RequestBody = {
+        description,
+        repository: name,
+        visibility,
+        namespace,
+        repo_kind: repoKind,
+      };
+
+      const uri = encodeURI(`${baseUrl}/api/v1/repository`);
+      const response = await fetch(uri, {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(params),
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const errorBody = (await response.json()) as ResponseErrorBody;
+        const errorStatus = errorBody.status || response.status;
+        // Some error responses don't have the structure defined in ResponseErrorBody
+        const errorMsg = errorBody.detail || (errorBody as any).error;
+        throw new Error(
+          `Failed to create Quay repository, ${errorStatus} -- ${errorMsg}`,
+        );
+      }
+
+      const body = (await response.json()) as ResponseBody;
+      ctx.output(
+        'repositoryUrl',
+        `${baseUrl}/repository/${body.namespace}/${body.name}`,
+      );
+    },
+  });
+}

--- a/plugins/quay-actions/src/actions/index.ts
+++ b/plugins/quay-actions/src/actions/index.ts
@@ -1,0 +1,1 @@
+export { createQuayRepositoryAction } from './createQuayRepository';

--- a/plugins/quay-actions/src/index.ts
+++ b/plugins/quay-actions/src/index.ts
@@ -1,0 +1,8 @@
+/***/
+/**
+ * The quay-actions module for @backstage/plugin-scaffolder-backend.
+ *
+ * @packageDocumentation
+ */
+
+export * from './actions';


### PR DESCRIPTION
Resolves #176

- Add a new package for quay actions with version `v1.0.0` and set it to public
- Add a custom scaffolder action to create a Quay repository using the quay API
- Add documentation for the created action
- Add tests for the created action

Note: Checks for required parameters are not done in code since they part of the schema and backstage won't run the actions unless it has all of the required parameters.