### PR TITLE
chore(release): update releasing config

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,13 +61,72 @@
       [
         "@semantic-release/commit-analyzer",
         {
-          "preset": "conventionalcommits"
+          "preset": "conventionalcommits",
+          "releaseRules": [
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "refactor",
+              "release": "patch"
+            },
+            {
+              "type": "perf",
+              "release": "minor"
+            },
+            {
+              "scope": "no-release",
+              "release": false
+            },
+            {
+              "type": "chore",
+              "scope": "deps",
+              "release": "patch"
+            }
+          ]
         }
       ],
       [
         "@semantic-release/release-notes-generator",
         {
-          "preset": "conventionalcommits"
+          "preset": "conventionalcommits",
+          "presetConfig": {
+            "types": [
+              {
+                "type": "feat",
+                "section": "Features"
+              },
+              {
+                "type": "fix",
+                "section": "Bug Fixes"
+              },
+              {
+                "type": "chore",
+                "section": "Other changes"
+              },
+              {
+                "type": "docs",
+                "section": "Documentation"
+              },
+              {
+                "type": "style",
+                "section": "Other changes"
+              },
+              {
+                "type": "refactor",
+                "section": "Other changes"
+              },
+              {
+                "type": "perf",
+                "section": "Other changes"
+              },
+              {
+                "type": "test",
+                "section": "Other changes"
+              }
+            ]
+          }
         }
       ],
       "@semantic-release/changelog",


### PR DESCRIPTION
This should allow us to release on:

- `chore(deps): .*`
- `docs(.*): .*` or `docs: .*`

Additionally, we can generate a bit richer changelogs.