### PR TITLE
chore(topology): fix docs heading link

### DIFF
--- a/plugins/topology/README.md
+++ b/plugins/topology/README.md
@@ -12,7 +12,7 @@ The Topology plugin enables you to visualize the workloads such as Deployment, J
 
 1. [For users](#for-users)
 
-   a. [Using the Topology plugin in Backstage](using-the-topology-plugin-in-backstage)
+   a. [Using the Topology plugin in Backstage](#using-the-topology-plugin-in-backstage)
 
 ## For administrators
 


### PR DESCRIPTION
This typo breaks the website build.

https://github.com/janus-idp/backstage-plugins/actions/runs/5046706430/jobs/9052601315