### PR TITLE
chore(ci): add PR title check for conventionalcommits schema

### DIFF
--- a/.github/workflows/pr-semantic.yaml
+++ b/.github/workflows/pr-semantic.yaml
@@ -1,0 +1,46 @@
+name: 'Semantic Release'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  title:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54 # v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Since we use `conventionalcommits` preset for
+          # `@semantic-release/commit-analyzer`, this list has to match allowed types
+          # Ref: https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#types
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          ignoreLabels: |
+            ignore-semantic-pull-request
+          # If the PR only contains a single commit, the action will validate that
+          # it matches the configured pattern.
+          validateSingleCommit: true
+          # Related to `validateSingleCommit` you can opt-in to validate that the PR
+          # title matches a single commit to avoid confusion.
+          validateSingleCommitMatchesPrTitle: true


### PR DESCRIPTION
SSIA, let's prevent situations when a change was not released because of a poorly formated PR name, like here: https://github.com/janus-idp/backstage-plugins/actions/runs/4797279674/jobs/8534234229#step:4:202