### PR TITLE
fix(topology): Get selected-node if data-model available

### DIFF
--- a/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
+++ b/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
@@ -57,7 +57,7 @@ const TopologyViewWorkloadComponent: React.FC<
   }, [layout, loaded, dataModel, controller]);
 
   React.useEffect(() => {
-    if (loaded && dataModel) {
+    if (dataModel) {
       const selectedNode: BaseNode | null = selectedId
         ? (controller.getElementById(selectedId) as BaseNode)
         : null;
@@ -68,14 +68,7 @@ const TopologyViewWorkloadComponent: React.FC<
         setSideBarOpen(false);
       }
     }
-  }, [
-    controller,
-    dataModel,
-    loaded,
-    selectedId,
-    setSelectedNode,
-    setSideBarOpen,
-  ]);
+  }, [controller, dataModel, selectedId, setSelectedNode, setSideBarOpen]);
 
   useEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
     setSelectedIds(ids);


### PR DESCRIPTION
Fixes: https://github.com/janus-idp/backstage-plugins/issues/257

During resource fetch, loaded is set to false till the time the call completes so during that time selected node was not getting set as loaded remained false. I have removed loaded from the check as it is not needed since we just want to have the data-model in place and the selected-node should be set when its available.

https://user-images.githubusercontent.com/20724543/232550733-accff3f4-fe3f-40df-a19f-38d8f00801e9.mov

