### PR TITLE
feat(keycloak): add transformation for username

### DIFF
--- a/plugins/keycloak-backend/src/providers/KeycloakOrgEntityProvider.ts
+++ b/plugins/keycloak-backend/src/providers/KeycloakOrgEntityProvider.ts
@@ -215,7 +215,23 @@ export class KeycloakOrgEntityProvider implements EntityProvider {
 
     await this.connection.applyMutation({
       type: 'full',
-      entities: [...users, ...groups].map(entity => ({
+      entities: [
+        ...users.map(obj => {
+          const existingUsernames = users.map(user => user.metadata.name);
+          let counter = 1;
+          const name = obj.metadata.name
+            .replace(/[^a-zA-Z0-9@-]/g, '-')
+            .replace(/@/g, '');
+          let username = name;
+
+          while (existingUsernames.includes(username)) {
+            username = `${name}-${counter}`;
+            counter++;
+          }
+          return { ...obj, metadata: { ...obj.metadata, name: username } };
+        }),
+        ...groups,
+      ].map(entity => ({
         locationKey: `keycloak-org-provider:${this.options.id}`,
         entity: withLocations(provider.baseUrl, provider.realm, entity),
       })),


### PR DESCRIPTION
- When Keycloak is configured with an external identity provider like Google, the username will be set as the associated email address.
- Backstage now enforces restrictions, allowing only alphanumeric characters for usernames.