### PR TITLE
fix(tekton): in case of bad configuration show empty state for tekton plugin and no cluster selector

### DIFF
--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunList.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunList.tsx
@@ -10,23 +10,33 @@ import PipelineRunRow from './PipelineRunRow';
 
 type WrapperInfoCardProps = {
   allErrors?: ClusterErrors;
+  showClusterSelector?: boolean;
 };
 
 const WrapperInfoCard = ({
   children,
   allErrors,
+  showClusterSelector = true,
 }: React.PropsWithChildren<WrapperInfoCardProps>) => (
   <>
     {allErrors && allErrors.length > 0 && <ErrorPanel allErrors={allErrors} />}
-    <InfoCard title="Pipeline Runs" subheader={<ClusterSelector />}>
+    <InfoCard
+      title="Pipeline Runs"
+      {...(showClusterSelector && { subheader: <ClusterSelector /> })}
+    >
       {children}
     </InfoCard>
   </>
 );
 
 const PipelineRunList = () => {
-  const { loaded, responseError, watchResourcesData, selectedClusterErrors } =
-    React.useContext(TektonResourcesContext);
+  const {
+    loaded,
+    responseError,
+    watchResourcesData,
+    selectedClusterErrors,
+    clusters,
+  } = React.useContext(TektonResourcesContext);
 
   const allErrors: ClusterErrors = [
     ...(responseError ? [{ message: responseError }] : []),
@@ -42,11 +52,14 @@ const PipelineRunList = () => {
 
   if (
     loaded &&
-    !responseError &&
-    !watchResourcesData?.pipelineruns?.data?.length
+    ((!responseError && !watchResourcesData?.pipelineruns?.data?.length) ||
+      responseError)
   ) {
     return (
-      <WrapperInfoCard allErrors={allErrors}>
+      <WrapperInfoCard
+        allErrors={allErrors}
+        showClusterSelector={clusters.length > 0}
+      >
         <EmptyState missing="data" title="No Pipeline Runs found" />
       </WrapperInfoCard>
     );

--- a/plugins/tekton/src/components/pipeline-topology/PipelineVisualization.test.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/PipelineVisualization.test.tsx
@@ -103,4 +103,56 @@ describe('PipelineVisualization', () => {
 
     expect(queryByTestId('pipeline-no-tasks')).not.toBeNull();
   });
+
+  it('should show empty state with no cluster selector when there is response error and no clusters are fetched', async () => {
+    const mockContextData = {
+      watchResourcesData: {
+        pipelineruns: {
+          data: [],
+        },
+        taskruns: {
+          data: [],
+        },
+      },
+      loaded: true,
+      responseError:
+        'getaddrinfo ENOTFOUND api.rhoms-4.13-052404.dev.openshiftappsvc.org',
+      selectedClusterErrors: [],
+      clusters: [],
+      setSelectedCluster: () => {},
+    };
+    const { queryByText } = render(
+      <TektonResourcesContext.Provider value={mockContextData}>
+        <PipelineVisualization />
+      </TektonResourcesContext.Provider>,
+    );
+    expect(queryByText(/No Pipeline Run to visualize/i)).not.toBeNull();
+    expect(queryByText(/Cluster/)).toBeNull();
+  });
+
+  it('should show empty state with cluster selector when there is response error and clusters are fetched', async () => {
+    const mockContextData = {
+      watchResourcesData: {
+        pipelineruns: {
+          data: [],
+        },
+        taskruns: {
+          data: [],
+        },
+      },
+      loaded: true,
+      responseError:
+        'getaddrinfo ENOTFOUND api.rhoms-4.13-052404.dev.openshiftappsvc.org',
+      selectedClusterErrors: [{ message: '403 - forbidden' }],
+      clusters: ['OCP'],
+      setSelectedCluster: () => {},
+    };
+    const { queryByText } = render(
+      <TektonResourcesContext.Provider value={mockContextData}>
+        <PipelineVisualization />
+      </TektonResourcesContext.Provider>,
+    );
+    expect(queryByText(/No Pipeline Run to visualize/i)).not.toBeNull();
+    expect(queryByText(/Cluster/)).not.toBeNull();
+  });
 });

--- a/plugins/tekton/src/components/pipeline-topology/PipelineVisualization.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/PipelineVisualization.tsx
@@ -29,18 +29,20 @@ type PipelineVisualizationProps = {
 type WrapperInfoCardProps = {
   allErrors?: ClusterErrors;
   footerLink?: BottomLinkProps;
+  showClusterSelector?: boolean;
 };
 
 const WrapperInfoCard = ({
   children,
   allErrors,
   footerLink,
+  showClusterSelector = true,
 }: React.PropsWithChildren<WrapperInfoCardProps>) => (
   <>
     {allErrors && allErrors.length > 0 && <ErrorPanel allErrors={allErrors} />}
     <InfoCard
       title="Latest Pipeline Run"
-      subheader={<ClusterSelector />}
+      {...(showClusterSelector && { subheader: <ClusterSelector /> })}
       deepLink={footerLink}
     >
       {children}
@@ -53,8 +55,13 @@ export const PipelineVisualization = ({
   url,
 }: PipelineVisualizationProps) => {
   useDarkTheme();
-  const { loaded, responseError, watchResourcesData, selectedClusterErrors } =
-    React.useContext(TektonResourcesContext);
+  const {
+    loaded,
+    responseError,
+    watchResourcesData,
+    selectedClusterErrors,
+    clusters,
+  } = React.useContext(TektonResourcesContext);
 
   const { entity } = useEntity();
   const allErrors: ClusterErrors = [
@@ -77,13 +84,12 @@ export const PipelineVisualization = ({
       </div>
     );
 
-  if (
-    loaded &&
-    (!responseError || responseError?.length === 0) &&
-    (!latestPipelineRun || isEmpty(latestPipelineRun))
-  ) {
+  if (loaded && (responseError || isEmpty(latestPipelineRun))) {
     return (
-      <WrapperInfoCard allErrors={allErrors}>
+      <WrapperInfoCard
+        allErrors={allErrors}
+        showClusterSelector={clusters.length > 0}
+      >
         <EmptyState
           missing="data"
           description="No Pipeline Run to visualize"

--- a/plugins/tekton/src/hooks/useTektonObjectResponse.test.ts
+++ b/plugins/tekton/src/hooks/useTektonObjectResponse.test.ts
@@ -68,4 +68,23 @@ describe('useTektonObjectResponse', () => {
       expect(result.current.selectedCluster).toEqual(1);
     });
   });
+
+  it('should return responseError with loaded if unable to fetch data', async () => {
+    mockUseKubernetesObjects.mockReturnValue({
+      error:
+        'getaddrinfo ENOTFOUND api.rhoms-4.13-052404.dev.openshiftappsvc.org',
+    });
+    const { result } = renderHook(() =>
+      useTektonObjectsResponse(watchedResources),
+    );
+    await waitFor(() => {
+      expect(result.current.watchResourcesData).toBeUndefined();
+      expect(result.current.clusters).toEqual([]);
+      expect(result.current.selectedClusterErrors).toEqual([]);
+      expect(result.current.loaded).toEqual(true);
+      expect(result.current.responseError).toEqual(
+        'getaddrinfo ENOTFOUND api.rhoms-4.13-052404.dev.openshiftappsvc.org',
+      );
+    });
+  });
 });

--- a/plugins/tekton/src/hooks/useTektonObjectsResponse.ts
+++ b/plugins/tekton/src/hooks/useTektonObjectsResponse.ts
@@ -44,6 +44,7 @@ export const useTektonObjectsResponse = (
         setLoaded(true);
         setPipelinesData(resData);
       } else if (errorData && mounted.current) {
+        setLoaded(true);
         setErrorState(errorData);
       }
     },


### PR DESCRIPTION
**Fixes:** https://github.com/janus-idp/backstage-plugins/issues/383

**Setup:**

use below in `app-config.yaml`

```
      clusters:
        - url: https://api.jephilli-4-13-0-rc-5-05-25-0642.devcluster.openshiftjai.com:6443
          name: ocp
          authProvider: 'serviceAccount'
          skipTLSVerify: true
          skipMetricsLookup: true
          serviceAccountToken: 'aaa'
```

**Screenshots:**

<img width="1739" alt="image" src="https://github.com/janus-idp/backstage-plugins/assets/5129024/53098940-c5f8-4a7d-acd2-9e9ea2f4eb2a">

<img width="1738" alt="image" src="https://github.com/janus-idp/backstage-plugins/assets/5129024/ae40a0a2-74f7-4adf-a54c-1890e39a1fff">



 