### PR TITLE
fix(3scale): don't expose token and use correct config

### DIFF
--- a/plugins/3scale-backend/config.d.ts
+++ b/plugins/3scale-backend/config.d.ts
@@ -2,8 +2,8 @@ import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
 
 interface ThreeScaleConfig {
   baseUrl: string;
-  serviceAccount: string;
-  serviceAccountCredentials: string;
+  /** @visibility secret */
+  accessToken: string;
   systemLabel?: string;
   ownerLabel?: string;
   addLabels?: boolean;


### PR DESCRIPTION
As far as I can see only `accessToken` is valid and should be a secret https://github.com/janus-idp/backstage-plugins/blob/main/plugins/3scale-backend/src/providers/config.ts#L26