### PR TITLE
feat(ocm-backend): add additional information to status endpoint

### DIFF
--- a/plugins/ocm-backend/__fixtures__/handlers.ts
+++ b/plugins/ocm-backend/__fixtures__/handlers.ts
@@ -19,6 +19,21 @@ export const handlers = [
     },
   ),
   rest.get(
+    `${LOCAL_ADDR}/apis/internal.open-cluster-management.io/v1beta1/managedclusterinfos`,
+    (_, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json({
+          items: [
+            require(`${__dirname}/internal.open-cluster-management.io/managedclusterinfos/local-cluster.json`),
+            require(`${__dirname}/internal.open-cluster-management.io/managedclusterinfos/cluster1.json`),
+            require(`${__dirname}/internal.open-cluster-management.io/managedclusterinfos/offline-cluster.json`),
+          ],
+        }),
+      );
+    },
+  ),
+  rest.get(
     `${LOCAL_ADDR}/apis/cluster.open-cluster-management.io/v1/managedclusters/local-cluster`,
     (_, res, ctx) => {
       return res(

--- a/plugins/ocm-backend/__fixtures__/internal.open-cluster-management.io/managedclusterinfos/offline-cluster.json
+++ b/plugins/ocm-backend/__fixtures__/internal.open-cluster-management.io/managedclusterinfos/offline-cluster.json
@@ -160,7 +160,7 @@
         },
         "conditions": [
           {
-            "status": "True",
+            "status": "Unknown",
             "type": "Ready"
           }
         ],
@@ -194,7 +194,7 @@
         },
         "conditions": [
           {
-            "status": "True",
+            "status": "Unknown",
             "type": "Ready"
           }
         ],

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -24,7 +24,7 @@
   "configSchema": "config.d.ts",
   "dependencies": {
     "@backstage/backend-common": "^0.18.5",
-    "@backstage/backend-tasks": "^0.5.1",
+    "@backstage/backend-tasks": "^0.5.2",
     "@backstage/catalog-client": "^1.4.1",
     "@backstage/catalog-model": "^1.3.0",
     "@backstage/config": "^1.0.7",

--- a/plugins/ocm-backend/src/helpers/kubernetes.test.ts
+++ b/plugins/ocm-backend/src/helpers/kubernetes.test.ts
@@ -3,6 +3,7 @@ import {
   getManagedCluster,
   listManagedClusters,
   getManagedClusterInfo,
+  listManagedClusterInfos,
 } from './kubernetes';
 import { createLogger } from 'winston';
 import transports from 'winston/lib/winston/transports';
@@ -100,5 +101,13 @@ describe('getManagedClusterInfo', () => {
   it('should return cluster', async () => {
     const result: any = await getManagedClusterInfo(getApi(), 'local-cluster');
     expect(result.metadata.name).toBe('local-cluster');
+  });
+});
+
+describe('getManagedClusterInfos', () => {
+  it('should return some cluster infos', async () => {
+    const result: any = await listManagedClusterInfos(getApi());
+    expect(result.items[0].metadata.name).toBe('local-cluster');
+    expect(result.items[1].metadata.name).toBe('cluster1');
   });
 });

--- a/plugins/ocm-backend/src/helpers/kubernetes.ts
+++ b/plugins/ocm-backend/src/helpers/kubernetes.ts
@@ -113,3 +113,13 @@ export const getManagedClusterInfo = (api: CustomObjectsApi, name: string) => {
     ),
   );
 };
+
+export const listManagedClusterInfos = (api: CustomObjectsApi) => {
+  return kubeApiResponseHandler<KubernetesListObject<ManagedClusterInfo>>(
+    api.listClusterCustomObject(
+      'internal.open-cluster-management.io',
+      'v1beta1',
+      'managedclusterinfos',
+    ),
+  );
+};

--- a/plugins/ocm-backend/src/helpers/parser.ts
+++ b/plugins/ocm-backend/src/helpers/parser.ts
@@ -91,7 +91,7 @@ export const parseUpdateInfo = (clusterInfo: ManagedClusterInfo) => {
 export const parseNodeStatus = (clusterInfo: ManagedClusterInfo) =>
   clusterInfo.status?.nodeList.map(node => {
     if (node.conditions.length !== 1) {
-      throw new Error('More node conditions then one');
+      throw new Error('Found more node conditions then one');
     }
     const condition = node.conditions[0];
     return {

--- a/plugins/ocm-backend/src/helpers/parser.ts
+++ b/plugins/ocm-backend/src/helpers/parser.ts
@@ -1,6 +1,7 @@
 import { CONSOLE_CLAIM, HUB_CLUSTER_NAME_IN_OCM } from '../constants';
 import {
   ClusterDetails,
+  ClusterNodesStatus,
   ClusterStatus,
 } from '@janus-idp/backstage-plugin-ocm-common';
 import { maxSatisfying } from 'semver';
@@ -86,6 +87,18 @@ export const parseUpdateInfo = (clusterInfo: ManagedClusterInfo) => {
     },
   };
 };
+
+export const parseNodeStatus = (clusterInfo: ManagedClusterInfo) =>
+  clusterInfo.status?.nodeList.map(node => {
+    if (node.conditions.length !== 1) {
+      throw new Error('More node conditions then one');
+    }
+    const condition = node.conditions[0];
+    return {
+      status: condition.status,
+      type: condition.type,
+    } as ClusterNodesStatus;
+  });
 
 export const translateResourceToOCM = (
   clusterName: string,

--- a/plugins/ocm-backend/src/service/router.test.ts
+++ b/plugins/ocm-backend/src/service/router.test.ts
@@ -60,6 +60,27 @@ describe('createRouter', () => {
             available: true,
             reason: 'Managed cluster is available',
           },
+          nodes: [
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+          ],
+          openshiftVersion: '4.10.26',
+          platform: 'BareMetal',
+          update: {
+            available: true,
+            url: 'https://access.redhat.com/errata/RHSA-2023:0561',
+            version: '4.10.51',
+          },
         },
         {
           name: 'cluster1',
@@ -67,12 +88,86 @@ describe('createRouter', () => {
             available: true,
             reason: 'Managed cluster is available',
           },
+          nodes: [
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+          ],
+          openshiftVersion: '4.9.21',
+          platform: 'BareMetal',
+          update: {
+            available: true,
+            url: 'https://access.redhat.com/errata/RHSA-2023:0561',
+            version: '4.10.51',
+          },
         },
         {
           name: 'offline-cluster',
           status: {
             available: false,
             reason: 'Managed cluster is unavailable',
+          },
+          nodes: [
+            {
+              status: 'Unknown',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'Unknown',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              status: 'True',
+              type: 'Ready',
+            },
+          ],
+          openshiftVersion: '4.9.21',
+          platform: 'BareMetal',
+          update: {
+            available: true,
+            url: 'https://access.redhat.com/errata/RHSA-2023:0561',
+            version: '4.10.51',
           },
         },
       ]);

--- a/plugins/ocm-backend/src/service/router.ts
+++ b/plugins/ocm-backend/src/service/router.ts
@@ -24,16 +24,22 @@ import {
   listManagedClusters,
   getManagedClusterInfo,
   hubApiClient,
+  listManagedClusterInfos,
 } from '../helpers/kubernetes';
 import {
+  getClaim,
   parseClusterStatus,
   parseManagedCluster,
+  parseNodeStatus,
   parseUpdateInfo,
   translateOCMToResource,
   translateResourceToOCM,
 } from '../helpers/parser';
 import { readOcmConfigs } from '../helpers/config';
-import { Cluster } from '@janus-idp/backstage-plugin-ocm-common';
+import {
+  Cluster,
+  ClusterOverview,
+} from '@janus-idp/backstage-plugin-ocm-common';
 
 export interface RouterOptions {
   logger: Logger;
@@ -101,11 +107,24 @@ export async function createRouter(
     const allClusters = await Promise.all(
       Object.values(clients).map(async c => {
         const mcs = await listManagedClusters(c.client);
+        const mcis = await listManagedClusterInfos(c.client);
 
-        return mcs.items.map(mc => ({
-          name: translateOCMToResource(mc.metadata!.name!, c.hubResourceName),
-          status: parseClusterStatus(mc),
-        }));
+        return mcs.items.map(
+          (mc, index) =>
+            ({
+              name: translateOCMToResource(
+                mc.metadata!.name!,
+                c.hubResourceName,
+              ),
+              status: parseClusterStatus(mc),
+              platform: getClaim(mc, 'platform.open-cluster-management.io'),
+              openshiftVersion:
+                mc.metadata!.labels?.openshiftVersion ||
+                getClaim(mc, 'version.openshift.io'),
+              nodes: parseNodeStatus(mcis.items[index]),
+              ...parseUpdateInfo(mcis.items[index]),
+            } as ClusterOverview),
+        );
       }),
     );
 

--- a/plugins/ocm-common/src/index.ts
+++ b/plugins/ocm-common/src/index.ts
@@ -14,6 +14,17 @@ export type ClusterBase = {
   name: string;
 };
 
+export type ClusterUpdate = {
+  available?: boolean;
+  version?: string;
+  url?: string;
+};
+
+export type ClusterNodesStatus = {
+  status: string;
+  type: string;
+};
+
 export type ClusterDetails = {
   consoleUrl?: string;
   kubernetesVersion?: string;
@@ -32,16 +43,18 @@ export type ClusterDetails = {
     memorySize?: string;
     numberOfPods?: number;
   };
-  update?: {
-    available?: boolean;
-    version?: string;
-    url?: string;
-  };
+  update?: ClusterUpdate;
   status: ClusterStatus;
 };
 
 export type Cluster = ClusterBase & ClusterDetails;
-export type ClusterOverview = ClusterBase & { status: ClusterStatus };
+export type ClusterOverview = ClusterBase & {
+  status: ClusterStatus;
+  update: ClusterUpdate;
+  platform: string;
+  openshiftVersion: string;
+  nodes: Array<ClusterNodesStatus>;
+};
 
 export const ANNOTATION_CLUSTER_ID = 'janus-idp.io/ocm-cluster-id';
 export const ANNOTATION_PROVIDER_ID = 'janus-idp.io/ocm-provider-id';


### PR DESCRIPTION
Part of #368 

Add platform, node list and update information to the status endpoint for the `ocm-backend` plugin. Also add tests for new functionality.

### More detailed changes:
- Add additional information to the `ocm` API
- Add a new k8s `api` function all to get all cluster infos at once since the update and node information is present in the `managedclusterinfos` endpoint
- Add a function to parse node information from a cluster info object
- Update and platform information is parsed using already implemented funtions

The `/api/ocm/status` call in this PR:
```json
[
  {
    "name": "foo",
    "status": {
      "available": true,
      "reason": "Managed cluster is available"
    },
    "platform": "BareMetal",
    "openshiftVersion": "4.10.26",
    "nodes": [
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      }
    ],
    "update": {
      "available": true,
      "version": "4.10.51",
      "url": "https://access.redhat.com/errata/RHSA-2023:0561"
    }
  },
  {
    "name": "cluster1",
    "status": {
      "available": true,
      "reason": "Managed cluster is available"
    },
    "platform": "BareMetal",
    "openshiftVersion": "4.9.21",
    "nodes": [
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      }
    ],
    "update": {
      "available": true,
      "version": "4.10.51",
      "url": "https://access.redhat.com/errata/RHSA-2023:0561"
    }
  },
  {
    "name": "offline-cluster",
    "status": {
      "available": false,
      "reason": "Managed cluster is unavailable"
    },
    "platform": "BareMetal",
    "openshiftVersion": "4.9.21",
    "nodes": [
      {
        "status": "Unknown",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "Unknown",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      },
      {
        "status": "True",
        "type": "Ready"
      }
    ],
    "update": {
      "available": true,
      "version": "4.10.51",
      "url": "https://access.redhat.com/errata/RHSA-2023:0561"
    }
  }
]
```
