### PR TITLE
feat(tekton): show cluster label before the select dropdown

### DIFF
--- a/plugins/tekton/src/components/common/ClusterSelector.css
+++ b/plugins/tekton/src/components/common/ClusterSelector.css
@@ -1,0 +1,8 @@
+.bs-tkn-cluster-selector {
+  display: flex;
+  align-items: center;
+}
+
+.bs-tkn-cluster-selector > div > div > div {
+  margin-top: 0;
+}

--- a/plugins/tekton/src/components/common/ClusterSelector.tsx
+++ b/plugins/tekton/src/components/common/ClusterSelector.tsx
@@ -1,8 +1,22 @@
-import { Select, SelectedItems } from '@backstage/core-components';
 import React from 'react';
+import { Select, SelectedItems } from '@backstage/core-components';
+import { BackstageTheme } from '@backstage/theme';
+import { makeStyles, Typography } from '@material-ui/core';
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
 
+import './ClusterSelector.css';
+
+const useStyles = makeStyles<BackstageTheme>(theme => ({
+  label: {
+    color: theme.palette.text.primary,
+    fontSize: '1rem',
+    paddingRight: '10px',
+    fontWeight: 'bold',
+  },
+}));
+
 export const ClusterSelector = () => {
+  const classes = useStyles();
   const {
     clusters: k8sClusters,
     selectedCluster,
@@ -27,13 +41,16 @@ export const ClusterSelector = () => {
     setClusterSelected(arg);
   };
   return (
-    <Select
-      onChange={onClusterChange}
-      label="Cluster"
-      items={clusterOptions}
-      selected={clusterSelected}
-      margin="dense"
-      native
-    />
+    <div className="bs-tkn-cluster-selector">
+      <Typography className={classes.label}>Cluster</Typography>
+      <Select
+        onChange={onClusterChange}
+        label=""
+        items={clusterOptions}
+        selected={clusterSelected}
+        margin="dense"
+        native
+      />
+    </div>
   );
 };


### PR DESCRIPTION
**Resolves:**
https://github.com/janus-idp/backstage-plugins/issues/329

**Solution description:**
The cluster selector label is shown before the dropdown

**Screenshots:**

<img width="1303" alt="Screenshot 2023-05-26 at 11 43 59 AM" src="https://github.com/janus-idp/backstage-plugins/assets/22490998/e55f281a-3cf7-400f-809e-465b176956df">
<img width="1303" alt="Screenshot 2023-05-26 at 11 44 05 AM" src="https://github.com/janus-idp/backstage-plugins/assets/22490998/8419bed3-3744-4707-9c2c-97508a8dbccb">

