### PR TITLE
feat(ocm-backend): add support for new backend system

### DIFF
--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -24,6 +24,7 @@
   "configSchema": "config.d.ts",
   "dependencies": {
     "@backstage/backend-common": "^0.18.5",
+    "@backstage/backend-plugin-api": "^0.5.2",
     "@backstage/backend-tasks": "^0.5.2",
     "@backstage/catalog-client": "^1.4.1",
     "@backstage/catalog-model": "^1.3.0",

--- a/plugins/ocm-backend/src/helpers/kubernetes.ts
+++ b/plugins/ocm-backend/src/helpers/kubernetes.ts
@@ -1,3 +1,5 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+
 import {
   CustomObjectsApi,
   KubeConfig,
@@ -11,7 +13,7 @@ import { ManagedCluster, ManagedClusterInfo, OcmConfig } from '../types';
 
 export const hubApiClient = (
   clusterConfig: OcmConfig,
-  logger: Logger,
+  logger: Logger | LoggerService,
 ): CustomObjectsApi => {
   const kubeConfig = new KubeConfig();
 

--- a/plugins/ocm/README.md
+++ b/plugins/ocm/README.md
@@ -228,6 +228,16 @@ If you are interested in Resource discovery and do not want any of the front-end
 
    For more information about the default owner configuration, see [upstream string references documentation](https://backstage.io/docs/features/software-catalog/references/#string-references).
 
+#### Setting up the OCM backend package using the new backend system
+
+The OCM plugin supports integration with the [new backend system](https://backstage.io/docs/backend-system/). In order to install the plugin follow the first 2 configuration steps described [here](#setting-up-the-ocm-backend-package). Then add the following lines to the `packages/backend/src/index.ts` file.
+
+```ts
+import { ocmPlugin } from '@janus-idp/backstage-plugin-ocm-backend';
+
+backend.add(ocmPlugin());
+```
+
 #### Setting up the OCM frontend package
 
 1. Install the OCM frontend plugin using the following command:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8336,9 +8336,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@17.0.60", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^17", "@types/react@^17.0.2":
-  version "17.0.60"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.60.tgz#a4a97dcdbebad76612c188fc06440e4995fd8ad2"
-  integrity sha512-pCH7bqWIfzHs3D+PDs3O/COCQJka+Kcw3RnO9rFA2zalqoXg7cNjJDh6mZ7oRtY1wmY4LVwDdAbA1F7Z8tv3BQ==
+  version "17.0.62"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.62.tgz#2efe8ddf8533500ec44b1334dd1a97caa2f860e3"
+  integrity sha512-eANCyz9DG8p/Vdhr0ZKST8JV12PhH2ACCDYlFw6DIO+D+ca+uP4jtEDEpVqXZrh/uZdXQGwk7whJa3ah5DtyLw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
Part of #238
Add support for the new backend system for the OCM plugin. It can still be used with the old backend system without any issue. The only change that happened is that the package now contains a new export that can be used in the new backend system.