### PR TITLE
fix(topology): adds wrapper to topology view for consistent border

### DIFF
--- a/plugins/topology/src/components/Topology/TopologyComponent.css
+++ b/plugins/topology/src/components/Topology/TopologyComponent.css
@@ -2,7 +2,6 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 }
 
 .topology-text-muted {

--- a/plugins/topology/src/components/Topology/TopologyToolbar.css
+++ b/plugins/topology/src/components/Topology/TopologyToolbar.css
@@ -5,3 +5,7 @@
 .pf-c-toolbar__content-section {
   padding: var(--pf-global--spacer--sm) 0 0 0;
 }
+
+.bs-topology-wrapper {
+  height: 100%;
+}

--- a/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
+++ b/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
@@ -8,7 +8,7 @@ import {
   useVisualizationController,
   VisualizationSurface,
 } from '@patternfly/react-topology';
-import { Progress } from '@backstage/core-components';
+import { InfoCard, Progress } from '@backstage/core-components';
 import { TopologyEmptyState } from './TopologyEmptyState';
 import { useWorkloadsWatcher } from '../../hooks/useWorkloadWatcher';
 import { TopologyControlBar } from './TopologyControlBar';
@@ -86,29 +86,31 @@ const TopologyViewWorkloadComponent: React.FC<
       {allErrors && allErrors.length > 0 && (
         <TopologyErrorPanel allErrors={allErrors} />
       )}
-      {clusters.length < 1 ? (
-        <TopologyEmptyState />
-      ) : (
-        <TopologyView
-          controlBar={
-            loaded &&
-            dataModel?.nodes?.length > 0 && (
-              <TopologyControlBar controller={controller} />
-            )
-          }
-          viewToolbar={useToolbar && <TopologyToolbar />}
-          sideBar={sideBar}
-          sideBarResizable
-          sideBarOpen={sideBarOpen}
-          minSideBarSize="400px"
-        >
-          {loaded && dataModel?.nodes?.length === 0 ? (
-            <TopologyEmptyState />
-          ) : (
-            <VisualizationSurface state={{ selectedIds }} />
-          )}
-        </TopologyView>
-      )}
+      <InfoCard className="bs-topology-wrapper" divider={false}>
+        {clusters.length < 1 ? (
+          <TopologyEmptyState />
+        ) : (
+          <TopologyView
+            controlBar={
+              loaded &&
+              dataModel?.nodes?.length > 0 && (
+                <TopologyControlBar controller={controller} />
+              )
+            }
+            viewToolbar={useToolbar && <TopologyToolbar />}
+            sideBar={sideBar}
+            sideBarResizable
+            sideBarOpen={sideBarOpen}
+            minSideBarSize="400px"
+          >
+            {loaded && dataModel?.nodes?.length === 0 ? (
+              <TopologyEmptyState />
+            ) : (
+              <VisualizationSurface state={{ selectedIds }} />
+            )}
+          </TopologyView>
+        )}
+      </InfoCard>
     </>
   );
 };


### PR DESCRIPTION
**Fixes:** https://github.com/janus-idp/backstage-plugins/issues/325

**Screenshots:**

**Dark Theme:**

<img width="1569" alt="image" src="https://user-images.githubusercontent.com/5129024/236188970-db315154-9e5c-42cb-814e-a61e01b32d4b.png">


**Light Theme:**

<img width="1565" alt="image" src="https://user-images.githubusercontent.com/5129024/236189188-0bc69c18-9da4-42c6-8da6-494f4be50eb5.png">

