### PR TITLE
fix(ocm): hide logo when not provided

### DIFF
--- a/plugins/ocm-backend/src/helpers/parser.test.ts
+++ b/plugins/ocm-backend/src/helpers/parser.test.ts
@@ -275,7 +275,7 @@ describe('parseNodeStatus', () => {
     ]);
   });
 
-  it('should should return an empty array if nodes are empty', () => {
+  it('should return an empty array if nodes are empty', () => {
     const mciOriginal: ManagedClusterInfo = require(`${FIXTURES_DIR}/internal.open-cluster-management.io/managedclusterinfos/local-cluster.json`);
     const mci = {
       ...mciOriginal,
@@ -290,7 +290,7 @@ describe('parseNodeStatus', () => {
     expect(result).toEqual([]);
   });
 
-  it('should should return an empty array if nodes are not present', () => {
+  it('should return an empty array if nodes are not present', () => {
     const mciOriginal: ManagedClusterInfo = require(`${FIXTURES_DIR}/internal.open-cluster-management.io/managedclusterinfos/local-cluster.json`);
     const mci = {
       ...mciOriginal,
@@ -305,7 +305,7 @@ describe('parseNodeStatus', () => {
     expect(result).toEqual([]);
   });
 
-  it('should should throw an error if there are more conditions in a node', () => {
+  it('should throw an error if there are more conditions in a node', () => {
     const mciOriginal: ManagedClusterInfo = require(`${FIXTURES_DIR}/internal.open-cluster-management.io/managedclusterinfos/local-cluster.json`);
     const mci = {
       ...mciOriginal,

--- a/plugins/ocm/src/components/ClusterStatusPage/ClusterStatusPage.tsx
+++ b/plugins/ocm/src/components/ClusterStatusPage/ClusterStatusPage.tsx
@@ -206,7 +206,7 @@ export const ClusterStatusPage = ({ logo }: { logo?: React.ReactNode }) => {
         <Header title="Your Managed Clusters" />
         <Content>
           <Grid container justifyContent="center" spacing={6}>
-            <HomePageCompanyLogo className={container} logo={logo} />
+            {logo && <HomePageCompanyLogo className={container} logo={logo} />}
             <Grid container item xs={12} justifyContent="center">
               <CatalogClusters />
             </Grid>


### PR DESCRIPTION
Allows the logo to be hidden if not provided.

+ additionally fixes typos in `ocm-backend` test cases descriptions.