### PR TITLE
fix(ocm-backend): handle a case when there are no nodes

### DIFF
--- a/plugins/ocm-backend/src/helpers/parser.test.ts
+++ b/plugins/ocm-backend/src/helpers/parser.test.ts
@@ -9,7 +9,9 @@ import {
   translateOCMToResource,
   translateResourceToOCM,
 } from './parser';
+import { getVoidLogger } from '@backstage/backend-common';
 
+const voidLogger = getVoidLogger();
 const FIXTURES_DIR = `${__dirname}/../../__fixtures__`;
 
 describe('getClaim', () => {
@@ -266,7 +268,7 @@ describe('parseNodeStatus', () => {
       },
     };
 
-    const result = parseNodeStatus(mci);
+    const result = parseNodeStatus(mci, voidLogger);
 
     expect(result).toEqual([
       { status: 'True', type: 'Ready' },
@@ -281,11 +283,11 @@ describe('parseNodeStatus', () => {
       ...mciOriginal,
       status: {
         ...mciOriginal.status!,
-        nodeList: [],
+        nodeList: undefined,
       },
     };
 
-    const result = parseNodeStatus(mci);
+    const result = parseNodeStatus(mci, voidLogger);
 
     expect(result).toEqual([]);
   });
@@ -323,7 +325,7 @@ describe('parseNodeStatus', () => {
       },
     };
 
-    const result = () => parseNodeStatus(mci);
+    const result = () => parseNodeStatus(mci, voidLogger);
 
     expect(result).toThrow('Found more node conditions then one');
   });

--- a/plugins/ocm-backend/src/helpers/parser.ts
+++ b/plugins/ocm-backend/src/helpers/parser.ts
@@ -6,6 +6,7 @@ import {
 } from '@janus-idp/backstage-plugin-ocm-common';
 import { maxSatisfying } from 'semver';
 import { ClusterClaim, ManagedCluster, ManagedClusterInfo } from '../types';
+import { Logger } from 'winston';
 
 const convertCpus = (cpus: string | undefined): number | undefined => {
   if (!cpus) {
@@ -88,8 +89,16 @@ export const parseUpdateInfo = (clusterInfo: ManagedClusterInfo) => {
   };
 };
 
-export const parseNodeStatus = (clusterInfo: ManagedClusterInfo) =>
-  clusterInfo.status?.nodeList.map(node => {
+export const parseNodeStatus = (
+  clusterInfo: ManagedClusterInfo,
+  logger: Logger,
+) => {
+  const nodeList = clusterInfo.status?.nodeList;
+  if (!nodeList) {
+    logger.warn(`No nodes found for cluster "${clusterInfo.metadata!.name}" `);
+    return [];
+  }
+  return nodeList.map(node => {
     if (node.conditions.length !== 1) {
       throw new Error('Found more node conditions then one');
     }
@@ -99,7 +108,7 @@ export const parseNodeStatus = (clusterInfo: ManagedClusterInfo) =>
       type: condition.type,
     } as ClusterNodesStatus;
   });
-
+};
 export const translateResourceToOCM = (
   clusterName: string,
   hubResourceName: string,

--- a/plugins/ocm-backend/src/service/router.ts
+++ b/plugins/ocm-backend/src/service/router.ts
@@ -123,7 +123,7 @@ export async function createRouter(
             openshiftVersion:
               mc.metadata!.labels?.openshiftVersion ||
               getClaim(mc, 'version.openshift.io'),
-            nodes: parseNodeStatus(mci),
+            nodes: parseNodeStatus(mci, logger),
             ...parseUpdateInfo(mci),
           } as ClusterOverview;
         });

--- a/plugins/ocm-backend/src/types.ts
+++ b/plugins/ocm-backend/src/types.ts
@@ -49,7 +49,7 @@ export interface ManagedClusterInfo extends KubernetesObject {
     masterEndpoint: string;
   };
   status?: {
-    nodeList: {
+    nodeList?: {
       capacity: {
         cpu: string;
         memory: string;


### PR DESCRIPTION
The OCM backend fails to parse a cluster when there is a cluster with no nodes (for example Jerry in operate-first). This PR fixes this issue. Update tests to correctly test for this condition.