### PR TITLE
feat(k8s-actions): add create namespace action

### DIFF
--- a/plugins/kubernetes-actions/.eslintrc.js
+++ b/plugins/kubernetes-actions/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/kubernetes-actions/README.md
+++ b/plugins/kubernetes-actions/README.md
@@ -1,5 +1,125 @@
-# @janus-idp/backstage-plugin-scaffolder-backend-module-kubernetes
+# Kubernetes actions for Backstage
 
-The kubernetes module for [@backstage/plugin-scaffolder-backend](https://www.npmjs.com/package/@backstage/plugin-scaffolder-backend).
+This module provides [Backstage](https://backstage.io/) template [actions](https://backstage.io/docs/features/software-templates/builtin-actions) for [Kubernetes](https://kubernetes.io/docs/home/).
 
-_This plugin was created through the Backstage CLI_
+The following actions are currently supported in this module:
+
+- Create a kubernetes namespace
+
+## Getting started
+
+1. Install the action package in your Backstage project
+
+   ```bash
+   yarn workspace backend add @janus-idp/backstage-scaffolder-backend-module-kubernetes
+   ```
+
+2. [Register](https://backstage.io/docs/features/software-templates/writing-custom-actions#registering-custom-actions) the Kubenretes actions by modifying the `packages/backend/src/plugins/scaffolder.ts` file from your project with the following changes:
+
+   ```ts
+   import { CatalogClient } from '@backstage/catalog-client';
+   import {
+     createBuiltinActions,
+     createRouter,
+   } from '@backstage/plugin-scaffolder-backend';
+   import { ScmIntegrations } from '@backstage/integration';
+   import { Router } from 'express';
+   import type { PluginEnvironment } from '../types';
+   import { createKubernetesNamespaceAction } from '@janus-idp/backstage-scaffolder-backend-module-kubernetes';
+
+   export default async function createPlugin(
+     env: PluginEnvironment,
+   ): Promise<Router> {
+     const catalogClient = new CatalogClient({
+       discoveryApi: env.discovery,
+     });
+
+     const integrations = ScmIntegrations.fromConfig(env.config);
+
+     const builtInActions = createBuiltinActions({
+       integrations,
+       catalogClient,
+       config: env.config,
+       reader: env.reader,
+     });
+
+     const actions = [
+       ...builtInActions,
+       createKubernetesNamespaceAction(catalogClient),
+     ];
+
+     return await createRouter({
+       actions,
+       logger: env.logger,
+       config: env.config,
+       database: env.database,
+       reader: env.reader,
+       catalogClient,
+       identity: env.identity,
+     });
+   }
+   ```
+
+3. **Optional**: If you are doing the previous step for the first time, you also have to install the `@backstage/integration` package
+
+   ```bash
+   yarn workspace backend add @backstage/integration
+   ```
+
+4. Add the Kubernetes actions to your templates, see the [example](./examples/templates/01-kubernetes-template.yaml) file in this repository for complete usage examples
+
+   ```yaml
+   action: kubernetes:create-namespace
+   id: create-kubernetes-namespace
+   name: Create kubernetes namespace
+   input:
+     namespace: foo
+     clusterRef: bar
+     token: TOKEN
+     skipTLSVerify: false
+     caData: Zm9v
+   ```
+
+## Usage
+
+### Action: kubernetes:create-namespace
+
+#### Input
+
+| Parameter Name |  Type   | Required | Description                                         | Example                           |
+| -------------- | :-----: | :------: | --------------------------------------------------- | --------------------------------- |
+| namespace      | string  |   Yes    | Kubernetes namespace name                           | foo                               |
+| clusterRef     | string  |    No    | Cluster resource entity reference from the catalog  | bar                               |
+| url            | string  |    No    | API url of the kubernetes cluster                   | <https://api.foo.redhat.com:6443> |
+| token          | string  |    No    | Kubernetes API bearer token used for authentication |                                   |
+| skipTLSVerify  | boolean |    No    | If true, ceritificate verification is skipped       | false                             |
+| caData         | string  |    No    | Base64 encoded certificate data                     |                                   |
+
+#### Output
+
+This action doesn't have any outputs.
+
+## Development
+
+1. Add the local package dependency to the Backstage instance
+
+   ```shell
+   yarn workspace backend add file:./plugins/kubernetes-actions
+   ```
+
+2. [Register](#getting-started) the Kubernetes actions in your Backstage project
+3. **Optional**: You can use the sample template from this repository and add it as `locations` in your `app-config.yaml` file
+
+   ```yaml
+   ---
+   catalog:
+     locations:
+       - type: file
+         target: ../../plugins/kubernetes-actions/examples/templates/01-kubernetes-template.yaml
+         rules:
+           - allow: [Template]
+   ```
+
+4. Run `yarn dev`
+5. Make sure you have an available kubernetes cluster
+6. Start using the Kubernetes actions in your templates

--- a/plugins/kubernetes-actions/README.md
+++ b/plugins/kubernetes-actions/README.md
@@ -1,0 +1,5 @@
+# @janus-idp/backstage-plugin-scaffolder-backend-module-kubernetes
+
+The kubernetes module for [@backstage/plugin-scaffolder-backend](https://www.npmjs.com/package/@backstage/plugin-scaffolder-backend).
+
+_This plugin was created through the Backstage CLI_

--- a/plugins/kubernetes-actions/__fixtures__/cluster-entities/bar.json
+++ b/plugins/kubernetes-actions/__fixtures__/cluster-entities/bar.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": "backstage.io/v1beta1",
+  "kind": "Resource",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/api-server": "http://localhost:5000"
+    },
+    "name": "bar"
+  },
+  "spec": {
+    "type": "db"
+  }
+}

--- a/plugins/kubernetes-actions/__fixtures__/cluster-entities/foo.json
+++ b/plugins/kubernetes-actions/__fixtures__/cluster-entities/foo.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": "backstage.io/v1beta1",
+  "kind": "Resource",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/api-server": "http://localhost:5000"
+    },
+    "name": "foo"
+  },
+  "spec": {
+    "type": "kubernetes-cluster"
+  }
+}

--- a/plugins/kubernetes-actions/__fixtures__/cluster-entities/qux.json
+++ b/plugins/kubernetes-actions/__fixtures__/cluster-entities/qux.json
@@ -1,0 +1,11 @@
+{
+  "apiVersion": "backstage.io/v1beta1",
+  "kind": "Resource",
+  "metadata": {
+    "annotations": {},
+    "name": "qux"
+  },
+  "spec": {
+    "type": "kubernetes-cluster"
+  }
+}

--- a/plugins/kubernetes-actions/examples/templates/01-kubernetes-template.yaml
+++ b/plugins/kubernetes-actions/examples/templates/01-kubernetes-template.yaml
@@ -1,0 +1,53 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-kubernetes-namespace
+  title: Create a kubernetes namespace
+  description: Create a kubernetes namespace
+
+spec:
+  type: service
+  parameters:
+    - title: Information
+      required: [namespace, token]
+      properties:
+        namespace:
+          title: Namespace name
+          type: string
+          description: Name of the namespace to be created
+        clusterRef:
+          title: Cluster reference
+          type: string
+          description: Cluster resource entity reference from the catalog
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              kind: Resource
+        url:
+          title: Url
+          type: string
+          description: Url of the kubernetes API, will be used if clusterRef is not provided
+        token:
+          title: Token
+          type: string
+          description: Bearer token to authenticate with
+        skipTLSVerify:
+          title: Skip TLS verification
+          type: boolean
+          description: Skip TLS certificate verification, not recommended to use in production environment, default to false
+        caData:
+          title: CA data
+          type: string
+          description: Certificate Authority base64 encoded certificate
+
+  steps:
+    - id: create-kubernetes-namespace
+      name: Create kubernetes namespace
+      action: kubernetes:create-namespace
+      input:
+        namespace: ${{ parameters.namespace }}
+        clusterRef: ${{ parameters.clusterRef }}
+        url: ${{ parameters.url }}
+        token: ${{ parameters.token }}
+        skipTLSVerify: ${{ parameters.skipTLSVerify }}
+        caData: ${{ parameters.caData }}

--- a/plugins/kubernetes-actions/package.json
+++ b/plugins/kubernetes-actions/package.json
@@ -30,7 +30,8 @@
   },
   "devDependencies": {
     "@backstage/backend-common": "^0.18.0",
-    "@backstage/cli": "^0.22.1"
+    "@backstage/cli": "^0.22.1",
+    "msw": "^1.2.1"
   },
   "files": [
     "dist"

--- a/plugins/kubernetes-actions/package.json
+++ b/plugins/kubernetes-actions/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@janus-idp/backstage-scaffolder-backend-module-kubernetes",
+  "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin-module"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/catalog-client": "^1.4.1",
+    "@backstage/catalog-model": "^1.3.0",
+    "@backstage/plugin-scaffolder-node": "^0.1.2",
+    "@kubernetes/client-node": "^0.18.1"
+  },
+  "devDependencies": {
+    "@backstage/backend-common": "^0.18.0",
+    "@backstage/cli": "^0.22.1"
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": "github:janus-idp/backstage-plugins",
+  "keywords": [
+    "backstage",
+    "backend-plugin-module"
+  ],
+  "homepage": "https://janus-idp.io/",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
+}

--- a/plugins/kubernetes-actions/src/actions/createKubernetesNamespace.test.ts
+++ b/plugins/kubernetes-actions/src/actions/createKubernetesNamespace.test.ts
@@ -1,0 +1,34 @@
+// import { PassThrough } from 'stream';
+// import { createKubernetesNamespaceAction } from './createKubernetesNamespace';
+// import { getVoidLogger } from '@backstage/backend-common';
+
+// afterEach(() => {
+//     describe('kubernetes:create-namespace', () => {
+//     jest.resetAllMocks();
+//   });
+
+//   it('should call action', async () => {
+//     const action = createKubernetesNamespaceAction();
+
+//     const logger = getVoidLogger();
+//     jest.spyOn(logger, 'info');
+
+//     await action.handler({
+//       input: {
+//         : 'test',
+//       },
+//       workspacePath: '/tmp',
+//       logger,
+//       logStream: new PassThrough(),
+//       output: jest.fn(),
+//       createTemporaryDirectory() {
+//         // Usage of mock-fs is recommended for testing of filesystem operations
+//         throw new Error('Not implemented');
+//       },
+//     });
+
+//     expect(logger.info).toHaveBeenCalledWith(
+//       'Running example template with parameters: test',
+//     );
+//   });
+// });

--- a/plugins/kubernetes-actions/src/actions/createKubernetesNamespace.test.ts
+++ b/plugins/kubernetes-actions/src/actions/createKubernetesNamespace.test.ts
@@ -1,34 +1,197 @@
-// import { PassThrough } from 'stream';
-// import { createKubernetesNamespaceAction } from './createKubernetesNamespace';
-// import { getVoidLogger } from '@backstage/backend-common';
+import os from 'os';
+import { PassThrough } from 'stream';
+import { createKubernetesNamespaceAction } from './createKubernetesNamespace';
+import { getVoidLogger } from '@backstage/backend-common';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+import { V1Namespace } from '@kubernetes/client-node';
+import { CatalogClient } from '@backstage/catalog-client';
 
-// afterEach(() => {
-//     describe('kubernetes:create-namespace', () => {
-//     jest.resetAllMocks();
-//   });
+const LOCAL_ADDR = 'http://localhost:5000';
+const FIXTURES_DIR = `${__dirname}/../../__fixtures__/cluster-entities`;
 
-//   it('should call action', async () => {
-//     const action = createKubernetesNamespaceAction();
+const handlers = [
+  rest.post(`${LOCAL_ADDR}/api/v1/namespaces`, async (req, res, ctx) => {
+    const ns = (await req.json()) as V1Namespace;
+    if (ns.metadata?.name === 'error') {
+      const error = {
+        body: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          metadata: {},
+          status: 'Failure',
+          message: 'Unauthorized',
+          reason: 'Unauthorized',
+          code: 401,
+        },
+        statusCode: 401,
+        message: 'Unauthorized',
+      };
+      return res(ctx.status(401), ctx.json(error));
+    }
+    return res(ctx.status(200), ctx.json({}));
+  }),
+];
 
-//     const logger = getVoidLogger();
-//     jest.spyOn(logger, 'info');
+const server = setupServer(...handlers);
 
-//     await action.handler({
-//       input: {
-//         : 'test',
-//       },
-//       workspacePath: '/tmp',
-//       logger,
-//       logStream: new PassThrough(),
-//       output: jest.fn(),
-//       createTemporaryDirectory() {
-//         // Usage of mock-fs is recommended for testing of filesystem operations
-//         throw new Error('Not implemented');
-//       },
-//     });
+beforeAll(() => server.listen());
+afterEach(() => server.restoreHandlers());
+afterAll(() => server.close());
 
-//     expect(logger.info).toHaveBeenCalledWith(
-//       'Running example template with parameters: test',
-//     );
-//   });
-// });
+describe('kubernetes:create-namespace', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const catalogClientFn = jest.fn(async (entityRef: string) => {
+    switch (entityRef) {
+      case 'resource:foo':
+        return require(`${FIXTURES_DIR}/foo`);
+      case 'resource:bar':
+        return require(`${FIXTURES_DIR}/bar`);
+      case 'resource:qux':
+        return require(`${FIXTURES_DIR}/qux`);
+      default:
+        return undefined;
+    }
+  });
+
+  const action = createKubernetesNamespaceAction({
+    getEntityByRef: catalogClientFn,
+  } as unknown as CatalogClient);
+
+  const mockContext = {
+    workspacePath: os.tmpdir(),
+    logger: getVoidLogger(),
+    logStream: new PassThrough(),
+    output: jest.fn(),
+    createTemporaryDirectory: jest.fn(),
+  };
+
+  it('should get the api url from the correct entity', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        namespace: 'foo',
+        clusterRef: 'resource:foo',
+        token: 'TOKEN',
+      },
+    });
+
+    expect(catalogClientFn).toHaveBeenCalledTimes(1);
+    expect(catalogClientFn).toHaveBeenCalledWith('resource:foo');
+  });
+
+  it.each([
+    {
+      entityName: 'foo',
+      calledWith: 'resource:foo',
+      warnMsg: 'Cluster reference in the wrong format, attempting to fix it',
+      name: 'should warn and try to fix the entity name',
+    },
+    {
+      entityName: 'resource:bar',
+      calledWith: 'resource:bar',
+      warnMsg: 'Resource is not of kubernetes-cluster type',
+      name: 'should warn if the resource is not kubernetes-cluster',
+    },
+  ])('$name', async ({ entityName, calledWith, warnMsg }) => {
+    const mockedWarn = jest.spyOn(mockContext.logger, 'warn');
+    await action.handler({
+      ...mockContext,
+      input: {
+        namespace: entityName,
+        clusterRef: entityName,
+        token: 'TOKEN',
+      },
+    });
+
+    expect(mockedWarn).toHaveBeenCalledWith(warnMsg);
+    expect(catalogClientFn).toHaveBeenCalledTimes(1);
+    expect(catalogClientFn).toHaveBeenCalledWith(calledWith);
+  });
+
+  it.each([
+    {
+      entityName: 'resource:missing-entity',
+      error: 'Resource not found',
+      name: 'should throw if the entity is not found',
+    },
+    {
+      entityName: 'resource:qux',
+      error: 'Cluster resource is missing kubernetes.io/api-server annotation',
+      name: 'should throw if the api url annotation is not present',
+    },
+  ])('$name', async ({ entityName, error }) => {
+    await expect(async () => {
+      await action.handler({
+        ...mockContext,
+        input: {
+          namespace: entityName,
+          clusterRef: entityName,
+          token: 'TOKEN',
+        },
+      });
+    }).rejects.toThrow(error);
+
+    expect(catalogClientFn).toHaveBeenCalledTimes(1);
+    expect(catalogClientFn).toHaveBeenCalledWith(entityName);
+  });
+
+  it('should throw if neither url nor clusterRef is provided', async () => {
+    await expect(async () => {
+      await action.handler({
+        ...mockContext,
+        input: {
+          namespace: 'foo',
+          token: 'TOKEN',
+        },
+      });
+    }).rejects.toThrow('Cluster reference or url are required');
+  });
+
+  it('should throw if url and clusterRef are provided', async () => {
+    await expect(async () => {
+      await action.handler({
+        ...mockContext,
+        input: {
+          namespace: 'foo',
+          url: 'http://example.com',
+          clusterRef: 'foo',
+          token: 'TOKEN',
+        },
+      });
+    }).rejects.toThrow(
+      "Cluster reference and url can't be specified at the same time",
+    );
+  });
+
+  it('should correctly parse a http error', async () => {
+    await expect(async () => {
+      await action.handler({
+        ...mockContext,
+        input: {
+          namespace: 'error',
+          url: 'http://localhost:5000',
+          token: 'TOKEN',
+        },
+      });
+    }).rejects.toThrow(
+      'Failed to create kubernetes namespace, 401 -- Unauthorized',
+    );
+  });
+
+  it('should throw an error while using an invalid api url', async () => {
+    await expect(async () => {
+      await action.handler({
+        ...mockContext,
+        input: {
+          namespace: 'foo',
+          token: 'TOKEN',
+          url: 'bar',
+        },
+      });
+    }).rejects.toThrow('"bar" is an invalid url');
+  });
+});

--- a/plugins/kubernetes-actions/src/actions/createKubernetesNamespace.ts
+++ b/plugins/kubernetes-actions/src/actions/createKubernetesNamespace.ts
@@ -1,0 +1,186 @@
+import {
+  ActionContext,
+  createTemplateAction,
+} from '@backstage/plugin-scaffolder-node';
+import {
+  KubeConfig,
+  CoreV1Api,
+  HttpError,
+  V1Namespace,
+} from '@kubernetes/client-node';
+import { CatalogClient } from '@backstage/catalog-client';
+import { Entity } from '@backstage/catalog-model';
+
+const KUBERNETES_API_URL_ANNOTATION = 'kubernetes.io/api-server';
+const KUBERNETES_CLUSTER_TYPE = 'kubernetes-cluster';
+
+export interface HttpErrorBody {
+  kind: string;
+  apiVersion: string;
+  metadata: Object;
+  status: string;
+  message: string;
+  reason: string;
+  details: { name: string; kind: string };
+  code: number;
+}
+
+type TemplateActionParameters = {
+  namespace: string;
+  clusterRef?: string;
+  url?: string;
+  token: string;
+  skipTLSVerify?: boolean;
+  caData?: string;
+};
+
+const getUrlFromClusterRef = async (
+  ctx: ActionContext<TemplateActionParameters>,
+  catalogClient: CatalogClient,
+  clusterRef: string,
+): Promise<string> => {
+  const isResource = clusterRef.startsWith('resource:');
+  if (!isResource) {
+    ctx.logger.warn(
+      'Cluster reference in the wrong format, attempting to fix it',
+    );
+  }
+  const catalogEntity: Entity | undefined = await catalogClient.getEntityByRef(
+    isResource ? clusterRef : `resource:${clusterRef}`,
+  );
+  if (!catalogEntity) {
+    throw new Error('Resource not found');
+  }
+  if (catalogEntity.spec?.type !== KUBERNETES_CLUSTER_TYPE) {
+    ctx.logger.warn(`Resource is not of ${KUBERNETES_CLUSTER_TYPE} type`);
+  }
+  const apiUrl =
+    catalogEntity.metadata?.annotations?.[KUBERNETES_API_URL_ANNOTATION];
+  if (!apiUrl) {
+    throw new Error(
+      `Cluster resource is missing ${KUBERNETES_API_URL_ANNOTATION} annotation`,
+    );
+  }
+  return apiUrl;
+};
+
+const validateUrl = (url: string | undefined) => {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url!);
+  } catch (error) {
+    throw new Error(`"${url}" is an invalid url`);
+  }
+};
+
+export function createKubernetesNamespaceAction(catalogClient: CatalogClient) {
+  return createTemplateAction<TemplateActionParameters>({
+    id: 'kubernetes:create-namespace',
+    description: 'Creates a kubernetes namespace',
+    schema: {
+      input: {
+        type: 'object',
+        oneOf: [
+          { required: ['namespace', 'token', 'url'] },
+          { required: ['namespace', 'token', 'clusterRef'] },
+        ],
+        properties: {
+          namespace: {
+            title: 'Namespace name',
+            description: 'Name of the namespace to be created',
+            type: 'string',
+          },
+          clusterRef: {
+            title: 'Cluster entity reference',
+            description: 'Cluster resource entity reference from the catalog',
+            type: 'string',
+          },
+          url: {
+            title: 'Url',
+            description:
+              'Url of the kubernetes API, will be used if clusterRef is not provided',
+            type: 'string',
+          },
+          token: {
+            title: 'Token',
+            description: 'Bearer token to authenticate with',
+            type: 'string',
+          },
+          skipTLSVerify: {
+            title: 'Skip TLS verification',
+            description:
+              'Skip TLS certificate verification, not recommended to use in production environment, defaults to false',
+            type: 'boolean',
+          },
+          caData: {
+            title: 'CA Data',
+            description: 'Certificate Authority base64 encoded certificate',
+            type: 'string',
+          },
+        },
+      },
+    },
+    async handler(ctx) {
+      const { namespace, clusterRef, token, url, skipTLSVerify, caData } =
+        ctx.input;
+      const kubeConfig = new KubeConfig();
+      const name = 'backstage';
+      const cluster = {
+        server: '',
+        name,
+        serviceAccountToken: token,
+        skipTLSVerify: skipTLSVerify || false,
+        caData,
+      };
+
+      if (clusterRef && url) {
+        throw new Error(
+          "Cluster reference and url can't be specified at the same time",
+        );
+      }
+
+      if (!clusterRef && !url) {
+        throw new Error('Cluster reference or url are required');
+      }
+
+      if (clusterRef) {
+        cluster.server = await getUrlFromClusterRef(
+          ctx,
+          catalogClient,
+          clusterRef,
+        );
+      } else {
+        validateUrl(url);
+        cluster.server = url!;
+      }
+
+      kubeConfig.loadFromOptions({
+        clusters: [cluster],
+        users: [{ name, token }],
+        contexts: [
+          {
+            name,
+            user: name,
+            cluster: name,
+          },
+        ],
+        currentContext: name,
+      });
+
+      const api = kubeConfig.makeApiClient(CoreV1Api);
+      const k8sNamespace: V1Namespace = {
+        metadata: {
+          name: namespace,
+        },
+      };
+      await api.createNamespace(k8sNamespace).catch((e: HttpError) => {
+        const errorBody = e.body as HttpErrorBody;
+        const statusCode = errorBody?.code || e.statusCode;
+        const message = errorBody?.message || e.message;
+        throw new Error(
+          `Failed to create kubernetes namespace, ${statusCode} -- ${message}`,
+        );
+      });
+    },
+  });
+}

--- a/plugins/kubernetes-actions/src/actions/index.ts
+++ b/plugins/kubernetes-actions/src/actions/index.ts
@@ -1,0 +1,1 @@
+export { createKubernetesNamespaceAction } from './createKubernetesNamespace';

--- a/plugins/kubernetes-actions/src/index.ts
+++ b/plugins/kubernetes-actions/src/index.ts
@@ -1,0 +1,8 @@
+/***/
+/**
+ * The kubernetes module for @backstage/plugin-scaffolder-backend.
+ *
+ * @packageDocumentation
+ */
+
+export * from './actions';

--- a/yarn.lock
+++ b/yarn.lock
@@ -14548,6 +14548,11 @@ is-node-process@^1.0.1, is-node-process@^1.2.0:
   resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
   integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
+
 is-number-object@^1.0.4:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
@@ -18049,6 +18054,11 @@ os-tmpdir@~1.0.2:
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 outvariant@^1.2.1, outvariant@^1.3.0, outvariant@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.0.tgz#e742e4bda77692da3eca698ef5bfac62d9fba06e"
+  integrity sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==
+
+outvariant@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.0.tgz#e742e4bda77692da3eca698ef5bfac62d9fba06e"
   integrity sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2381,7 +2381,7 @@
     winston "^3.2.1"
     winston-transport "^4.5.0"
 
-"@backstage/backend-common@0.18.5", "@backstage/backend-common@^0.18.5":
+"@backstage/backend-common@0.18.5", "@backstage/backend-common@^0.18.0", "@backstage/backend-common@^0.18.5":
   version "0.18.5"
   resolved "https://registry.yarnpkg.com/@backstage/backend-common/-/backend-common-0.18.5.tgz#d9c84396414c1df13df3892a9cb9e5b193ab5381"
   integrity sha512-zVSNH5loujEr8AMnah7mZkBK9xS7CXmssiS6lGht627+rwwwHgegHuutkjqe/0MDJRd/of+ScDIbrbI7vxiszA==
@@ -2523,7 +2523,7 @@
     semver "^7.3.2"
     zod "^3.21.4"
 
-"@backstage/cli@0.22.7", "@backstage/cli@^0.22.7":
+"@backstage/cli@0.22.7", "@backstage/cli@^0.22.1", "@backstage/cli@^0.22.7":
   version "0.22.7"
   resolved "https://registry.yarnpkg.com/@backstage/cli/-/cli-0.22.7.tgz#777fb9be41c541b404567b1460356398888b13ae"
   integrity sha512-+lhTVNMIuN2C1tiasTRydoO9F9QYQwXJT87eQODvRzw590oi4cyD51BaZYdXy4w8pcaOUn1Vcs52pb5JGKwdfQ==
@@ -3323,7 +3323,11 @@
     "@backstage/plugin-permission-common" "^0.7.5"
     "@backstage/types" "^1.0.2"
 
+<<<<<<< HEAD
 "@backstage/plugin-scaffolder-node@^0.1.1", "@backstage/plugin-scaffolder-node@^0.1.3":
+=======
+"@backstage/plugin-scaffolder-node@^0.1.1", "@backstage/plugin-scaffolder-node@^0.1.2", "@backstage/plugin-scaffolder-node@^0.1.3":
+>>>>>>> 5d0db3f (feat(k8s-actions): Add create namespace action)
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder-node/-/plugin-scaffolder-node-0.1.3.tgz#40e514c78e11d694361a7d56474cedac7453269a"
   integrity sha512-EtUBxcK8y+9utOx+ZGElVdydxtGvTumX0DoAMXYSeyWqyGum7WRqgKBcbxXq6oOGFdopFQIOEYu8sgR9eEfjFQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3323,11 +3323,7 @@
     "@backstage/plugin-permission-common" "^0.7.5"
     "@backstage/types" "^1.0.2"
 
-<<<<<<< HEAD
-"@backstage/plugin-scaffolder-node@^0.1.1", "@backstage/plugin-scaffolder-node@^0.1.3":
-=======
 "@backstage/plugin-scaffolder-node@^0.1.1", "@backstage/plugin-scaffolder-node@^0.1.2", "@backstage/plugin-scaffolder-node@^0.1.3":
->>>>>>> 5d0db3f (feat(k8s-actions): Add create namespace action)
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder-node/-/plugin-scaffolder-node-0.1.3.tgz#40e514c78e11d694361a7d56474cedac7453269a"
   integrity sha512-EtUBxcK8y+9utOx+ZGElVdydxtGvTumX0DoAMXYSeyWqyGum7WRqgKBcbxXq6oOGFdopFQIOEYu8sgR9eEfjFQ==
@@ -14548,11 +14544,6 @@ is-node-process@^1.0.1, is-node-process@^1.2.0:
   resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
   integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
-is-node-process@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
-  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
-
 is-number-object@^1.0.4:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
@@ -17230,7 +17221,7 @@ msw@0.49.3:
     type-fest "^2.19.0"
     yargs "^17.3.1"
 
-msw@1.2.1:
+msw@1.2.1, msw@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/msw/-/msw-1.2.1.tgz#9dd347583eeba5e5c7f33b54be5600a899dc61bd"
   integrity sha512-bF7qWJQSmKn6bwGYVPXOxhexTCGD5oJSZg8yt8IBClxvo3Dx/1W0zqE1nX9BSWmzRsCKWfeGWcB/vpqV6aclpw==
@@ -18054,11 +18045,6 @@ os-tmpdir@~1.0.2:
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 outvariant@^1.2.1, outvariant@^1.3.0, outvariant@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.0.tgz#e742e4bda77692da3eca698ef5bfac62d9fba06e"
-  integrity sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==
-
-outvariant@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.0.tgz#e742e4bda77692da3eca698ef5bfac62d9fba06e"
   integrity sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==


### PR DESCRIPTION
Resolves #175 

- Add a new package for kubernetes actions with version `v1.0.0` and set it to public
- Add a custom scaffolder action to create a Kubernetes repository using the kubernetes client API library
- Add documentation for the created action
- Add tests for the created action

The `name` parameter that is used in the kube config values (like `cluster`, `name` ...) can be anything as far as I am aware since I think its only used for the kube config description itself and not for the API calls. 

Note: Checks for required parameters are not done in code since they part of the schema and backstage won't run the actions unless it has all of the required parameters. 