### PR TITLE
fix(topology): close workload sidepanel on outside-click

### DIFF
--- a/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
+++ b/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
@@ -77,8 +77,9 @@ const TopologyViewWorkloadComponent = ({
 
   useEventListener<SelectionEventListener>(SELECTION_EVENT, (ids: string[]) => {
     const id = ids[0] ? ids[0] : '';
-    setSelectedNode(controller.getElementById(id) as BaseNode);
-    if (!id) {
+    const selNode = controller.getElementById(id) as BaseNode;
+    setSelectedNode(selNode);
+    if (!id || selNode.getType() !== TYPE_WORKLOAD) {
       removeSelectedIdParam();
     }
   });


### PR DESCRIPTION
Fixes: https://github.com/janus-idp/backstage-plugins/issues/398

This PR fixes the issue with workload sidepanel not closing on outside-click. For the sidepanel to be closed, selected-id should be removed from the URL but currently it was only getting removed when there was no id returned by the selection event listener hence it was failing when some other type of topology node was selected for ex - the graph node or app node. Added a check to remove the selected-id if the the selected node is not of type workload.


https://github.com/janus-idp/backstage-plugins/assets/20724543/99130d89-c171-442c-8a42-ca2091c35d66

