### PR TITLE
test(ocm-backend): Migrate tests from nock to msw

### DIFF
--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -42,7 +42,6 @@
     "@types/express": "4.17.17",
     "@types/supertest": "2.0.12",
     "msw": "1.0.1",
-    "nock": "13.3.0",
     "supertest": "6.3.3"
   },
   "files": [

--- a/plugins/ocm-backend/src/service/router.test.ts
+++ b/plugins/ocm-backend/src/service/router.test.ts
@@ -1,11 +1,25 @@
 import { ConfigReader } from '@backstage/config';
 import express from 'express';
-import nock from 'nock';
 import request from 'supertest';
 import { createLogger, transports } from 'winston';
 import { createRouter } from './router';
+import { setupServer } from 'msw/node';
+import { handlers } from '../../__fixtures__/handlers';
 
-const FIXTURES_DIR = `${__dirname}/../../__fixtures__`;
+const server = setupServer(...handlers);
+
+beforeAll(() =>
+  server.listen({
+    /*
+     *  This is required so that msw doesn't throw
+     *  warnings when the express app is requesting an endpoint
+     */
+    onUnhandledRequest: 'bypass',
+  }),
+);
+afterEach(() => server.restoreHandlers());
+afterAll(() => server.close());
+
 const logger = createLogger({
   transports: [new transports.Console({ silent: true })],
 });
@@ -23,7 +37,7 @@ describe('createRouter', () => {
             ocm: {
               foo: {
                 name: 'thisishub',
-                url: 'https://127.0.0.1:51010',
+                url: 'http://localhost:5000',
                 serviceAccountToken: 'TOKEN',
               },
             },
@@ -35,22 +49,6 @@ describe('createRouter', () => {
   });
 
   describe('GET /status', () => {
-    beforeAll(() => {
-      nock('https://127.0.0.1:51010')
-        .get('/apis/cluster.open-cluster-management.io/v1/managedclusters')
-        .reply(200, {
-          items: [
-            require(`${FIXTURES_DIR}/cluster.open-cluster-management.io/managedclusters/local-cluster.json`),
-            require(`${FIXTURES_DIR}/cluster.open-cluster-management.io/managedclusters/cluster1.json`),
-          ],
-        })
-        .persist();
-    });
-
-    afterAll(() => {
-      nock.cleanAll();
-    });
-
     it('should get all clusters', async () => {
       const result = await request(app).get('/status');
 
@@ -75,50 +73,6 @@ describe('createRouter', () => {
   });
 
   describe('GET /status/:hubName/:clusterName', () => {
-    beforeAll(() => {
-      nock('https://127.0.0.1:51010')
-        .get(
-          '/apis/cluster.open-cluster-management.io/v1/managedclusters/local-cluster',
-        )
-        .reply(
-          200,
-          require(`${FIXTURES_DIR}/cluster.open-cluster-management.io/managedclusters/local-cluster.json`),
-        )
-        .get(
-          '/apis/cluster.open-cluster-management.io/v1/managedclusters/cluster1',
-        )
-        .reply(
-          200,
-          require(`${FIXTURES_DIR}/cluster.open-cluster-management.io/managedclusters/cluster1.json`),
-        )
-        .get(
-          '/apis/cluster.open-cluster-management.io/v1/managedclusters/non_existent_cluster',
-        )
-        .reply(
-          404,
-          require(`${FIXTURES_DIR}/cluster.open-cluster-management.io/managedclusters/non_existent_cluster.json`),
-        )
-        .get(
-          '/apis/internal.open-cluster-management.io/v1beta1/namespaces/cluster1/managedclusterinfos/cluster1',
-        )
-        .reply(
-          200,
-          require(`${FIXTURES_DIR}/internal.open-cluster-management.io/managedclusterinfos/cluster1.json`),
-        )
-        .get(
-          '/apis/internal.open-cluster-management.io/v1beta1/namespaces/local-cluster/managedclusterinfos/local-cluster',
-        )
-        .reply(
-          200,
-          require(`${FIXTURES_DIR}/internal.open-cluster-management.io/managedclusterinfos/local-cluster.json`),
-        )
-        .persist();
-    });
-
-    afterAll(() => {
-      nock.cleanAll();
-    });
-
     it('should correctly parse a cluster', async () => {
       const result = await request(app).get('/status/foo/cluster1');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17757,16 +17757,6 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-nock@13.3.0:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.3.0.tgz#b13069c1a03f1ad63120f994b04bfd2556925768"
-  integrity sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==
-  dependencies:
-    debug "^4.1.0"
-    json-stringify-safe "^5.0.1"
-    lodash "^4.17.21"
-    propagate "^2.0.0"
-
 node-abi@^3.3.0:
   version "3.32.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.32.0.tgz#a22e038efab01d9a35c6b19808b430616ed80539"
@@ -19681,11 +19671,6 @@ prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.6.2,
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
-
-propagate@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
-  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 property-expr@^2.0.4:
   version "2.0.5"


### PR DESCRIPTION
Migrate tests for `kubernetes.ts` and `router.ts` to use `msw` instead of `nock` since `msw` is used backstage wide for mocking. We can now also utilize the defined handlers that are used in the `ocm-backend` dev setup.