### PR TITLE
chore(monorepo): add husky

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+./.husky/scripts/sync-node-modules

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+./.husky/scripts/sync-node-modules

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+./.husky/scripts/sync-node-modules

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint
+npm run prettier:check

--- a/.husky/scripts/sync-node-modules
+++ b/.husky/scripts/sync-node-modules
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+changed_files="$(git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD)"
+
+if [[ $changed_files == *"package.json"* ]]; then
+  eval "yarn install"
+fi

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": "16 || 18"
   },
   "scripts": {
+    "preinstall": "npx only-allow yarn",
     "dev": "concurrently \"yarn start\" \"yarn start-backend\"",
     "start": "yarn workspace app start",
     "start-backend": "yarn workspace backend start",
@@ -18,7 +19,8 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "new": "backstage-cli new --scope @janus-idp",
-    "release": "multi-semantic-release"
+    "release": "multi-semantic-release",
+    "prepare": "husky install"
   },
   "workspaces": {
     "packages": [
@@ -39,7 +41,8 @@
     "multi-semantic-release": "3.0.2",
     "node-gyp": "9.3.1",
     "prettier": "2.8.8",
-    "typescript": "5.0.4"
+    "typescript": "5.0.4",
+    "husky": "8.0.3"
   },
   "resolutions": {
     "@types/react": "^17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14122,6 +14122,11 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+
 hyphenate-style-name@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"


### PR DESCRIPTION
Adds husky to enable git hooks

- `precommit`: runs `lint` and `prettier:check`
- `post-merge`, `post-rewrite`, and `post-checkout`: runs `yarn install` if any `package.json` changes.