### PR TITLE
fix(ocm): handle missing nodeList properly

### DIFF
--- a/plugins/ocm-backend/src/helpers/parser.test.ts
+++ b/plugins/ocm-backend/src/helpers/parser.test.ts
@@ -275,13 +275,28 @@ describe('parseNodeStatus', () => {
     ]);
   });
 
-  it('should should return an empty array if no nodes are present', () => {
+  it('should should return an empty array if nodes are empty', () => {
     const mciOriginal: ManagedClusterInfo = require(`${FIXTURES_DIR}/internal.open-cluster-management.io/managedclusterinfos/local-cluster.json`);
     const mci = {
       ...mciOriginal,
       status: {
         ...mciOriginal.status!,
         nodeList: [],
+      },
+    };
+
+    const result = parseNodeStatus(mci);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should should return an empty array if nodes are not present', () => {
+    const mciOriginal: ManagedClusterInfo = require(`${FIXTURES_DIR}/internal.open-cluster-management.io/managedclusterinfos/local-cluster.json`);
+    const mci = {
+      ...mciOriginal,
+      status: {
+        ...mciOriginal.status!,
+        nodeList: undefined,
       },
     };
 

--- a/plugins/ocm-backend/src/helpers/parser.ts
+++ b/plugins/ocm-backend/src/helpers/parser.ts
@@ -89,7 +89,7 @@ export const parseUpdateInfo = (clusterInfo: ManagedClusterInfo) => {
 };
 
 export const parseNodeStatus = (clusterInfo: ManagedClusterInfo) =>
-  clusterInfo.status?.nodeList.map(node => {
+  clusterInfo.status?.nodeList?.map(node => {
     if (node.conditions.length !== 1) {
       throw new Error('Found more node conditions then one');
     }
@@ -98,7 +98,7 @@ export const parseNodeStatus = (clusterInfo: ManagedClusterInfo) =>
       status: condition.status,
       type: condition.type,
     } as ClusterNodesStatus;
-  });
+  }) || [];
 
 export const translateResourceToOCM = (
   clusterName: string,

--- a/plugins/ocm-backend/src/types.ts
+++ b/plugins/ocm-backend/src/types.ts
@@ -49,7 +49,7 @@ export interface ManagedClusterInfo extends KubernetesObject {
     masterEndpoint: string;
   };
   status?: {
-    nodeList: {
+    nodeList?: {
       capacity: {
         cpu: string;
         memory: string;


### PR DESCRIPTION
In testing the `3.0.0` in live environment I've noticed it can happen the `nodeList` is not present in the `ManagedClusterInfo`s `.status`...

In such case then OCM page crashes because it tries to do `.map()` on `undefined`.

As an example is a Jerry cluster on OperateFirst:

https://console-openshift-console.apps.moc-infra.massopen.cloud/k8s/ns/jerry/internal.open-cluster-management.io~v1beta1~ManagedClusterInfo/jerry/yaml