### PR TITLE
feat(keycloak): Add support for scheduler in config file

### DIFF
--- a/plugins/keycloak-backend/config.d.ts
+++ b/plugins/keycloak-backend/config.d.ts
@@ -1,3 +1,5 @@
+import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
+
 interface KeycloakOrg {
   /**
    * Location of the Keycloak instance
@@ -35,9 +37,10 @@ export interface Config {
   catalog?: {
     providers?: {
       keycloakOrg?: {
-        [key: string]:
+        [key: string]: (
           | Omit<KeycloakOrg, 'username' | 'password'>
-          | Omit<KeycloakOrg, 'clientId' | 'clientSecret'>;
+          | Omit<KeycloakOrg, 'clientId' | 'clientSecret'>
+        ) & { scheduler: TaskScheduleDefinitionConfig };
       };
     };
   };

--- a/plugins/keycloak-backend/src/lib/config.ts
+++ b/plugins/keycloak-backend/src/lib/config.ts
@@ -119,8 +119,10 @@ export const readProviderConfigs = (
       throw new Error(`username must be provided when password is defined.`);
     }
 
-    const schedule = config.has('schedule')
-      ? readTaskScheduleDefinitionFromConfig(config.getConfig('schedule'))
+    const schedule = providerConfigInstance.has('schedule')
+      ? readTaskScheduleDefinitionFromConfig(
+          providerConfigInstance.getConfig('schedule'),
+        )
       : undefined;
 
     return {


### PR DESCRIPTION
Part of #235 

The scheduler for the entity provider is now configurable by changing the `app-config.yaml` or by changing code in `catalog.ts`. Since this plugin almost already supported all of the scheduler configuration methods, just one code change was needed and an updated README.