### PR TITLE
fix(plugins): remove React.FC types

### DIFF
--- a/plugins/quay/src/components/QuayTagDetails/component.tsx
+++ b/plugins/quay/src/components/QuayTagDetails/component.tsx
@@ -1,12 +1,12 @@
-import { TableColumn, Link, Table } from '@backstage/core-components';
-import React from 'react';
-import { Layer, Vulnerability, VulnerabilityListItem } from '../../types';
+import { Link, Table, TableColumn } from '@backstage/core-components';
+import type { RouteFunc } from '@backstage/core-plugin-api';
+import { TableContainer, TableHead, makeStyles } from '@material-ui/core';
+import KeyboardBackspaceIcon from '@material-ui/icons/KeyboardBackspace';
 import LinkIcon from '@material-ui/icons/Link';
 import WarningIcon from '@material-ui/icons/Warning';
-import KeyboardBackspaceIcon from '@material-ui/icons/KeyboardBackspace';
+import React from 'react';
 import { SEVERITY_COLORS } from '../../lib/utils';
-import { TableContainer, TableHead, makeStyles } from '@material-ui/core';
-import type { RouteFunc } from '@backstage/core-plugin-api';
+import { Layer, Vulnerability, VulnerabilityListItem } from '../../types';
 
 type QuayTagDetailsProps = {
   layer: Layer;
@@ -99,7 +99,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const QuayTagDetails: React.FC<QuayTagDetailsProps> = ({
+export const QuayTagDetails = ({
   layer,
   rootLink,
   digest,

--- a/plugins/quay/src/components/QuayTagPage/component.tsx
+++ b/plugins/quay/src/components/QuayTagPage/component.tsx
@@ -1,14 +1,12 @@
-import React from 'react';
-import { useRepository, useTagDetails } from '../../hooks';
-import { useParams } from 'react-router-dom';
-import { QuayTagDetails } from '../QuayTagDetails';
 import { ErrorPanel, Progress } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useRepository, useTagDetails } from '../../hooks';
 import { rootRouteRef } from '../../routes';
+import { QuayTagDetails } from '../QuayTagDetails';
 
-type QuayTagPageProps = Record<never, string>;
-
-export const QuayTagPage: React.FC<QuayTagPageProps> = () => {
+export const QuayTagPage = () => {
   const rootLink = useRouteRef(rootRouteRef);
   const { repository, organization } = useRepository();
   const { digest } = useParams();

--- a/plugins/tekton/src/components/Charts/HorizontalStackedBars.tsx
+++ b/plugins/tekton/src/components/Charts/HorizontalStackedBars.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import classNames from 'classnames';
+import * as React from 'react';
 
 import './HorizontalStackedBars.css';
 
@@ -17,13 +17,13 @@ type HorizontalStackedBarsProps = {
   width?: number | string;
 };
 
-const HorizontalStackedBars: React.FC<HorizontalStackedBarsProps> = ({
+const HorizontalStackedBars = ({
   barGap,
   height,
   inline,
   values,
   width,
-}) => {
+}: HorizontalStackedBarsProps) => {
   return (
     <div
       className={classNames('bs-tkn-horizontal-stacked-bars', {

--- a/plugins/tekton/src/components/Charts/PipelineBars.tsx
+++ b/plugins/tekton/src/components/Charts/PipelineBars.tsx
@@ -1,21 +1,21 @@
-import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
-import HorizontalStackedBars from './HorizontalStackedBars';
-import TaskStatusToolTip from './TaskStatusTooltip';
+import * as React from 'react';
+import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
 import { ComputedStatus, TaskStatus } from '../../types/computedStatus';
+import { PipelineRunKind } from '../../types/pipelineRun';
 import { getRunStatusColor } from '../../utils/tekton-status';
 import {
   getTaskRunsForPipelineRun,
   getTaskStatus,
 } from '../../utils/tekton-utils';
-import { PipelineRunKind } from '../../types/pipelineRun';
-import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
+import HorizontalStackedBars from './HorizontalStackedBars';
+import TaskStatusToolTip from './TaskStatusTooltip';
 
 export interface PipelineBarProps {
   pipelinerun: PipelineRunKind;
 }
 
-export const PipelineBars: React.FC<PipelineBarProps> = ({ pipelinerun }) => {
+export const PipelineBars = ({ pipelinerun }: PipelineBarProps) => {
   const { watchResourcesData } = React.useContext(TektonResourcesContext);
   const taskRuns = watchResourcesData?.taskruns?.data || [];
   const plrTasks = getTaskRunsForPipelineRun(pipelinerun, taskRuns);

--- a/plugins/tekton/src/components/Charts/TaskStatusTooltip.tsx
+++ b/plugins/tekton/src/components/Charts/TaskStatusTooltip.tsx
@@ -8,9 +8,7 @@ interface TaskStatusToolTipProps {
   taskStatus: TaskStatus;
 }
 
-const TaskStatusToolTip: React.FC<TaskStatusToolTipProps> = ({
-  taskStatus,
-}) => {
+const TaskStatusToolTip = ({ taskStatus }: TaskStatusToolTipProps) => {
   return (
     <div className="bs-tkn-task-status-tooltip">
       {Object.keys(ComputedStatus).map(status => {

--- a/plugins/tekton/src/components/PipelineRunList/LinkedPipelineRunTaskStatus.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/LinkedPipelineRunTaskStatus.tsx
@@ -6,9 +6,9 @@ export interface LinkedPipelineRunTaskStatusProps {
   pipelineRun: PipelineRunKind;
 }
 
-const LinkedPipelineRunTaskStatus: React.FC<
-  LinkedPipelineRunTaskStatusProps
-> = ({ pipelineRun }) => {
+const LinkedPipelineRunTaskStatus = ({
+  pipelineRun,
+}: LinkedPipelineRunTaskStatusProps) => {
   return (
     <PipelineBars key={pipelineRun.metadata?.name} pipelinerun={pipelineRun} />
   );

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunList.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunList.tsx
@@ -1,20 +1,21 @@
-import * as React from 'react';
 import { EmptyState, InfoCard, Progress } from '@backstage/core-components';
 import { SortByDirection } from '@patternfly/react-table';
+import * as React from 'react';
+import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
+import { ClusterErrors } from '../../types/types';
+import { Table } from '../Table/Table';
+import { ClusterSelector, ErrorPanel } from '../common';
 import PipelineRunHeader from './PipelineRunHeader';
 import PipelineRunRow from './PipelineRunRow';
-import { Table } from '../Table/Table';
-import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
-import { ErrorPanel, ClusterSelector } from '../common';
-import { ClusterErrors } from '../../types/types';
+
+type WrapperInfoCardProps = {
+  allErrors?: ClusterErrors;
+};
 
 const WrapperInfoCard = ({
   children,
   allErrors,
-}: {
-  children: React.ReactNode;
-  allErrors?: any;
-}) => (
+}: React.PropsWithChildren<WrapperInfoCardProps>) => (
   <>
     {allErrors && allErrors.length > 0 && <ErrorPanel allErrors={allErrors} />}
     <InfoCard title="Pipeline Runs" subheader={<ClusterSelector />}>
@@ -23,7 +24,7 @@ const WrapperInfoCard = ({
   </>
 );
 
-const PipelineRunList: React.FC = () => {
+const PipelineRunList = () => {
   const { loaded, responseError, watchResourcesData, selectedClusterErrors } =
     React.useContext(TektonResourcesContext);
 

--- a/plugins/tekton/src/components/PipelineRunList/PlrStatus.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PlrStatus.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
@@ -6,6 +5,7 @@ import {
   PendingIcon,
   SyncAltIcon,
 } from '@patternfly/react-icons';
+import * as React from 'react';
 import { PipelineRunKind } from '../../types/pipelineRun';
 import { pipelineRunFilterReducer } from '../../utils/pipeline-filter-reducer';
 
@@ -32,7 +32,9 @@ const getPlrStatusIcon = (plrStatus1: string) => {
   }
 };
 
-const PlrStatus: React.FC<{ obj: PipelineRunKind }> = ({ obj }) => {
+type PlrStatusProps = { obj: PipelineRunKind };
+
+const PlrStatus = ({ obj }: PlrStatusProps) => {
   const plrStatus = pipelineRunFilterReducer(obj);
   return (
     <>

--- a/plugins/tekton/src/components/PipelineVisualizationRouter.tsx
+++ b/plugins/tekton/src/components/PipelineVisualizationRouter.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { Routes, Route } from 'react-router-dom';
 import { Entity } from '@backstage/catalog-model';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
 import { TEKTON_CI_ANNOTATION } from '../consts/tekton-const';
 import { LatestPipelineRunVisualization } from './pipeline-topology';
 
@@ -15,9 +15,10 @@ type PipelineVisualizationRouterProps = {
 };
 
 /** @public */
-export const PipelineVisualizationRouter: React.FC<
-  PipelineVisualizationRouterProps
-> = ({ linkTekton, url }) => {
+export const PipelineVisualizationRouter = ({
+  linkTekton,
+  url,
+}: PipelineVisualizationRouterProps) => {
   const { entity } = useEntity();
   if (isTektonCIAvailable(entity)) {
     return (

--- a/plugins/tekton/src/components/Table/Table.tsx
+++ b/plugins/tekton/src/components/Table/Table.tsx
@@ -1,19 +1,19 @@
-import * as React from 'react';
-import { findIndex } from 'lodash';
 import {
-  Table as PfTable,
-  TableHeader,
-  TableGridBreakpoint,
   OnSelect,
+  Table as PfTable,
+  TableGridBreakpoint,
+  TableHeader,
 } from '@patternfly/react-table';
 import {
   AutoSizer,
   WindowScroller,
 } from '@patternfly/react-virtualized-extension';
 import { Scroll } from '@patternfly/react-virtualized-extension/dist/esm/components/Virtualized/types';
-import { VirtualBody } from './VirtualBody';
+import { findIndex } from 'lodash';
+import * as React from 'react';
 import { useTableData } from '../../hooks/useTableData';
 import { WithScrollContainer } from '../../utils/WithScrollContainer';
+import { VirtualBody } from './VirtualBody';
 
 type HeaderFunc = () => any[];
 
@@ -31,7 +31,7 @@ type TableProps<D = any, C = any> = Partial<D> & {
   onSelect?: OnSelect;
 };
 
-export const Table: React.FC<TableProps> = ({
+export const Table = ({
   header,
   Row,
   customData,
@@ -44,7 +44,7 @@ export const Table: React.FC<TableProps> = ({
   scrollElement,
   gridBreakPoint = TableGridBreakpoint.none,
   onSelect,
-}) => {
+}: TableProps) => {
   const [sortBy, setSortBy] = React.useState({});
   const [currentSortField, setCurrentSortField] =
     React.useState(defaultSortField);

--- a/plugins/tekton/src/components/Table/TableRow.tsx
+++ b/plugins/tekton/src/components/Table/TableRow.tsx
@@ -9,14 +9,14 @@ type TableRowProps = {
   className?: string;
 };
 
-export const TableRow: React.FC<TableRowProps> = ({
+export const TableRow = ({
   id,
   index,
   trKey,
   style,
   className,
   ...props
-}) => {
+}: React.PropsWithChildren<TableRowProps>) => {
   return (
     <tr
       {...props}

--- a/plugins/tekton/src/components/Table/VirtualBody.tsx
+++ b/plugins/tekton/src/components/Table/VirtualBody.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import { CellMeasurerCache, CellMeasurer } from 'react-virtualized';
 import { VirtualTableBody } from '@patternfly/react-virtualized-extension';
 import { Scroll } from '@patternfly/react-virtualized-extension/dist/esm/components/Virtualized/types';
+import * as React from 'react';
+import { CellMeasurer, CellMeasurerCache } from 'react-virtualized';
 import { MeasuredCellParent } from 'react-virtualized/dist/es/CellMeasurer';
 import { TableRow } from './TableRow';
 
@@ -32,7 +32,7 @@ export const RowMemo = React.memo<
   RowFunctionArgs & { Row: React.FC<RowFunctionArgs> }
 >(({ Row, ...props }) => <Row {...props} />);
 
-export const VirtualBody: React.FC<VirtualBodyProps> = props => {
+export const VirtualBody = (props: VirtualBodyProps) => {
   const {
     customData,
     Row,

--- a/plugins/tekton/src/components/common/CamelCaseWrap.tsx
+++ b/plugins/tekton/src/components/common/CamelCaseWrap.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 const MEMO: { [key: string]: any } = {};
 
-const CamelCaseWrap: React.FC<CamelCaseWrapProps> = ({ value, dataTest }) => {
+const CamelCaseWrap = ({ value, dataTest }: CamelCaseWrapProps) => {
   if (!value) {
     return '-';
   }

--- a/plugins/tekton/src/components/common/ClusterSelector.tsx
+++ b/plugins/tekton/src/components/common/ClusterSelector.tsx
@@ -1,8 +1,8 @@
+import { Select, SelectedItems } from '@backstage/core-components';
 import * as React from 'react';
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
-import { Select, SelectedItems } from '@backstage/core-components';
 
-export const ClusterSelector: React.FC = () => {
+export const ClusterSelector = () => {
   const {
     clusters: k8sClusters,
     selectedCluster,

--- a/plugins/tekton/src/components/common/ErrorPanel.tsx
+++ b/plugins/tekton/src/components/common/ErrorPanel.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
 import { WarningPanel } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { Typography } from '@material-ui/core';
+import * as React from 'react';
 import { ClusterError, ClusterErrors } from '../../types/types';
 
-export const ErrorPanel: React.FC<{ allErrors: ClusterErrors }> = ({
-  allErrors,
-}) => {
+type ErrorPanelProps = { allErrors: ClusterErrors };
+
+export const ErrorPanel = ({ allErrors }: ErrorPanelProps) => {
   const {
     entity: {
       metadata: { name: entityName },

--- a/plugins/tekton/src/components/common/ResourceStatus.tsx
+++ b/plugins/tekton/src/components/common/ResourceStatus.tsx
@@ -1,13 +1,12 @@
-import * as React from 'react';
 import { Badge } from '@patternfly/react-core';
 import classNames from 'classnames';
+import * as React from 'react';
 
 import './ResourceStatus.css';
 
 type ResourceStatusProps = {
   additionalClassNames?: string;
   badgeAlt?: boolean;
-  children: React.ReactNode;
 };
 
 /**
@@ -24,11 +23,11 @@ type ResourceStatusProps = {
  * )
  * ```
  */
-export const ResourceStatus: React.FC<ResourceStatusProps> = ({
+export const ResourceStatus = ({
   additionalClassNames,
   badgeAlt,
   children,
-}) => {
+}: React.PropsWithChildren<ResourceStatusProps>) => {
   return (
     <span
       className={classNames('bs-tkn-resource-status', additionalClassNames)}

--- a/plugins/tekton/src/components/common/Status.tsx
+++ b/plugins/tekton/src/components/common/Status.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   BanIcon,
   ClipboardListIcon,
@@ -8,6 +7,7 @@ import {
   SyncAltIcon,
   UnknownIcon,
 } from '@patternfly/react-icons';
+import * as React from 'react';
 import StatusIconAndText from './StatusIconAndText';
 import {
   GreenCheckCircleIcon,
@@ -25,7 +25,6 @@ export type StatusComponentProps = {
 
 export type StatusProps = StatusComponentProps & {
   status: string;
-  children?: React.ReactNode;
 };
 
 const DASH = '-';
@@ -44,13 +43,13 @@ const DASH = '-';
  * <Status status='Warning' />
  * ```
  */
-export const Status: React.FC<StatusProps> = ({
+export const Status = ({
   status,
   title,
   iconOnly,
   noTooltip,
   className,
-}) => {
+}: React.PropsWithChildren<StatusProps>) => {
   const statusProps = {
     title: title || status,
     iconOnly,

--- a/plugins/tekton/src/components/common/StatusIcon.tsx
+++ b/plugins/tekton/src/components/common/StatusIcon.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import classNames from 'classnames';
 import {
   AngleDoubleRightIcon,
   CheckCircleIcon,
@@ -8,8 +6,10 @@ import {
   HourglassHalfIcon,
   SyncAltIcon,
 } from '@patternfly/react-icons';
-import { YellowExclamationTriangleIcon } from './icons';
+import classNames from 'classnames';
+import * as React from 'react';
 import { ComputedStatus } from '../../types/computedStatus';
+import { YellowExclamationTriangleIcon } from './icons';
 
 interface StatusIconProps {
   status: string;
@@ -18,11 +18,11 @@ interface StatusIconProps {
   disableSpin?: boolean;
 }
 
-export const StatusIcon: React.FC<StatusIconProps> = ({
+export const StatusIcon = ({
   status,
   disableSpin,
   ...props
-}) => {
+}: StatusIconProps) => {
   switch (status) {
     case ComputedStatus['In Progress']:
     case ComputedStatus.Running:
@@ -48,7 +48,7 @@ export const StatusIcon: React.FC<StatusIconProps> = ({
       return <HourglassHalfIcon {...props} />;
 
     case ComputedStatus.Cancelled:
-      return <YellowExclamationTriangleIcon {...props} />;
+      return <YellowExclamationTriangleIcon />;
 
     case ComputedStatus.Skipped:
       return <AngleDoubleRightIcon {...props} />;

--- a/plugins/tekton/src/components/common/StatusIconAndText.tsx
+++ b/plugins/tekton/src/components/common/StatusIconAndText.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import classNames from 'classnames';
+import * as React from 'react';
 import CamelCaseWrap from './CamelCaseWrap';
 
 import './StatusIconAndText.css';
@@ -29,14 +29,14 @@ const DASH = '-';
  * <StatusIconAndText title={title} icon={renderIcon} />
  * ```
  */
-const StatusIconAndText: React.FC<StatusIconAndTextProps> = ({
+const StatusIconAndText = ({
   icon,
   title,
   spin,
   iconOnly,
   noTooltip,
   className,
-}) => {
+}: StatusIconAndTextProps) => {
   if (!title) {
     return <>{DASH}</>;
   }

--- a/plugins/tekton/src/components/common/icons.tsx
+++ b/plugins/tekton/src/components/common/icons.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
 import {
   CheckCircleIcon,
-  InfoCircleIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
+  InfoCircleIcon,
 } from '@patternfly/react-icons';
 import classNames from 'classnames';
+import * as React from 'react';
 
 import './icons.css';
 
@@ -25,11 +25,11 @@ export type ColoredIconProps = {
  * <GreenCheckCircleIcon title="Healthy" />
  * ```
  */
-export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({
+export const GreenCheckCircleIcon = ({
   className,
   title,
   size,
-}) => (
+}: ColoredIconProps) => (
   <CheckCircleIcon
     data-test="success-icon"
     size={size}
@@ -48,11 +48,11 @@ export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({
  * <RedExclamationCircleIcon title="Failed" />
  * ```
  */
-export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({
+export const RedExclamationCircleIcon = ({
   className,
   title,
   size,
-}) => (
+}: ColoredIconProps) => (
   <ExclamationCircleIcon
     size={size}
     className={classNames('icons__red-exclamation-icon', className)}
@@ -70,11 +70,11 @@ export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({
  * <YellowExclamationTriangleIcon title="Warning" />
  * ```
  */
-export const YellowExclamationTriangleIcon: React.FC<ColoredIconProps> = ({
+export const YellowExclamationTriangleIcon = ({
   className,
   title,
   size,
-}) => (
+}: ColoredIconProps) => (
   <ExclamationTriangleIcon
     size={size}
     className={classNames('icons__yellow-exclamation-icon', className)}
@@ -92,10 +92,7 @@ export const YellowExclamationTriangleIcon: React.FC<ColoredIconProps> = ({
  * <BlueInfoCircleIcon title="Info" />
  * ```
  */
-export const BlueInfoCircleIcon: React.FC<ColoredIconProps> = ({
-  className,
-  title,
-}) => (
+export const BlueInfoCircleIcon = ({ className, title }: ColoredIconProps) => (
   <InfoCircleIcon
     className={classNames('icons__blue-info-icon', className)}
     title={title}

--- a/plugins/tekton/src/components/pipeline-topology/LatestPipelineRunVisualization.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/LatestPipelineRunVisualization.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
-import { PipelineVisualization } from './PipelineVisualization';
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
-import { ModelsPlural } from '../../models';
 import { useTektonObjectsResponse } from '../../hooks/useTektonObjectsResponse';
+import { ModelsPlural } from '../../models';
+import { PipelineVisualization } from './PipelineVisualization';
 
 type LatestPipelineRunVisualizationProps = {
   linkTekton?: boolean;
   url?: string;
 };
 
-export const LatestPipelineRunVisualization: React.FC<
-  LatestPipelineRunVisualizationProps
-> = ({ linkTekton, url }) => {
+export const LatestPipelineRunVisualization = ({
+  linkTekton,
+  url,
+}: LatestPipelineRunVisualizationProps) => {
   const watchedResources = [ModelsPlural.pipelineruns, ModelsPlural.taskruns];
   const tektonResourcesContextData = useTektonObjectsResponse(watchedResources);
 

--- a/plugins/tekton/src/components/pipeline-topology/PipelineLayout.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/PipelineLayout.tsx
@@ -1,36 +1,36 @@
+import '@patternfly/react-styles/css/components/Topology/topology-components.css';
+import {
+  Controller,
+  EdgeModel,
+  GRAPH_LAYOUT_END_EVENT,
+  GRAPH_POSITION_CHANGE_EVENT,
+  GraphModel,
+  Node,
+  NodeModel,
+  Rect,
+  TopologyControlBar,
+  TopologyView,
+  Visualization,
+  VisualizationProvider,
+  VisualizationSurface,
+  action,
+  createTopologyControlButtons,
+  defaultControlButtonsOptions,
+} from '@patternfly/react-topology';
 import React from 'react';
 import Measure from 'react-measure';
 import {
-  Visualization,
-  VisualizationProvider,
-  TopologyView,
-  VisualizationSurface,
-  GRAPH_LAYOUT_END_EVENT,
-  action,
-  GRAPH_POSITION_CHANGE_EVENT,
-  GraphModel,
-  EdgeModel,
-  defaultControlButtonsOptions,
-  createTopologyControlButtons,
-  TopologyControlBar,
-  Controller,
-  NodeModel,
-  Node,
-  Rect,
-} from '@patternfly/react-topology';
-import '@patternfly/react-styles/css/components/Topology/topology-components.css';
+  DROP_SHADOW_SPACING,
+  GRAPH_MIN_WIDTH,
+  NODE_HEIGHT,
+  PipelineLayout as PipelineLayoutTypes,
+  TOOLBAR_HEIGHT,
+} from '../../consts/pipeline-topology-const';
 import { PipelineMixedNodeModel } from '../../types/pipeline-topology-types';
+import { getLayoutData } from '../../utils/pipeline-topology-utils';
 import pipelineComponentFactory, {
   layoutFactory,
 } from './pipelineComponentFactory';
-import { getLayoutData } from '../../utils/pipeline-topology-utils';
-import {
-  PipelineLayout as PipelineLayoutTypes,
-  DROP_SHADOW_SPACING,
-  NODE_HEIGHT,
-  TOOLBAR_HEIGHT,
-  GRAPH_MIN_WIDTH,
-} from '../../consts/pipeline-topology-const';
 
 type PipelineLayoutProps = {
   model: {
@@ -40,7 +40,7 @@ type PipelineLayoutProps = {
   };
 };
 
-export const PipelineLayout: React.FC<PipelineLayoutProps> = ({ model }) => {
+export const PipelineLayout = ({ model }: PipelineLayoutProps) => {
   const [vis, setVis] = React.useState<Controller | null>(null);
   const [width, setWidth] = React.useState<number>(0);
   const [maxSize, setMaxSize] = React.useState<{

--- a/plugins/tekton/src/components/pipeline-topology/PipelineTaskNode.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/PipelineTaskNode.tsx
@@ -1,29 +1,29 @@
-import * as React from 'react';
-// eslint-disable-next-line @backstage/no-undeclared-imports
-import { observer } from 'mobx-react';
 import { Tooltip } from '@patternfly/react-core';
 import {
   DEFAULT_LAYER,
   DEFAULT_WHEN_OFFSET,
+  GraphElement,
   Layer,
   Node,
+  RunStatus,
   ScaleDetailsLevel,
-  TaskNode,
   TOP_LAYER,
-  useDetailsLevel,
-  useHover,
+  TaskNode,
   WhenDecorator,
   WithContextMenuProps,
   WithSelectionProps,
-  GraphElement,
-  RunStatus,
+  useDetailsLevel,
+  useHover,
 } from '@patternfly/react-topology';
+import * as React from 'react';
+// eslint-disable-next-line @backstage/no-undeclared-imports
+import { observer } from 'mobx-react';
+import { NodeType } from '../../consts/pipeline-topology-const';
 import { PipelineTaskWithStatus } from '../../types/pipelineRun';
 import { StepStatus } from '../../types/taskRun';
+import { createStepStatus } from '../../utils/pipeline-step-utils';
 import { getTaskStatus } from '../../utils/pipelineRun-utils';
 import { PipelineVisualizationStepList } from './PipelineVisualizationStepList';
-import { createStepStatus } from '../../utils/pipeline-step-utils';
-import { NodeType } from '../../consts/pipeline-topology-const';
 
 import './PipelineTaskNode.css';
 
@@ -33,12 +33,12 @@ type PipelineTaskNodeProps = {
   WithSelectionProps &
   GraphElement;
 
-const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
+const PipelineTaskNode = ({
   element,
   onContextMenu,
   contextMenuOpen,
   ...rest
-}) => {
+}: PipelineTaskNodeProps) => {
   const data = element.getData();
   const [hover, hoverRef] = useHover();
   const detailsLevel = useDetailsLevel();

--- a/plugins/tekton/src/components/pipeline-topology/PipelineVisualization.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/PipelineVisualization.tsx
@@ -1,23 +1,23 @@
-import React from 'react';
-import { isEmpty } from 'lodash';
-import { useEntity } from '@backstage/plugin-catalog-react';
-import { Split, SplitItem } from '@patternfly/react-core';
-import { Typography } from '@material-ui/core';
 import {
   BottomLinkProps,
   EmptyState,
   InfoCard,
   Progress,
 } from '@backstage/core-components';
-import { ResourceStatus, Status, ErrorPanel, ClusterSelector } from '../common';
-import { pipelineRunStatus } from '../../utils/pipeline-filter-reducer';
-import { PipelineLayout } from './PipelineLayout';
-import { useDarkTheme } from '../../hooks/useDarkTheme';
-import { getGraphDataModel } from '../../utils/pipeline-topology-utils';
-import { PipelineRunModel } from '../../models';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { Typography } from '@material-ui/core';
+import { Split, SplitItem } from '@patternfly/react-core';
+import { isEmpty } from 'lodash';
+import React from 'react';
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
-import { getLatestPipelineRun } from '../../utils/pipelineRun-utils';
+import { useDarkTheme } from '../../hooks/useDarkTheme';
+import { PipelineRunModel } from '../../models';
 import { ClusterErrors } from '../../types/types';
+import { pipelineRunStatus } from '../../utils/pipeline-filter-reducer';
+import { getGraphDataModel } from '../../utils/pipeline-topology-utils';
+import { getLatestPipelineRun } from '../../utils/pipelineRun-utils';
+import { ClusterSelector, ErrorPanel, ResourceStatus, Status } from '../common';
+import { PipelineLayout } from './PipelineLayout';
 
 import './PipelineVisualization.css';
 
@@ -26,15 +26,16 @@ type PipelineVisualizationProps = {
   url?: string;
 };
 
+type WrapperInfoCardProps = {
+  allErrors?: ClusterErrors;
+  footerLink?: BottomLinkProps;
+};
+
 const WrapperInfoCard = ({
   children,
   allErrors,
   footerLink,
-}: {
-  children: React.ReactNode;
-  allErrors?: ClusterErrors;
-  footerLink?: BottomLinkProps;
-}) => (
+}: React.PropsWithChildren<WrapperInfoCardProps>) => (
   <>
     {allErrors && allErrors.length > 0 && <ErrorPanel allErrors={allErrors} />}
     <InfoCard
@@ -47,10 +48,10 @@ const WrapperInfoCard = ({
   </>
 );
 
-export const PipelineVisualization: React.FC<PipelineVisualizationProps> = ({
+export const PipelineVisualization = ({
   linkTekton = true,
   url,
-}) => {
+}: PipelineVisualizationProps) => {
   useDarkTheme();
   const { loaded, responseError, watchResourcesData, selectedClusterErrors } =
     React.useContext(TektonResourcesContext);

--- a/plugins/tekton/src/components/pipeline-topology/PipelineVisualizationStepList.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/PipelineVisualizationStepList.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
-import classNames from 'classnames';
 import { RunStatus } from '@patternfly/react-topology';
-import { StatusIcon } from '../common';
+import classNames from 'classnames';
+import * as React from 'react';
 import { StepStatus } from '../../types/taskRun';
 import { getRunStatusColor } from '../../utils/tekton-status';
+import { StatusIcon } from '../common';
 
 import './PipelineVisualizationStepList.css';
 
@@ -19,9 +19,9 @@ type TooltipColoredStatusIconProps = {
   status: RunStatus;
 };
 
-const TooltipColoredStatusIcon: React.FC<TooltipColoredStatusIconProps> = ({
+const TooltipColoredStatusIcon = ({
   status,
-}) => {
+}: TooltipColoredStatusIconProps) => {
   const size = 18;
   const sharedProps = {
     height: size,
@@ -51,9 +51,13 @@ const TooltipColoredStatusIcon: React.FC<TooltipColoredStatusIconProps> = ({
   return icon;
 };
 
-export const PipelineVisualizationStepList: React.FC<
-  PipelineVisualizationStepListProps
-> = ({ isSpecOverview, taskName, steps, isFinallyTask, hideHeader }) => {
+export const PipelineVisualizationStepList = ({
+  isSpecOverview,
+  taskName,
+  steps,
+  isFinallyTask,
+  hideHeader,
+}: PipelineVisualizationStepListProps) => {
   return (
     <div className="bs-tkn-pipeline-visualization-step-list">
       {!hideHeader && (

--- a/plugins/tekton/src/components/pipeline-topology/TaskGroupEdge.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/TaskGroupEdge.tsx
@@ -1,14 +1,14 @@
+import { Edge, TaskEdge } from '@patternfly/react-topology';
 import * as React from 'react';
 // eslint-disable-next-line @backstage/no-undeclared-imports
 import { observer } from 'mobx-react';
-import { Edge, TaskEdge } from '@patternfly/react-topology';
 import { GROUPED_PIPELINE_NODE_SEPARATION_HORIZONTAL } from '../../consts/pipeline-topology-const';
 
 interface TaskEdgeProps {
   element: Edge;
 }
 
-const TaskGroupEdge: React.FunctionComponent<TaskEdgeProps> = props => (
+const TaskGroupEdge = (props: TaskEdgeProps) => (
   <TaskEdge
     nodeSeparation={GROUPED_PIPELINE_NODE_SEPARATION_HORIZONTAL}
     {...props}

--- a/plugins/tekton/src/utils/WithScrollContainer.tsx
+++ b/plugins/tekton/src/utils/WithScrollContainer.tsx
@@ -25,9 +25,7 @@ export const getParentScrollableElement = (node: HTMLElement) => {
   return undefined;
 };
 
-export const WithScrollContainer: React.FC<WithScrollContainerProps> = ({
-  children,
-}) => {
+export const WithScrollContainer = ({ children }: WithScrollContainerProps) => {
   const [scrollContainer, setScrollContainer] = React.useState<HTMLElement>();
   const ref = React.useCallback(node => {
     if (node) {

--- a/plugins/topology/src/common/components/CamelCaseWrap.tsx
+++ b/plugins/topology/src/common/components/CamelCaseWrap.tsx
@@ -7,7 +7,7 @@ type CamelCaseWrapProps = {
   dataTest?: string;
 };
 
-const CamelCaseWrap: React.FC<CamelCaseWrapProps> = ({ value, dataTest }) => {
+const CamelCaseWrap = ({ value, dataTest }: CamelCaseWrapProps) => {
   if (!value) {
     return '-';
   }

--- a/plugins/topology/src/common/components/ResourceName.tsx
+++ b/plugins/topology/src/common/components/ResourceName.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
 import classNames from 'classnames';
-import { kindToAbbr } from '../utils/getResources';
-import { resourceModels } from '../../models';
+import * as React from 'react';
 import { MEMO } from '../../const';
+import { resourceModels } from '../../models';
+import { kindToAbbr } from '../utils/getResources';
 
 import './ResourceName.css';
 
@@ -11,10 +11,7 @@ export type ResourceIconProps = {
   kind: string;
 };
 
-export const ResourceIcon: React.FunctionComponent<ResourceIconProps> = ({
-  className,
-  kind,
-}) => {
+export const ResourceIcon = ({ className, kind }: ResourceIconProps) => {
   // if no kind, return null so an empty icon isn't rendered
   if (!kind) {
     return null;
@@ -51,11 +48,7 @@ export type ResourceNameProps = {
   large?: boolean;
 };
 
-export const ResourceName: React.FunctionComponent<ResourceNameProps> = ({
-  kind,
-  name,
-  large,
-}) => (
+export const ResourceName = ({ kind, name, large }: ResourceNameProps) => (
   <span className="bs-topology-resource-item">
     <ResourceIcon
       kind={kind}

--- a/plugins/topology/src/common/components/ResourceStatus.tsx
+++ b/plugins/topology/src/common/components/ResourceStatus.tsx
@@ -1,13 +1,12 @@
-import * as React from 'react';
 import { Badge } from '@patternfly/react-core';
 import classNames from 'classnames';
+import * as React from 'react';
 
 import './ResourceStatus.css';
 
 type ResourceStatusProps = {
   additionalClassNames?: string;
   badgeAlt?: boolean;
-  children: React.ReactNode;
   noStatusBackground?: boolean;
 };
 
@@ -25,12 +24,12 @@ type ResourceStatusProps = {
  * )
  * ```
  */
-const ResourceStatus: React.FC<ResourceStatusProps> = ({
+const ResourceStatus = ({
   additionalClassNames,
   badgeAlt,
   children,
   noStatusBackground,
-}) => {
+}: React.PropsWithChildren<ResourceStatusProps>) => {
   return (
     <span
       className={classNames(

--- a/plugins/topology/src/common/components/Status.tsx
+++ b/plugins/topology/src/common/components/Status.tsx
@@ -1,16 +1,15 @@
-import * as React from 'react';
 import {
   BanIcon,
   HourglassHalfIcon,
   SyncAltIcon,
   UnknownIcon,
 } from '@patternfly/react-icons';
+import * as React from 'react';
 import StatusIconAndText from './StatusIconAndText';
 import { GreenCheckCircleIcon, RedExclamationCircleIcon } from './icons';
 
 type StatusProps = {
   status: string;
-  children?: React.ReactNode;
 };
 
 const DASH = '-';
@@ -18,13 +17,12 @@ const DASH = '-';
 /**
  * Component for displaying a status message
  * @param {string} status - type of status to be displayed
- * * @param {ReactNode} [children] - (optional) children for the component
  * @example
  * ```tsx
  * <Status status='Warning' />
  * ```
  */
-const Status: React.FC<StatusProps> = ({ status, children }) => {
+const Status = ({ status }: StatusProps) => {
   const statusProps = {
     title: status,
   };
@@ -46,9 +44,10 @@ const Status: React.FC<StatusProps> = ({ status, children }) => {
     case 'Failed':
     case 'ImagePullBackOff':
       return (
-        <StatusIconAndText {...statusProps} icon={<RedExclamationCircleIcon />}>
-          {children}
-        </StatusIconAndText>
+        <StatusIconAndText
+          {...statusProps}
+          icon={<RedExclamationCircleIcon />}
+        />
       );
 
     case 'Succeeded':

--- a/plugins/topology/src/common/components/StatusIconAndText.tsx
+++ b/plugins/topology/src/common/components/StatusIconAndText.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import classNames from 'classnames';
+import * as React from 'react';
 import CamelCaseWrap from './CamelCaseWrap';
 
 import './StatusIconAndText.css';
@@ -19,10 +19,7 @@ const DASH = '-';
  * <StatusIconAndText icon={renderIcon} />
  * ```
  */
-const StatusIconAndText: React.FC<StatusIconAndTextProps> = ({
-  icon,
-  title,
-}) => {
+const StatusIconAndText = ({ icon, title }: StatusIconAndTextProps) => {
   if (!title) {
     return <>{DASH}</>;
   }

--- a/plugins/topology/src/common/components/icons.tsx
+++ b/plugins/topology/src/common/components/icons.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
 } from '@patternfly/react-icons';
 import classNames from 'classnames';
+import * as React from 'react';
 
 import './icons.css';
 
@@ -13,11 +13,11 @@ export type ColoredIconProps = {
   size?: 'sm' | 'md' | 'lg' | 'xl';
 };
 
-export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({
+export const GreenCheckCircleIcon = ({
   className,
   title,
   size,
-}) => (
+}: ColoredIconProps) => (
   <CheckCircleIcon
     data-test="success-icon"
     size={size}
@@ -26,11 +26,11 @@ export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({
   />
 );
 
-export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({
+export const RedExclamationCircleIcon = ({
   className,
   title,
   size,
-}) => (
+}: ColoredIconProps) => (
   <ExclamationCircleIcon
     size={size}
     className={classNames('bs-topology-icons__red-exclamation-icon', className)}

--- a/plugins/topology/src/components/Graph/BaseNode.tsx
+++ b/plugins/topology/src/components/Graph/BaseNode.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import classNames from 'classnames';
 import {
   BadgeLocation,
   DEFAULT_LAYER,
@@ -7,14 +5,16 @@ import {
   Layer,
   Node,
   NodeStatus,
-  observer,
   ScaleDetailsLevel,
   TOP_LAYER,
-  useCombineRefs,
   WithDragNodeProps,
   WithSelectionProps,
+  observer,
+  useCombineRefs,
   useHover,
 } from '@patternfly/react-topology';
+import classNames from 'classnames';
+import * as React from 'react';
 import { getKindAbbrColor } from '../../utils/workload-node-utils';
 
 import './BaseNode.css';
@@ -32,7 +32,6 @@ type BaseNodeProps = {
   badgeBorderColor?: string;
   badgeClassName?: string;
   badgeLocation?: BadgeLocation;
-  children?: React.ReactNode;
   attachments?: React.ReactNode;
   element: Node;
   hoverRef?: (node: Element) => () => void;
@@ -43,7 +42,7 @@ type BaseNodeProps = {
 } & Partial<WithSelectionProps> &
   Partial<WithDragNodeProps>;
 
-const BaseNode: React.FC<BaseNodeProps> = ({
+const BaseNode = ({
   className,
   innerRadius = 10,
   icon,
@@ -53,7 +52,7 @@ const BaseNode: React.FC<BaseNodeProps> = ({
   children,
   alertVariant,
   ...rest
-}) => {
+}: React.PropsWithChildren<BaseNodeProps>) => {
   const [hover, internalHoverRef] = useHover();
   const nodeHoverRefs = useCombineRefs(
     internalHoverRef,

--- a/plugins/topology/src/components/Graph/DefaultGraph.tsx
+++ b/plugins/topology/src/components/Graph/DefaultGraph.tsx
@@ -1,23 +1,20 @@
-import * as React from 'react';
 import {
-  GraphElement,
   Graph,
-  observer,
   GraphComponent,
-  isGraph,
+  GraphElement,
   WithPanZoomProps,
   WithSelectionProps,
+  isGraph,
+  observer,
 } from '@patternfly/react-topology';
+import * as React from 'react';
 
 type DefaultGraphProps = {
   element?: GraphElement;
 } & Partial<WithPanZoomProps> &
   Partial<WithSelectionProps>;
 
-const DefaultGraph: React.FunctionComponent<DefaultGraphProps> = ({
-  element,
-  ...rest
-}) => {
+const DefaultGraph = ({ element, ...rest }: DefaultGraphProps) => {
   if (!isGraph) {
     return null;
   }

--- a/plugins/topology/src/components/Graph/EdgeConnect.tsx
+++ b/plugins/topology/src/components/Graph/EdgeConnect.tsx
@@ -1,21 +1,18 @@
-import * as React from 'react';
-// eslint-disable-next-line @backstage/no-undeclared-imports
-import { observer } from 'mobx-react';
 import {
   DefaultEdge,
   GraphElement,
   isEdge,
   WithSelectionProps,
 } from '@patternfly/react-topology';
+import * as React from 'react';
+// eslint-disable-next-line @backstage/no-undeclared-imports
+import { observer } from 'mobx-react';
 
 type EdgeConnectProps = {
   element?: GraphElement;
 } & Partial<WithSelectionProps>;
 
-const EdgeConnect: React.FunctionComponent<EdgeConnectProps> = ({
-  element,
-  ...rest
-}) =>
+const EdgeConnect = ({ element, ...rest }: EdgeConnectProps) =>
   !element || !isEdge(element) ? null : (
     <DefaultEdge element={element} {...rest} />
   );

--- a/plugins/topology/src/components/Graph/GroupNode.tsx
+++ b/plugins/topology/src/components/Graph/GroupNode.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   DefaultGroup,
   GraphElement,
@@ -9,15 +8,13 @@ import {
   WithDragNodeProps,
   WithSelectionProps,
 } from '@patternfly/react-topology';
+import * as React from 'react';
 
 type GroupNodeProps = {
   element?: GraphElement;
 } & Partial<WithSelectionProps & WithDragNodeProps>;
 
-const GroupNode: React.FunctionComponent<GroupNodeProps> = ({
-  element,
-  ...rest
-}) => {
+const GroupNode = ({ element, ...rest }: GroupNodeProps) => {
   const detailsLevel = useDetailsLevel();
 
   if (!element || !isNode(element)) {

--- a/plugins/topology/src/components/Graph/WorkloadNode.tsx
+++ b/plugins/topology/src/components/Graph/WorkloadNode.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   getDefaultShapeDecoratorCenter,
   GraphElement,
@@ -13,10 +12,11 @@ import {
   WithDragNodeProps,
   WithSelectionProps,
 } from '@patternfly/react-topology';
-import BaseNode from './BaseNode';
-import PodSet, { podSetInnerRadius } from '../Pods/PodSet';
-import { AllPodStatus } from '../Pods/pod';
+import * as React from 'react';
 import { calculateRadius, getPodStatus } from '../../utils/workload-node-utils';
+import { AllPodStatus } from '../Pods/pod';
+import PodSet, { podSetInnerRadius } from '../Pods/PodSet';
+import BaseNode from './BaseNode';
 import { UrlDecorator } from './decorators/UrlDecorator';
 
 import './WorkloadNode.css';
@@ -57,8 +57,8 @@ type InnerWorkloadNodeProps = {
   element: Node;
 } & Partial<WithSelectionProps & WithDragNodeProps>;
 
-const InnerWorkloadNode: React.FC<InnerWorkloadNodeProps> = observer(
-  ({ element, onSelect, ...rest }) => {
+const InnerWorkloadNode = observer(
+  ({ element, onSelect, ...rest }: InnerWorkloadNodeProps) => {
     const data = element.getData();
     const { width, height } = element.getDimensions();
     const workloadData = data.data;
@@ -125,7 +125,7 @@ type WorkloadNodeProps = {
   element?: GraphElement;
 } & Partial<WithSelectionProps & WithDragNodeProps>;
 
-const WorkloadNode: React.FC<WorkloadNodeProps> = ({ element, ...rest }) =>
+const WorkloadNode = ({ element, ...rest }: WorkloadNodeProps) =>
   !element || !isNode(element) ? null : (
     <InnerWorkloadNode element={element} {...rest} />
   );

--- a/plugins/topology/src/components/Graph/decorators/Decorator.tsx
+++ b/plugins/topology/src/components/Graph/decorators/Decorator.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { Decorator as PfDecorator } from '@patternfly/react-topology';
+import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import './Decorator.css';
@@ -15,7 +15,7 @@ type DecoratorTypes = {
   circleRef?: React.Ref<SVGCircleElement>;
 };
 
-const Decorator: React.FunctionComponent<DecoratorTypes> = ({
+const Decorator = ({
   x,
   y,
   radius,
@@ -23,7 +23,7 @@ const Decorator: React.FunctionComponent<DecoratorTypes> = ({
   ariaLabel,
   external,
   ...rest
-}) => {
+}: DecoratorTypes) => {
   const decorator = (
     <PfDecorator
       x={x}

--- a/plugins/topology/src/components/Graph/decorators/Decorator.tsx
+++ b/plugins/topology/src/components/Graph/decorators/Decorator.tsx
@@ -23,7 +23,7 @@ const Decorator = ({
   ariaLabel,
   external,
   ...rest
-}: DecoratorTypes) => {
+}: React.PropsWithChildren<DecoratorTypes>) => {
   const decorator = (
     <PfDecorator
       x={x}

--- a/plugins/topology/src/components/Graph/decorators/UrlDecorator.tsx
+++ b/plugins/topology/src/components/Graph/decorators/UrlDecorator.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import Decorator from './Decorator';
 
 interface DefaultDecoratorProps {
@@ -10,12 +10,7 @@ interface DefaultDecoratorProps {
   y: number;
 }
 
-export const UrlDecorator: React.FC<DefaultDecoratorProps> = ({
-  url,
-  radius,
-  x,
-  y,
-}) => {
+export const UrlDecorator = ({ url, radius, x, y }: DefaultDecoratorProps) => {
   if (!url) {
     return null;
   }

--- a/plugins/topology/src/components/Pods/PodSet.tsx
+++ b/plugins/topology/src/components/Pods/PodSet.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import PodStatus from './PodStatus';
+import { PodRCData } from '../../types/pods';
+import { usePodRingLabel } from '../../utils/pod-ring-utils';
 import {
   calculateRadius,
   getPodData,
   podDataInProgress,
 } from '../../utils/workload-node-utils';
-import { usePodRingLabel } from '../../utils/pod-ring-utils';
-import { PodRCData } from '../../types/pods';
+import PodStatus from './PodStatus';
 
 type PodSetProps = {
   size: number;
@@ -60,14 +60,14 @@ export const podSetInnerRadius = (size: number, data?: PodRCData) => {
   return radius - innerStrokeWidth - podStatusInset;
 };
 
-const PodSet: React.FC<PodSetProps> = React.memo(function PodSet({
+const PodSet = React.memo(function PodSet({
   size,
   data,
   x = 0,
   y = 0,
   showPodCount,
   standalone,
-}) {
+}: PodSetProps) {
   const { podStatusOuterRadius, podStatusInnerRadius, podStatusStrokeWidth } =
     calculateRadius(size);
   const { innerPodStatusOuterRadius, innerPodStatusInnerRadius } =

--- a/plugins/topology/src/components/Pods/PodStatus.tsx
+++ b/plugins/topology/src/components/Pods/PodStatus.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react';
 import { ChartDonut } from '@patternfly/react-charts';
 import { Tooltip } from '@patternfly/react-core';
 import * as _ from 'lodash';
+import * as React from 'react';
+import { useForceUpdate } from '../../hooks/useForceUpdate';
+import { getSize } from '../../utils/pod-ring-utils';
 import {
   calculateRadius,
-  podStatus,
   getPodStatus,
+  podStatus,
 } from '../../utils/workload-node-utils';
-import { getSize } from '../../utils/pod-ring-utils';
 import { AllPodStatus, podColor } from './pod';
-import { useForceUpdate } from '../../hooks/useForceUpdate';
 
 import './PodStatus.css';
 
@@ -47,7 +47,7 @@ const podStatusIsNumeric = (podStatusValue: string) => {
   );
 };
 
-const PodStatus: React.FC<PodStatusProps> = ({
+const PodStatus = ({
   innerRadius = podStatusInnerRadius,
   outerRadius = podStatusOuterRadius,
   x,
@@ -60,7 +60,7 @@ const PodStatus: React.FC<PodStatusProps> = ({
   titleComponent,
   subTitleComponent,
   data,
-}) => {
+}: PodStatusProps) => {
   const [updateOnEnd, setUpdateOnEnd] = React.useState<boolean>(false);
   const forceUpdate = useForceUpdate();
   const prevVData = React.useRef<PodData[] | null>(null);

--- a/plugins/topology/src/components/Topology/TopologyControlBar.tsx
+++ b/plugins/topology/src/components/Topology/TopologyControlBar.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   action,
   Controller,
@@ -6,14 +5,13 @@ import {
   defaultControlButtonsOptions,
   TopologyControlBar as PfTopologyControlBar,
 } from '@patternfly/react-topology';
+import * as React from 'react';
 
 type TopologyControlBarProps = {
   controller: Controller;
 };
 
-export const TopologyControlBar: React.FC<TopologyControlBarProps> = ({
-  controller,
-}) => (
+export const TopologyControlBar = ({ controller }: TopologyControlBarProps) => (
   <PfTopologyControlBar
     controlButtons={createTopologyControlButtons({
       ...defaultControlButtonsOptions,

--- a/plugins/topology/src/components/Topology/TopologyEmptyState.tsx
+++ b/plugins/topology/src/components/Topology/TopologyEmptyState.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   EmptyState,
   EmptyStateIcon,
@@ -6,8 +5,9 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { TopologyIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 
-export const TopologyEmptyState: React.FC = () => {
+export const TopologyEmptyState = () => {
   return (
     <EmptyState
       variant={EmptyStateVariant.full}

--- a/plugins/topology/src/components/Topology/TopologyErrorPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologyErrorPanel.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react';
 import { WarningPanel } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { Typography } from '@material-ui/core';
+import * as React from 'react';
 import { ClusterError, ClusterErrors } from '../../types/types';
 
 import './TopologyErrorPanel.css';
 
-const TopologyErrorPanel: React.FC<{ allErrors: ClusterErrors }> = ({
-  allErrors,
-}) => {
+type TopologyErrorPanelProps = { allErrors: ClusterErrors };
+
+const TopologyErrorPanel = ({ allErrors }: TopologyErrorPanelProps) => {
   const {
     entity: {
       metadata: { name: entityName },

--- a/plugins/topology/src/components/Topology/TopologySideBar/IngressRules.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/IngressRules.tsx
@@ -1,9 +1,11 @@
-import * as React from 'react';
 import { CodeSnippet } from '@backstage/core-components';
 import { V1Ingress } from '@kubernetes/client-node';
 import jsYaml from 'js-yaml';
+import * as React from 'react';
 
-const IngressRules: React.FC<{ ingress: V1Ingress }> = ({ ingress }) => {
+type IngressRulesProps = { ingress: V1Ingress };
+
+const IngressRules = ({ ingress }: IngressRulesProps) => {
   return <CodeSnippet text={jsYaml.dump(ingress.spec)} language="yaml" />;
 };
 

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDeploymentDetails.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDeploymentDetails.tsx
@@ -1,12 +1,14 @@
-import * as React from 'react';
 import { V1Deployment } from '@kubernetes/client-node';
+import * as React from 'react';
 import TopologySideBarDetailsItem from './TopologySideBarDetailsItem';
 
 import './TopologyDeploymentDetails.css';
 
-const TopologyDeploymentDetails: React.FC<{ resource: V1Deployment }> = ({
+type TopologyDeploymentDetailsProps = { resource: V1Deployment };
+
+const TopologyDeploymentDetails = ({
   resource,
-}) => {
+}: TopologyDeploymentDetailsProps) => {
   return (
     <div
       className="topology-deployment-details"

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.tsx
@@ -1,21 +1,23 @@
-import * as React from 'react';
+import { V1Deployment, V1OwnerReference } from '@kubernetes/client-node';
 import {
   Split,
   SplitItem,
   Timestamp,
   TimestampFormat,
 } from '@patternfly/react-core';
-import PodSet from '../../Pods/PodSet';
-import TopologySideBarDetailsItem from './TopologySideBarDetailsItem';
-import { DeploymentModel } from '../../../models';
-import TopologyDeploymentDetails from './TopologyDeploymentDetails';
-import { V1Deployment, V1OwnerReference } from '@kubernetes/client-node';
 import { BaseNode } from '@patternfly/react-topology';
+import * as React from 'react';
+import { DeploymentModel } from '../../../models';
+import PodSet from '../../Pods/PodSet';
+import TopologyDeploymentDetails from './TopologyDeploymentDetails';
 import TopologyResourceLabels from './TopologyResourceLabels';
+import TopologySideBarDetailsItem from './TopologySideBarDetailsItem';
 
 import './TopologyDetailsTabPanel.css';
 
-const TopologyDetailsTabPanel: React.FC<{ node: BaseNode }> = ({ node }) => {
+type TopologyDetailsTabPanelProps = { node: BaseNode };
+
+const TopologyDetailsTabPanel = ({ node }: TopologyDetailsTabPanelProps) => {
   const { width, height } = node.getDimensions();
   const data = node.getData();
   const resource = data.resource;

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourceLabels.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourceLabels.tsx
@@ -1,12 +1,17 @@
-import * as React from 'react';
 import { Label } from '@patternfly/react-core';
+import * as React from 'react';
 
 import './TopologyResourceLabels.css';
 
-const TopologyResourceLabels: React.FC<{
+type TopologyResourceLabelsProps = {
   labels: { [key: string]: string };
   dataTest?: string;
-}> = ({ labels, dataTest }) => {
+};
+
+const TopologyResourceLabels = ({
+  labels,
+  dataTest,
+}: TopologyResourceLabelsProps) => {
   return (
     <ul className="topology-resource-labels-list" data-testid={dataTest}>
       {Object.keys(labels ?? {}).map((key: string) => (

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
@@ -1,16 +1,20 @@
-import * as React from 'react';
 import { V1Pod, V1Service, V1ServicePort } from '@kubernetes/client-node';
 import { LongArrowAltRightIcon } from '@patternfly/react-icons';
 import { BaseNode } from '@patternfly/react-topology';
+import * as React from 'react';
+import ResourceName from '../../../common/components/ResourceName';
 import ResourceStatus from '../../../common/components/ResourceStatus';
 import Status from '../../../common/components/Status';
 import { IngressModel, PodModel, ServiceModel } from '../../../models';
 import { IngressData } from '../../../types/ingresses';
-import ResourceName from '../../../common/components/ResourceName';
-import TopologyResourcesTabPanelItem from './TopologyResourcesTabPaneltem';
 import IngressRules from './IngressRules';
+import TopologyResourcesTabPanelItem from './TopologyResourcesTabPaneltem';
 
-const TopologyResourcesTabPanel: React.FC<{ node: BaseNode }> = ({ node }) => {
+type TopologyResourcesTabPanelProps = { node: BaseNode };
+
+const TopologyResourcesTabPanel = ({
+  node,
+}: TopologyResourcesTabPanelProps) => {
   const nodeData = node.getData()?.data;
   return (
     <div data-testid="resources-tab">

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPaneltem.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPaneltem.tsx
@@ -2,10 +2,16 @@ import * as React from 'react';
 
 import './TopologyResourcesTabPanelItem.css';
 
-const TopologyResourcesTabPanelItem: React.FC<{
+type TopologyResourcesTabPanelItemProps = {
   resourceLabel: string;
   dataTest?: string;
-}> = ({ resourceLabel, children, dataTest }) => {
+};
+
+const TopologyResourcesTabPanelItem = ({
+  resourceLabel,
+  children,
+  dataTest,
+}: React.PropsWithChildren<TopologyResourcesTabPanelItemProps>) => {
   const emptyState = (
     <span className="topology-text-muted">{`No ${resourceLabel} found for this resource.`}</span>
   );

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBar.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBar.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
 import {
   BaseNode,
   TopologySideBar as PFTopologySideBar,
 } from '@patternfly/react-topology';
+import * as React from 'react';
 import TopologySideBarContent from './TopologySideBarContent';
 
 import './TopologySideBar.css';
@@ -12,7 +12,7 @@ type TopologySideBarProps = {
   onClose: () => void;
 };
 
-const TopologySideBar: React.FC<TopologySideBarProps> = ({ onClose, node }) => {
+const TopologySideBar = ({ onClose, node }: TopologySideBarProps) => {
   return (
     <PFTopologySideBar resizable onClose={onClose}>
       <div className="pf-topology-side-bar__body">

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.tsx
@@ -1,18 +1,17 @@
+import { Divider, Tab, Tabs } from '@material-ui/core';
+import { BaseNode } from '@patternfly/react-topology';
 import * as React from 'react';
-import { Tabs, Tab, Divider } from '@material-ui/core';
 import TopologyDetailsTabPanel from './TopologyDetailsTabPanel';
 import TopologyResourcesTabPanel from './TopologyResourcesTabPanel';
-import { BaseNode } from '@patternfly/react-topology';
 
 import './TopologySideBarBody.css';
 
 interface TabPanelProps {
-  children?: React.ReactNode;
   index: number;
   value: number;
 }
 
-const TabPanel = (props: TabPanelProps) => {
+const TabPanel = (props: React.PropsWithChildren<TabPanelProps>) => {
   const { children, value, index } = props;
 
   return (
@@ -24,7 +23,9 @@ const TabPanel = (props: TabPanelProps) => {
   );
 };
 
-const TopologySideBarBody: React.FC<{ node: BaseNode }> = ({ node }) => {
+type TopologySideBarBodyProps = { node: BaseNode };
+
+const TopologySideBarBody = ({ node }: TopologySideBarBodyProps) => {
   const [value, setValue] = React.useState(0);
   const handleChange = (_event: React.ChangeEvent<{}>, newValue: number) => {
     setValue(newValue);

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarContent.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarContent.tsx
@@ -1,12 +1,14 @@
-import * as React from 'react';
 import { Divider } from '@material-ui/core';
 import { BaseNode } from '@patternfly/react-topology';
+import * as React from 'react';
 import TopologySideBarBody from './TopologySideBarBody';
 import TopologySideBarHeading from './TopologySideBarHeading';
 
 import './TopologySideBarContent.css';
 
-const TopologySideBarContent: React.FC<{ node: BaseNode }> = ({ node }) => {
+type TopologySideBarContentProps = { node: BaseNode };
+
+const TopologySideBarContent = ({ node }: TopologySideBarContentProps) => {
   return (
     <div className="topology-side-bar-content">
       <TopologySideBarHeading resource={node.getData().resource} />

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarDetailsItem.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarDetailsItem.tsx
@@ -2,10 +2,16 @@ import * as React from 'react';
 
 import './TopologySideBarDetailsItem.css';
 
-const TopologySideBarDetailsItem: React.FC<{
+type TopologySideBarDetailsItemProps = {
   label: string;
   emptyText?: string;
-}> = ({ label, children, emptyText }) => {
+};
+
+const TopologySideBarDetailsItem = ({
+  label,
+  children,
+  emptyText,
+}: React.PropsWithChildren<TopologySideBarDetailsItemProps>) => {
   return (
     <div className="topology-side-bar-details-item">
       <dt>{label}</dt>

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarHeading.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarHeading.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react';
 import { Typography } from '@material-ui/core';
 import { Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
+import * as React from 'react';
 import ResourceName from '../../../common/components/ResourceName';
 import { resourceModels } from '../../../models';
 import { K8sWorkloadResource } from '../../../types/types';
 
 import './TopologySideBarHeading.css';
 
-const TopologySideBarHeading: React.FC<{ resource: K8sWorkloadResource }> = ({
-  resource,
-}) => {
+type TopologySideBarHeadingProps = { resource: K8sWorkloadResource };
+
+const TopologySideBarHeading = ({ resource }: TopologySideBarHeadingProps) => {
   const resourceName = resource.metadata?.name;
   const resourceKind = resource.kind ?? '';
   return (

--- a/plugins/topology/src/components/Topology/TopologyToolbar.tsx
+++ b/plugins/topology/src/components/Topology/TopologyToolbar.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react';
 import {
-  ToolbarItem,
   Select,
   SelectOption,
-  SelectVariant,
   SelectOptionObject,
+  SelectVariant,
+  ToolbarItem,
 } from '@patternfly/react-core';
+import * as React from 'react';
 import { K8sResourcesContext } from '../../hooks/K8sResourcesContext';
 
-const TopologyToolbar: React.FC = () => {
+const TopologyToolbar = () => {
   const { clusters: k8sClusters, setSelectedCluster: setClusterContext } =
     React.useContext(K8sResourcesContext);
   const clusterOptions = k8sClusters.map(cluster => ({

--- a/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
+++ b/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
@@ -1,23 +1,23 @@
-import * as React from 'react';
+import { InfoCard, Progress } from '@backstage/core-components';
 import {
   BaseNode,
-  SelectionEventListener,
   SELECTION_EVENT,
+  SelectionEventListener,
   TopologyView,
+  VisualizationSurface,
   useEventListener,
   useVisualizationController,
-  VisualizationSurface,
 } from '@patternfly/react-topology';
-import { InfoCard, Progress } from '@backstage/core-components';
-import { TopologyEmptyState } from './TopologyEmptyState';
-import { useWorkloadsWatcher } from '../../hooks/useWorkloadWatcher';
-import { TopologyControlBar } from './TopologyControlBar';
-import TopologyToolbar from './TopologyToolbar';
-import { K8sResourcesContext } from '../../hooks/K8sResourcesContext';
-import TopologyErrorPanel from './TopologyErrorPanel';
-import { ClusterErrors } from '../../types/types';
-import { useSideBar } from '../../hooks/useSideBar';
+import * as React from 'react';
 import { TYPE_WORKLOAD } from '../../const';
+import { K8sResourcesContext } from '../../hooks/K8sResourcesContext';
+import { useSideBar } from '../../hooks/useSideBar';
+import { useWorkloadsWatcher } from '../../hooks/useWorkloadWatcher';
+import { ClusterErrors } from '../../types/types';
+import { TopologyControlBar } from './TopologyControlBar';
+import { TopologyEmptyState } from './TopologyEmptyState';
+import TopologyErrorPanel from './TopologyErrorPanel';
+import TopologyToolbar from './TopologyToolbar';
 
 import './TopologyToolbar.css';
 
@@ -25,9 +25,9 @@ type TopologyViewWorkloadComponentProps = {
   useToolbar?: boolean;
 };
 
-const TopologyViewWorkloadComponent: React.FC<
-  TopologyViewWorkloadComponentProps
-> = ({ useToolbar = false }) => {
+const TopologyViewWorkloadComponent = ({
+  useToolbar = false,
+}: TopologyViewWorkloadComponentProps) => {
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
   const controller = useVisualizationController();
   const layout = 'ColaNoForce';


### PR DESCRIPTION
## Description

Please explain the changes you made here.

Removes React.FC types to be consistent with [Backstage ADRs](https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr006-avoid-react-fc.md). 

## Which issue(s) does this PR fix

No applicable related issue; however, there were a few instances where components were passed a `children` prop and the components did nothing with them.
