### PR TITLE
chore(ci): enable local turbo cache

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -7,17 +7,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Read Node.js version
-      id: node_version
-      uses: juliangruber/read-file-action@v1
-      with:
-        path: ./.nvmrc
-
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '${{ steps.node_version.outputs.content }}'
+        node-version-file: '.nvmrc'
         cache: 'yarn'
+
+    - name: Setup local Turbo cache
+      uses: dtinth/setup-github-actions-caching-for-turbo@v1
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -7,17 +7,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Read Node.js version
-      id: node_version
-      uses: juliangruber/read-file-action@v1
-      with:
-        path: ./.nvmrc
-
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '${{ steps.node_version.outputs.content }}'
+        node-version-file: '.nvmrc'
         cache: 'yarn'
+
+    - name: Setup local Turbo cache
+      uses: dtinth/setup-github-actions-caching-for-turbo@v1
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
Adds a step in `test` and `build` workflows which sets up the local turbo cache using Github Cache via https://github.com/dtinth/setup-github-actions-caching-for-turbo

Also cleans up node version parsing, since this is now supported out of the box via `actions/setup-node` via `node-version-file`.