### PR TITLE
test(ocm): add unit tests for ocm plugin

### DIFF
--- a/plugins/ocm/__fixtures__/aborted-cluster.json
+++ b/plugins/ocm/__fixtures__/aborted-cluster.json
@@ -1,0 +1,18 @@
+{
+  "name": "aborted",
+  "consoleUrl": "https://console-openshift-console.apps.foo.bar.baz",
+  "kubernetesVersion": "v1.23.5+012e945",
+  "oauthUrl": "https://oauth-openshift.apps.foo.bar.baz/oauth/token/implicit",
+  "openshiftId": "91976abd-8b8e-47b9-82d3-e84793396ed7",
+  "openshiftVersion": "4.10.51",
+  "platform": "BareMetal",
+  "region": "",
+  "allocatableResources": {
+    "cpuCores": 94.5,
+    "memorySize": "524485752Ki",
+    "numberOfPods": 750
+  },
+  "update": {
+    "available": false
+  }
+}

--- a/plugins/ocm/__fixtures__/cluster1.json
+++ b/plugins/ocm/__fixtures__/cluster1.json
@@ -1,0 +1,29 @@
+{
+  "name": "foo",
+  "consoleUrl": "https://console-openshift-console.apps.foo.bar.baz",
+  "kubernetesVersion": "v1.23.5+012e945",
+  "oauthUrl": "https://oauth-openshift.apps.foo.bar.baz/oauth/token/implicit",
+  "openshiftId": "91976abd-8b8e-47b9-82d3-e84793396ed7",
+  "openshiftVersion": "4.10.26",
+  "platform": "BareMetal",
+  "region": "",
+  "allocatableResources": {
+    "cpuCores": 94.5,
+    "memorySize": "524485752Ki",
+    "numberOfPods": 750
+  },
+  "availableResources": {
+    "cpuCores": 96,
+    "memorySize": "527938680Ki",
+    "numberOfPods": 750
+  },
+  "update": {
+    "available": true,
+    "version": "4.10.51",
+    "url": "https://access.redhat.com/errata/RHSA-2023:0561"
+  },
+  "status": {
+    "available": true,
+    "reason": "Managed cluster is available"
+  }
+}

--- a/plugins/ocm/__fixtures__/offline-cluster.json
+++ b/plugins/ocm/__fixtures__/offline-cluster.json
@@ -1,0 +1,29 @@
+{
+  "name": "offline-cluster",
+  "consoleUrl": "https://console-openshift-console.apps.offline-cluster.bar.baz",
+  "kubernetesVersion": "v1.22.3+fdba464",
+  "oauthUrl": "https://oauth-openshift.apps.offline-cluster.bar.baz/oauth/token/implicit",
+  "openshiftId": "5d448ae7-05f1-42cc-aacc-3122a8ad0184",
+  "openshiftVersion": "4.9.21",
+  "platform": "BareMetal",
+  "region": "",
+  "allocatableResources": {
+    "cpuCores": "1136500m",
+    "memorySize": "7469511796Ki",
+    "numberOfPods": "7750"
+  },
+  "availableResources": {
+    "cpuCores": "1152",
+    "memorySize": "7505192052Ki",
+    "numberOfPods": "7750"
+  },
+  "update": {
+    "available": true,
+    "version": "4.10.51",
+    "url": "https://access.redhat.com/errata/RHSA-2023:0561"
+  },
+  "status": {
+    "available": false,
+    "reason": "Managed cluster is unavailable"
+  }
+}

--- a/plugins/ocm/src/components/ClusterAvailableResourcesCard/ClusterAvailableResourcesCard.test.tsx
+++ b/plugins/ocm/src/components/ClusterAvailableResourcesCard/ClusterAvailableResourcesCard.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import abortedCluster from '../../../__fixtures__/aborted-cluster.json';
+import clusterOne from '../../../__fixtures__/cluster1.json';
+import { useCluster } from '../ClusterContext';
+import { ClusterAvailableResourceCard } from './ClusterAvailableResourcesCard';
+
+jest.mock('../ClusterContext/', () => ({
+  useCluster: jest.fn().mockReturnValue({}),
+}));
+
+describe('ClusterAvailableResourceCard', () => {
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should render the table', () => {
+    (useCluster as jest.Mock).mockReturnValue({ data: clusterOne });
+    const { getByText } = render(<ClusterAvailableResourceCard />);
+
+    expect(getByText('96')).toBeInTheDocument();
+    expect(getByText('503 Gi')).toBeInTheDocument();
+    expect(getByText('750')).toBeInTheDocument();
+  });
+
+  it('should render nothing when there is no cluster data', () => {
+    (useCluster as jest.Mock).mockReturnValue({});
+    const { queryByText } = render(<ClusterAvailableResourceCard />);
+
+    expect(queryByText('96')).toBeNull();
+    expect(queryByText('503 Gi')).toBeNull();
+    expect(queryByText('750')).toBeNull();
+  });
+
+  it('should render nothing when available resources are missing', () => {
+    (useCluster as jest.Mock).mockReturnValue({ data: abortedCluster });
+    const { queryByText } = render(<ClusterAvailableResourceCard />);
+
+    expect(queryByText('96')).toBeNull();
+    expect(queryByText('503 Gi')).toBeNull();
+    expect(queryByText('750')).toBeNull();
+  });
+});

--- a/plugins/ocm/src/components/ClusterContext/ClusterContext.test.tsx
+++ b/plugins/ocm/src/components/ClusterContext/ClusterContext.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import data from '../../../__fixtures__/cluster1.json';
+import { ClusterContextProvider } from './ClusterContext';
+
+jest.mock('../ClusterContext/', () => ({
+  useCluster: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    apiVersion: 'backstage.io/v1beta1',
+    kind: 'Resource',
+    spec: { owner: 'unknown', type: 'kubernetes-cluster' },
+    metadata: {
+      name: 'foo',
+      namespace: 'default',
+      annotations: {
+        'janus-idp.io/ocm-provider-id': 'hub',
+      },
+    },
+  }),
+}));
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: () => ({
+    getClusterByName: () => data,
+  }),
+}));
+
+describe('ClusterContext', () => {
+  it('should render children', () => {
+    const { getByText } = render(
+      <ClusterContextProvider>Child</ClusterContextProvider>,
+    );
+
+    expect(getByText('Child')).toBeInTheDocument();
+  });
+});

--- a/plugins/ocm/src/components/ClusterInfoCard/ClusterInfoCard.test.tsx
+++ b/plugins/ocm/src/components/ClusterInfoCard/ClusterInfoCard.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import data from '../../../__fixtures__/cluster1.json';
+import { useCluster } from '../ClusterContext';
+import { ClusterInfoCard } from './ClusterInfoCard';
+
+jest.mock('../ClusterContext/', () => ({
+  useCluster: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../common', () => ({
+  Status: () => 'Ready',
+  Update: () => '4.10.26',
+}));
+
+describe('ClusterInfoCard', () => {
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should render the table', () => {
+    (useCluster as jest.Mock).mockReturnValue({ data: data });
+    const { getByText } = render(<ClusterInfoCard />);
+
+    expect(getByText('foo')).toBeInTheDocument();
+    expect(getByText('Ready')).toBeInTheDocument();
+    expect(getByText('v1.23.5+012e945')).toBeInTheDocument();
+    expect(
+      getByText('91976abd-8b8e-47b9-82d3-e84793396ed7'),
+    ).toBeInTheDocument();
+    expect(getByText('4.10.26')).toBeInTheDocument();
+    expect(getByText('BareMetal')).toBeInTheDocument();
+  });
+
+  it('should render nothing when there is no cluster data', () => {
+    (useCluster as jest.Mock).mockReturnValue({});
+    const { queryByText } = render(<ClusterInfoCard />);
+
+    expect(queryByText('foo')).toBeNull();
+    expect(queryByText('Ready')).toBeNull();
+    expect(queryByText('v1.23.5+012e945')).toBeNull();
+    expect(queryByText('91976abd-8b8e-47b9-82d3-e84793396ed7')).toBeNull();
+    expect(queryByText('4.10.26')).toBeNull();
+    expect(queryByText('BareMetal')).toBeNull();
+  });
+});

--- a/plugins/ocm/src/components/TableCardFromData/TableCardFromData.test.tsx
+++ b/plugins/ocm/src/components/TableCardFromData/TableCardFromData.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import data from '../../../__fixtures__/cluster1.json';
+import { TableCardFromData } from './TableCardFromData';
+
+describe('TableCardFromData', () => {
+  it('should render the cluster info', () => {
+    const clusterInfoNameMap = new Map<string, string>([
+      ['name', 'Name'],
+      ['kubernetesVersion', 'Kubernetes version'],
+      ['openshiftId', 'OpenShift ID'],
+      ['openshiftVersion', 'OpenShift version'],
+      ['platform', 'Platform'],
+    ]);
+
+    const { getByText } = render(
+      <TableCardFromData
+        data={data}
+        title="Cluster Info"
+        nameMap={clusterInfoNameMap}
+      />,
+    );
+
+    expect(getByText('foo')).toBeInTheDocument();
+    expect(getByText('v1.23.5+012e945')).toBeInTheDocument();
+    expect(
+      getByText('91976abd-8b8e-47b9-82d3-e84793396ed7'),
+    ).toBeInTheDocument();
+    expect(getByText('4.10.26')).toBeInTheDocument();
+    expect(getByText('BareMetal')).toBeInTheDocument();
+  });
+
+  it('should render the available resources', () => {
+    const availableNameMap = new Map<string, string>([
+      ['cpuCores', 'CPU cores'],
+      ['memorySize', 'Memory size'],
+      ['numberOfPods', 'Number of pods'],
+    ]);
+
+    const { getByText } = render(
+      <TableCardFromData
+        data={data.availableResources}
+        title="Available"
+        nameMap={availableNameMap}
+      />,
+    );
+
+    expect(getByText('96')).toBeInTheDocument();
+    expect(getByText('503 Gi')).toBeInTheDocument();
+    expect(getByText('750')).toBeInTheDocument();
+  });
+
+  it('should render nothing if there is an empty name map', () => {
+    const availableNameMap = new Map<string, string>([]);
+
+    const { queryByText } = render(
+      <TableCardFromData
+        data={data.availableResources}
+        title="Available"
+        nameMap={availableNameMap}
+      />,
+    );
+
+    expect(queryByText('96')).toBeNull();
+    expect(queryByText('503 Gi')).toBeNull();
+    expect(queryByText('750')).toBeNull();
+  });
+
+  it('should ignore unknown keys in name map', () => {
+    const availableNameMap = new Map<string, string>([
+      ['cpuCores', 'CPU cores'],
+      ['memorySize', 'Memory size'],
+      ['numberOfProds', 'Number of prods'],
+    ]);
+
+    const { queryByText } = render(
+      <TableCardFromData
+        data={data.availableResources}
+        title="Available"
+        nameMap={availableNameMap}
+      />,
+    );
+
+    expect(queryByText('96')).toBeInTheDocument();
+    expect(queryByText('503 Gi')).toBeInTheDocument();
+    expect(queryByText('Number of prods')).toBeNull();
+  });
+});

--- a/plugins/ocm/src/components/common.test.tsx
+++ b/plugins/ocm/src/components/common.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import abortedCluster from '../../__fixtures__/aborted-cluster.json';
+import clusterOne from '../../__fixtures__/cluster1.json';
+import offlineCluster from '../../__fixtures__/offline-cluster.json';
+import { Status, Update } from './common';
+
+jest.mock('@backstage/core-components', () => ({
+  StatusOK: () => 'StatusOK',
+  StatusError: () => 'StatusError',
+  StatusAborted: () => 'StatusAborted',
+}));
+
+describe('Status', () => {
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should show a Ready status', () => {
+    const { getByText } = render(<Status status={clusterOne.status} />);
+
+    expect(getByText(/StatusOK/i)).toBeInTheDocument();
+  });
+
+  it('should show a Not Ready status', () => {
+    const { getByText } = render(<Status status={offlineCluster.status} />);
+
+    expect(getByText(/StatusError/i)).toBeInTheDocument();
+  });
+});
+
+describe('Update', () => {
+  it('should show that there is an Update', () => {
+    const version = clusterOne.openshiftVersion;
+    const update = clusterOne.update;
+    const { getByText } = render(<Update data={{ version, update }} />);
+
+    expect(getByText('Upgrade available')).toBeInTheDocument();
+  });
+
+  it('should show that there is no Update', () => {
+    const version = abortedCluster.openshiftVersion;
+    const update = abortedCluster.update;
+    const { queryByText } = render(<Update data={{ version, update }} />);
+
+    expect(queryByText('4.10.51')).toBeInTheDocument();
+    expect(queryByText('Upgrade available')).toBeNull();
+  });
+});

--- a/plugins/ocm/src/plugin.test.ts
+++ b/plugins/ocm/src/plugin.test.ts
@@ -1,7 +1,14 @@
+import { OcmApiClient } from './api';
 import { ocmPlugin } from './plugin';
 
 describe('ocm', () => {
   it('should export plugin', () => {
     expect(ocmPlugin).toBeDefined();
+  });
+
+  it('should have the OCM api', () => {
+    const apiFactories = Array.from(ocmPlugin.getApis());
+    expect(apiFactories.length).toBe(1);
+    expect(apiFactories[0].factory({})).toBeInstanceOf(OcmApiClient);
   });
 });


### PR DESCRIPTION
## Description
Add unit tests for the OCM plugin
`ClusterAvailableResourcesCard`
`ClusterContext`
`ClusterInfoCard`
`TableCardFromData`
`common`
`plugin`

## Screenshot
![Screenshot from 2023-06-13 08-13-04](https://github.com/janus-idp/backstage-plugins/assets/82788581/b5f59ac4-67ff-4cbb-8e78-89c368c57db7)
