### PR TITLE
chore(plugins): remove react namespace import

### DIFF
--- a/plugins/tekton/src/components/Charts/HorizontalStackedBars.tsx
+++ b/plugins/tekton/src/components/Charts/HorizontalStackedBars.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 import './HorizontalStackedBars.css';

--- a/plugins/tekton/src/components/Charts/PipelineBars.tsx
+++ b/plugins/tekton/src/components/Charts/PipelineBars.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import HorizontalStackedBars from './HorizontalStackedBars';
 import TaskStatusToolTip from './TaskStatusTooltip';

--- a/plugins/tekton/src/components/Charts/TaskStatusTooltip.tsx
+++ b/plugins/tekton/src/components/Charts/TaskStatusTooltip.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { ComputedStatus, TaskStatus } from '../../types/computedStatus';
 import { getRunStatusColor } from '../../utils/tekton-status';
 

--- a/plugins/tekton/src/components/PipelineRunList/LinkedPipelineRunTaskStatus.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/LinkedPipelineRunTaskStatus.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { PipelineRunKind } from '../../types/pipelineRun';
 import { PipelineBars } from '../Charts/PipelineBars';
 

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunList.test.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunList.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import PipelineRunList from './PipelineRunList';
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunList.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { EmptyState, InfoCard, Progress } from '@backstage/core-components';
 import { SortByDirection } from '@patternfly/react-table';
 import PipelineRunHeader from './PipelineRunHeader';

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunRow.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunRow.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Timestamp } from '@patternfly/react-core';
 import { tableColumnClasses } from './pipelinerun-table';
 import LinkedPipelineRunTaskStatus from './LinkedPipelineRunTaskStatus';

--- a/plugins/tekton/src/components/PipelineRunList/PlrStatus.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PlrStatus.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,

--- a/plugins/tekton/src/components/PipelineRunList/ResourceBadge.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/ResourceBadge.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Split, SplitItem } from '@patternfly/react-core';
 
 import './ResourceBadge.css';

--- a/plugins/tekton/src/components/Table/Table.tsx
+++ b/plugins/tekton/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { findIndex } from 'lodash';
 import {
   Table as PfTable,

--- a/plugins/tekton/src/components/Table/TableRow.tsx
+++ b/plugins/tekton/src/components/Table/TableRow.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 type TableRowProps = {
   id: React.ReactText;

--- a/plugins/tekton/src/components/Table/VirtualBody.tsx
+++ b/plugins/tekton/src/components/Table/VirtualBody.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { CellMeasurerCache, CellMeasurer } from 'react-virtualized';
 import { VirtualTableBody } from '@patternfly/react-virtualized-extension';
 import { Scroll } from '@patternfly/react-virtualized-extension/dist/esm/components/Virtualized/types';

--- a/plugins/tekton/src/components/Tekton/TektonComponent.tsx
+++ b/plugins/tekton/src/components/Tekton/TektonComponent.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { ModelsPlural } from '../../models';
 import { useTektonObjectsResponse } from '../../hooks/useTektonObjectsResponse';
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';

--- a/plugins/tekton/src/components/common/CamelCaseWrap.tsx
+++ b/plugins/tekton/src/components/common/CamelCaseWrap.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 const MEMO: { [key: string]: any } = {};
 

--- a/plugins/tekton/src/components/common/ClusterSelector.tsx
+++ b/plugins/tekton/src/components/common/ClusterSelector.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
 import { Select, SelectedItems } from '@backstage/core-components';
 

--- a/plugins/tekton/src/components/common/ErrorPanel.tsx
+++ b/plugins/tekton/src/components/common/ErrorPanel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { WarningPanel } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { Typography } from '@material-ui/core';

--- a/plugins/tekton/src/components/common/ResourceStatus.tsx
+++ b/plugins/tekton/src/components/common/ResourceStatus.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Badge } from '@patternfly/react-core';
 import classNames from 'classnames';
 

--- a/plugins/tekton/src/components/common/Status.tsx
+++ b/plugins/tekton/src/components/common/Status.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   BanIcon,
   ClipboardListIcon,

--- a/plugins/tekton/src/components/common/StatusIcon.tsx
+++ b/plugins/tekton/src/components/common/StatusIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import {
   AngleDoubleRightIcon,

--- a/plugins/tekton/src/components/common/StatusIconAndText.tsx
+++ b/plugins/tekton/src/components/common/StatusIconAndText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import CamelCaseWrap from './CamelCaseWrap';
 

--- a/plugins/tekton/src/components/common/icons.tsx
+++ b/plugins/tekton/src/components/common/icons.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   CheckCircleIcon,
   InfoCircleIcon,

--- a/plugins/tekton/src/components/pipeline-topology/PipelineTaskNode.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/PipelineTaskNode.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 // eslint-disable-next-line @backstage/no-undeclared-imports
 import { observer } from 'mobx-react';
 import { Tooltip } from '@patternfly/react-core';

--- a/plugins/tekton/src/components/pipeline-topology/PipelineVisualizationStepList.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/PipelineVisualizationStepList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { RunStatus } from '@patternfly/react-topology';
 import { StatusIcon } from '../common';

--- a/plugins/tekton/src/components/pipeline-topology/TaskGroupEdge.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/TaskGroupEdge.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 // eslint-disable-next-line @backstage/no-undeclared-imports
 import { observer } from 'mobx-react';
 import { Edge, TaskEdge } from '@patternfly/react-topology';

--- a/plugins/tekton/src/components/pipeline-topology/pipelineComponentFactory.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/pipelineComponentFactory.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   GraphElement,
   ComponentFactory,

--- a/plugins/tekton/src/hooks/TektonResourcesContext.ts
+++ b/plugins/tekton/src/hooks/TektonResourcesContext.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { TektonResourcesContextData } from '../types/types';
 
 export const TektonResourcesContext =

--- a/plugins/tekton/src/hooks/debounce.ts
+++ b/plugins/tekton/src/hooks/debounce.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { debounce } from 'lodash';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 

--- a/plugins/tekton/src/hooks/useDarkTheme.ts
+++ b/plugins/tekton/src/hooks/useDarkTheme.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { useTheme } from '@material-ui/core/styles';
 
 const THEME_DARK = 'dark';

--- a/plugins/tekton/src/hooks/useDeepCompareMemoize.ts
+++ b/plugins/tekton/src/hooks/useDeepCompareMemoize.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as _ from 'lodash';
 
 export const useDeepCompareMemoize = <T = any>(

--- a/plugins/tekton/src/utils/WithScrollContainer.tsx
+++ b/plugins/tekton/src/utils/WithScrollContainer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 type WithScrollContainerProps = {
   children: (scrollContainer: HTMLElement) => React.ReactElement | null;

--- a/plugins/topology/src/common/components/CamelCaseWrap.tsx
+++ b/plugins/topology/src/common/components/CamelCaseWrap.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 const MEMO: { [key: string]: any } = {};
 

--- a/plugins/topology/src/common/components/ResourceName.tsx
+++ b/plugins/topology/src/common/components/ResourceName.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { kindToAbbr } from '../utils/getResources';
 import { resourceModels } from '../../models';

--- a/plugins/topology/src/common/components/ResourceStatus.tsx
+++ b/plugins/topology/src/common/components/ResourceStatus.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Badge } from '@patternfly/react-core';
 import classNames from 'classnames';
 

--- a/plugins/topology/src/common/components/Status.tsx
+++ b/plugins/topology/src/common/components/Status.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   BanIcon,
   HourglassHalfIcon,

--- a/plugins/topology/src/common/components/StatusIconAndText.tsx
+++ b/plugins/topology/src/common/components/StatusIconAndText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import CamelCaseWrap from './CamelCaseWrap';
 

--- a/plugins/topology/src/common/components/icons.tsx
+++ b/plugins/topology/src/common/components/icons.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,

--- a/plugins/topology/src/components/Graph/BaseNode.tsx
+++ b/plugins/topology/src/components/Graph/BaseNode.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import {
   BadgeLocation,

--- a/plugins/topology/src/components/Graph/DefaultGraph.tsx
+++ b/plugins/topology/src/components/Graph/DefaultGraph.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   GraphElement,
   Graph,

--- a/plugins/topology/src/components/Graph/EdgeConnect.tsx
+++ b/plugins/topology/src/components/Graph/EdgeConnect.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 // eslint-disable-next-line @backstage/no-undeclared-imports
 import { observer } from 'mobx-react';
 import {

--- a/plugins/topology/src/components/Graph/GroupNode.tsx
+++ b/plugins/topology/src/components/Graph/GroupNode.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   DefaultGroup,
   GraphElement,

--- a/plugins/topology/src/components/Graph/TopologyComponentFactory.tsx
+++ b/plugins/topology/src/components/Graph/TopologyComponentFactory.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   GraphElement,
   ComponentFactory,

--- a/plugins/topology/src/components/Graph/WorkloadNode.tsx
+++ b/plugins/topology/src/components/Graph/WorkloadNode.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   getDefaultShapeDecoratorCenter,
   GraphElement,

--- a/plugins/topology/src/components/Graph/decorators/Decorator.test.tsx
+++ b/plugins/topology/src/components/Graph/decorators/Decorator.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Link, MemoryRouter } from 'react-router-dom';
 import { Decorator as PfDecorator } from '@patternfly/react-topology';

--- a/plugins/topology/src/components/Graph/decorators/Decorator.tsx
+++ b/plugins/topology/src/components/Graph/decorators/Decorator.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Decorator as PfDecorator } from '@patternfly/react-topology';
 import { Link } from 'react-router-dom';
 

--- a/plugins/topology/src/components/Graph/decorators/UrlDecorator.test.tsx
+++ b/plugins/topology/src/components/Graph/decorators/UrlDecorator.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import * as React from 'react';
+import React from 'react';
 import { UrlDecorator } from './UrlDecorator';
 
 // mock Decorator

--- a/plugins/topology/src/components/Graph/decorators/UrlDecorator.tsx
+++ b/plugins/topology/src/components/Graph/decorators/UrlDecorator.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import Decorator from './Decorator';

--- a/plugins/topology/src/components/Pods/PodSet.tsx
+++ b/plugins/topology/src/components/Pods/PodSet.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import PodStatus from './PodStatus';
 import {
   calculateRadius,

--- a/plugins/topology/src/components/Pods/PodStatus.tsx
+++ b/plugins/topology/src/components/Pods/PodStatus.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { ChartDonut } from '@patternfly/react-charts';
 import { Tooltip } from '@patternfly/react-core';
 import * as _ from 'lodash';

--- a/plugins/topology/src/components/Topology/TopologyControlBar.tsx
+++ b/plugins/topology/src/components/Topology/TopologyControlBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   action,
   Controller,

--- a/plugins/topology/src/components/Topology/TopologyEmptyState.test.tsx
+++ b/plugins/topology/src/components/Topology/TopologyEmptyState.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import * as React from 'react';
+import React from 'react';
 import { TopologyEmptyState } from './TopologyEmptyState';
 
 describe('TopologyEmptyState', () => {

--- a/plugins/topology/src/components/Topology/TopologyEmptyState.tsx
+++ b/plugins/topology/src/components/Topology/TopologyEmptyState.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   EmptyState,
   EmptyStateIcon,

--- a/plugins/topology/src/components/Topology/TopologyErrorPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologyErrorPanel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { WarningPanel } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { Typography } from '@material-ui/core';

--- a/plugins/topology/src/components/Topology/TopologySideBar/IngressRules.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/IngressRules.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { CodeSnippet } from '@backstage/core-components';
 import { V1Ingress } from '@kubernetes/client-node';
 import jsYaml from 'js-yaml';

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDeploymentDetails.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDeploymentDetails.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { V1Deployment } from '@kubernetes/client-node';
 import TopologySideBarDetailsItem from './TopologySideBarDetailsItem';
 

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyDetailsTabPanel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   Split,
   SplitItem,

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourceLabels.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourceLabels.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Label } from '@patternfly/react-core';
 
 import './TopologyResourceLabels.css';

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { V1Pod, V1Service, V1ServicePort } from '@kubernetes/client-node';
 import { LongArrowAltRightIcon } from '@patternfly/react-icons';
 import { BaseNode } from '@patternfly/react-topology';

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPaneltem.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPaneltem.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import './TopologyResourcesTabPanelItem.css';
 

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBar.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   BaseNode,
   TopologySideBar as PFTopologySideBar,

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarBody.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Tabs, Tab, Divider } from '@material-ui/core';
 import TopologyDetailsTabPanel from './TopologyDetailsTabPanel';
 import TopologyResourcesTabPanel from './TopologyResourcesTabPanel';

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarContent.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarContent.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Divider } from '@material-ui/core';
 import { BaseNode } from '@patternfly/react-topology';
 import TopologySideBarBody from './TopologySideBarBody';

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarDetailsItem.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarDetailsItem.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import './TopologySideBarDetailsItem.css';
 

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarHeading.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologySideBarHeading.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Typography } from '@material-ui/core';
 import { Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
 import ResourceName from '../../../common/components/ResourceName';

--- a/plugins/topology/src/components/Topology/TopologyToolbar.tsx
+++ b/plugins/topology/src/components/Topology/TopologyToolbar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   ToolbarItem,
   Select,

--- a/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.test.tsx
+++ b/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import { useWorkloadsWatcher } from '../../hooks/useWorkloadWatcher';
 import TopologyViewWorkloadComponent from './TopologyViewWorkloadComponent';

--- a/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
+++ b/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   BaseNode,
   SelectionEventListener,

--- a/plugins/topology/src/components/Topology/TopologyWorkloadView.test.tsx
+++ b/plugins/topology/src/components/Topology/TopologyWorkloadView.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import { TopologyWorkloadView } from './TopologyWorkloadView';
 

--- a/plugins/topology/src/components/Topology/TopologyWorkloadView.tsx
+++ b/plugins/topology/src/components/Topology/TopologyWorkloadView.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   Visualization,
   VisualizationProvider,

--- a/plugins/topology/src/hooks/K8sResourcesContext.ts
+++ b/plugins/topology/src/hooks/K8sResourcesContext.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { K8sResourcesContextData } from '../types/types';
 
 export const K8sResourcesContext = React.createContext<K8sResourcesContextData>(

--- a/plugins/topology/src/hooks/debounce.ts
+++ b/plugins/topology/src/hooks/debounce.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { debounce } from 'lodash';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 

--- a/plugins/topology/src/hooks/useDeepCompareMemoize.ts
+++ b/plugins/topology/src/hooks/useDeepCompareMemoize.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as _ from 'lodash';
 
 export const useDeepCompareMemoize = <T = any>(

--- a/plugins/topology/src/hooks/useForceUpdate.ts
+++ b/plugins/topology/src/hooks/useForceUpdate.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 export const useForceUpdate = () => {
   const [, setTick] = React.useState(0);

--- a/plugins/topology/src/hooks/useSideBar.tsx
+++ b/plugins/topology/src/hooks/useSideBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { BaseNode } from '@patternfly/react-topology';
 import { TYPE_WORKLOAD } from '../const';
 import TopologySideBar from '../components/Topology/TopologySideBar/TopologySideBar';

--- a/plugins/topology/src/hooks/useWorkloadWatcher.ts
+++ b/plugins/topology/src/hooks/useWorkloadWatcher.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { useDebounceCallback } from './debounce';
 import { updateTopologyDataModel } from '../data-transforms/updateTopologyDataModel';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';

--- a/plugins/topology/src/utils/pod-ring-utils.ts
+++ b/plugins/topology/src/utils/pod-ring-utils.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { ChartLabel } from '@patternfly/react-charts';
 import classNames from 'classnames';
 import { V1DaemonSet, V1Deployment, V1Pod } from '@kubernetes/client-node';


### PR DESCRIPTION
This PR replaces global react namespace imports to allow for tree-shaking builds.

```diff
- import * as React from 'react';
+ import React from 'react';
```

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
