### PR TITLE
feat(ocm-backend)!: add a scheduler configuration option

### DIFF
--- a/plugins/ocm-backend/config.d.ts
+++ b/plugins/ocm-backend/config.d.ts
@@ -1,3 +1,5 @@
+import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
+
 interface KubernetesPluginRef {
   /**
    * Match the cluster name in kubernetes plugin config
@@ -41,6 +43,7 @@ export interface Config {
            * Owner reference to created cluster entities in the catalog
            */
           owner?: string;
+          schedule?: TaskScheduleDefinitionConfig;
         };
       };
     };

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -24,6 +24,7 @@
   "configSchema": "config.d.ts",
   "dependencies": {
     "@backstage/backend-common": "^0.18.5",
+    "@backstage/backend-tasks": "^0.5.1",
     "@backstage/catalog-client": "^1.4.1",
     "@backstage/catalog-model": "^1.3.0",
     "@backstage/config": "^1.0.7",

--- a/plugins/ocm-backend/src/helpers/config.ts
+++ b/plugins/ocm-backend/src/helpers/config.ts
@@ -1,5 +1,6 @@
 import { Config } from '@backstage/config';
 import { OcmConfig } from '../types';
+import { readTaskScheduleDefinitionFromConfig } from '@backstage/backend-tasks';
 
 const KUBERNETES_PLUGIN_CONFIG = 'kubernetes.clusterLocatorMethods';
 const OCM_PREFIX = 'catalog.providers.ocm';
@@ -85,6 +86,9 @@ export const getHubClusterFromConfig = (
     skipTLSVerify: hub.getOptionalBoolean('skipTLSVerify') || false,
     caData: hub.getOptionalString('caData'),
     owner: config.getOptionalString(OWNER_KEY) || 'unknown',
+    schedule: config.has('schedule')
+      ? readTaskScheduleDefinitionFromConfig(config.getConfig('schedule'))
+      : undefined,
   };
 };
 

--- a/plugins/ocm-backend/src/providers/ManagedClusterProvider.ts
+++ b/plugins/ocm-backend/src/providers/ManagedClusterProvider.ts
@@ -39,6 +39,7 @@ import {
   ANNOTATION_PROVIDER_ID,
   ANNOTATION_CLUSTER_ID,
 } from '@janus-idp/backstage-plugin-ocm-common';
+import { PluginTaskScheduler, TaskRunner } from '@backstage/backend-tasks';
 
 /**
  * Provides OpenShift cluster resource entities from Open Cluster Management.
@@ -49,6 +50,7 @@ export class ManagedClusterProvider implements EntityProvider {
   protected readonly id: string;
   protected readonly owner: string;
   protected readonly logger: winston.Logger;
+  private readonly scheduleFn: () => Promise<void>;
   protected connection?: EntityProviderConnection;
 
   protected constructor(
@@ -57,28 +59,64 @@ export class ManagedClusterProvider implements EntityProvider {
     id: string,
     options: { logger: winston.Logger },
     owner: string,
+    taskRunner: TaskRunner,
   ) {
     this.client = client;
     this.hubResourceName = hubResourceName;
     this.id = id;
     this.logger = options.logger;
     this.owner = owner;
+    this.scheduleFn = this.createScheduleFn(taskRunner);
   }
 
-  static fromConfig(config: Config, options: { logger: winston.Logger }) {
+  static fromConfig(
+    config: Config,
+    options: {
+      logger: winston.Logger;
+      schedule?: TaskRunner;
+      scheduler?: PluginTaskScheduler;
+    },
+  ) {
     return readOcmConfigs(config).map(provider => {
       const client = hubApiClient(provider, options.logger);
+      const taskRunner =
+        options.schedule ||
+        options.scheduler!.createScheduledTaskRunner(provider.schedule!);
+
+      if (!options.schedule && !provider.schedule) {
+        throw new Error(
+          `No schedule provided neither via code nor config for "${provider.id}" hub.`,
+        );
+      }
+
       return new ManagedClusterProvider(
         client,
         provider.hubResourceName,
         provider.id,
         options,
         provider.owner,
+        taskRunner,
       );
     });
   }
   public async connect(connection: EntityProviderConnection): Promise<void> {
     this.connection = connection;
+    await this.scheduleFn();
+  }
+
+  private createScheduleFn(taskRunner: TaskRunner): () => Promise<void> {
+    return async () => {
+      return taskRunner.run({
+        id: `run_ocm_refresh_${this.getProviderName()}`,
+        fn: async () => {
+          try {
+            await this.run();
+          } catch (error) {
+            this.logger.error(error);
+          }
+        },
+      });
+    };
   }
 
   getProviderName(): string {

--- a/plugins/ocm-backend/src/types.ts
+++ b/plugins/ocm-backend/src/types.ts
@@ -1,4 +1,5 @@
 import { KubernetesObject, V1PodCondition } from '@kubernetes/client-node';
+import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 
 export type OcmConfig = {
   id: string;
@@ -8,6 +9,7 @@ export type OcmConfig = {
   skipTLSVerify?: boolean;
   caData?: string;
   owner: string;
+  schedule?: TaskScheduleDefinition;
 };
 
 export interface ClusterClaim {


### PR DESCRIPTION
BREAKING CHANGE :boom:

Part of #235 

The scheduler for the entity provider is now configurable by changing the `app-config.yaml` or by changing code in `catalog.ts`. The old configuration for entity provider in `catalog.ts` is no longer valid.

The configuration options are described in the updated README file.