### PR TITLE
fix(quay): indicate when a layer has no security vulnerabilities detected

### DIFF
--- a/plugins/quay/src/components/QuayRepository/tableHeading.tsx
+++ b/plugins/quay/src/components/QuayRepository/tableHeading.tsx
@@ -19,9 +19,10 @@ const vulnerabilitySummary = (layer?: Layer): string => {
     });
   });
 
-  return Object.entries(summary)
+  const scanResults = Object.entries(summary)
     .map(([severity, count]) => `${severity}: ${count}`)
     .join(', ');
+  return scanResults.trim() !== '' ? scanResults : 'Passed';
 };
 
 export const columns: TableColumn[] = [
@@ -44,6 +45,7 @@ export const columns: TableColumn[] = [
       const retStr = vulnerabilitySummary(rowData.securityDetails as Layer);
       return <Link to={`tag/${tagManifest}`}>{retStr}</Link>;
     },
+    id: 'securityScan',
   },
   {
     title: 'Size',


### PR DESCRIPTION
Fixes: #293 

This PR fixes issue [janus-idp/backstage-showcase#219](https://github.com/janus-idp/backstage-showcase/issues/219) which occurs when a layer has no security vulnerabilities detected.

### Previous behavior

When no details are provided for the given layer:
![image](https://user-images.githubusercontent.com/97077423/234672115-f8756694-d8d5-46f2-b137-3be0b14afef5.png)

### New Behavior

![image](https://user-images.githubusercontent.com/97077423/234673250-474fe935-d0b6-4b62-b495-a52060e69bf0.png)



Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
