### PR TITLE
feat(topology): support for logviewer for pods based on container

### DIFF
--- a/plugins/topology/src/__fixtures__/1-deployments.ts
+++ b/plugins/topology/src/__fixtures__/1-deployments.ts
@@ -123,7 +123,7 @@ export const mockKubernetesResponse = {
         ],
         containers: [
           {
-            name: 'container',
+            name: 'container-hello',
             image: 'openshift/hello-openshift',
             ports: [
               {

--- a/plugins/topology/src/common/components/ResourceName.tsx
+++ b/plugins/topology/src/common/components/ResourceName.tsx
@@ -19,7 +19,7 @@ export const ResourceIcon = ({ className, kind }: ResourceIconProps) => {
     return null;
   }
   const kindObj = resourceModels[kind];
-  const kindStr = kindObj?.kind;
+  const kindStr = kindObj?.kind || kind;
   const memoKey = className ? `${kind}/${className}` : kind;
   if (MEMO[memoKey]) {
     return MEMO[memoKey];

--- a/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/ContainerSelector.test.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/ContainerSelector.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { fireEvent, render, within } from '@testing-library/react';
+
+import { mockKubernetesResponse } from '../../../../__fixtures__/1-deployments';
+import { ContainerSelector } from './ContainerSelector';
+
+const containerList = [
+  mockKubernetesResponse.pods[0].spec.containers[0],
+  {
+    name: 'container2',
+    image: 'openshift/hello-openshift',
+    ports: [
+      {
+        containerPort: 8080,
+        protocol: 'TCP',
+      },
+    ],
+    resources: {},
+    volumeMounts: [
+      {
+        name: 'kube-api-access-7g8nf',
+        readOnly: true,
+        mountPath: '/var/run/secrets/kubernetes.io/serviceaccount',
+      },
+    ],
+    terminationMessagePath: '/dev/termination-log',
+    terminationMessagePolicy: 'File',
+    imagePullPolicy: 'Always',
+  },
+];
+
+const mockOnContainerChange = jest.fn();
+
+describe('ContainerSelector', () => {
+  it('should render the select dropdown and show selected option', () => {
+    const { queryByText, queryByTestId } = render(
+      <ContainerSelector
+        containersList={containerList}
+        containerSelected="container-hello"
+        onContainerChange={mockOnContainerChange}
+      />,
+    );
+    expect(queryByText(/container-hello/i)).toBeInTheDocument();
+    expect(queryByTestId('container-select')).toBeInTheDocument();
+  });
+
+  it('should trigger onChange handler', () => {
+    const { queryByText, getByRole } = render(
+      <ContainerSelector
+        containersList={containerList}
+        containerSelected="container-hello"
+        onContainerChange={mockOnContainerChange}
+      />,
+    );
+
+    fireEvent.mouseDown(getByRole('button'));
+    const listbox = within(getByRole('listbox'));
+
+    fireEvent.click(listbox.getByText(/container2/i));
+    expect(mockOnContainerChange).toHaveBeenCalled();
+    expect(queryByText(/container2/i)).toBeInTheDocument();
+  });
+});

--- a/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/ContainerSelector.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/ContainerSelector.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { V1Container } from '@kubernetes/client-node';
+import { MenuItem, Select } from '@material-ui/core';
+
+import ResourceName from '../../../../common/components/ResourceName';
+
+type ContainerSelectorType = {
+  containersList: V1Container[];
+  containerSelected: string;
+  onContainerChange: (
+    event: React.ChangeEvent<{
+      name?: string;
+      value: unknown;
+    }>,
+    child: React.ReactNode,
+  ) => void;
+};
+
+export const ContainerSelector = ({
+  containersList,
+  containerSelected,
+  onContainerChange,
+}: ContainerSelectorType) => {
+  return (
+    <Select
+      onChange={onContainerChange}
+      label="Container"
+      style={{ marginLeft: '20px' }}
+      value={containerSelected}
+      data-testid="container-select"
+    >
+      {containersList.map(container => {
+        return (
+          <MenuItem value={container.name} key={container.name}>
+            <ResourceName name={container.name} kind="Container" />
+          </MenuItem>
+        );
+      })}
+    </Select>
+  );
+};

--- a/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/PodLogs.test.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/PodLogs.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { usePodLogs } from '../../../../hooks/usePodLogs';
+import { PodLogs } from './PodLogs';
+
+jest.mock('../../../../hooks/usePodLogs', () => ({
+  usePodLogs: jest.fn(),
+}));
+
+jest.mock('@backstage/core-components', () => ({
+  ...jest.requireActual('@backstage/core-components'),
+  LogViewer: () => <div data-testid="log-viewer">Log viewer</div>,
+  DismissableBanner: () => (
+    <div data-testid="pod-log-banner">Dismissable banner</div>
+  ),
+}));
+
+describe('PodLogs', () => {
+  it('should render logviewer', () => {
+    const podScopeData = {
+      podName: 'node-ex-git-er56',
+      podNamespace: 'sample-app',
+      containerName: 'node-ex-git',
+      clusterName: 'OCP',
+    };
+    (usePodLogs as jest.Mock).mockReturnValue({
+      loading: false,
+      value: 'log data...',
+    });
+    const { queryByTestId } = render(<PodLogs podScope={podScopeData} />);
+    expect(queryByTestId('pod-log-banner')).not.toBeInTheDocument();
+    expect(queryByTestId('log-viewer')).toBeInTheDocument();
+  });
+
+  it('should render logviewer skeleton', () => {
+    const podScopeData = {
+      podName: 'node-ex-git-er56',
+      podNamespace: 'sample-app',
+      containerName: 'node-ex-git',
+      clusterName: 'OCP',
+    };
+    (usePodLogs as jest.Mock).mockReturnValue({ loading: true });
+    const { queryByTestId } = render(<PodLogs podScope={podScopeData} />);
+    expect(queryByTestId('pod-log-banner')).not.toBeInTheDocument();
+    expect(queryByTestId('log-viewer')).not.toBeInTheDocument();
+    expect(queryByTestId('logs-skeleton')).toBeInTheDocument();
+  });
+
+  it('should render DismissableBanner in case of error', () => {
+    const podScopeData = {
+      podName: 'node-ex-git-er56',
+      podNamespace: 'sample-app',
+      containerName: 'node-ex-git',
+      clusterName: 'OCP',
+    };
+    (usePodLogs as jest.Mock).mockReturnValue({
+      loading: false,
+      error: { message: 'some crash!!' },
+    });
+    const { queryByTestId } = render(<PodLogs podScope={podScopeData} />);
+    expect(queryByTestId('pod-log-banner')).toBeInTheDocument();
+    expect(queryByTestId('log-viewer')).not.toBeInTheDocument();
+    expect(queryByTestId('logs-skeleton')).not.toBeInTheDocument();
+  });
+});

--- a/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/PodLogs.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/PodLogs.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import { DismissableBanner, LogViewer } from '@backstage/core-components';
+
+import { Paper } from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
+
+import { usePodLogs } from '../../../../hooks/usePodLogs';
+import { ContainerScope } from './types';
+
+type PodLogsProps = {
+  podScope: ContainerScope;
+};
+
+export const PodLogs = ({ podScope }: PodLogsProps) => {
+  const { value, error, loading } = usePodLogs({
+    podScope: podScope,
+  });
+
+  return (
+    <>
+      {error && (
+        <DismissableBanner
+          {...{
+            message: error.message,
+            variant: 'error',
+            fixed: false,
+          }}
+          id="pod-logs"
+        />
+      )}
+      <Paper
+        elevation={1}
+        style={{ height: '100%', width: '100%', minHeight: '30rem' }}
+      >
+        {loading && (
+          <Skeleton
+            data-testid="logs-skeleton"
+            variant="rect"
+            width="100%"
+            height="100%"
+          />
+        )}
+        {!loading && value !== undefined && <LogViewer text={value.text} />}
+      </Paper>
+    </>
+  );
+};

--- a/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/PodLogsDialog.test.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/PodLogsDialog.test.tsx
@@ -1,0 +1,48 @@
+import React, { useContext } from 'react';
+
+import { V1Pod } from '@kubernetes/client-node';
+import { render } from '@testing-library/react';
+
+import { mockKubernetesResponse } from '../../../../__fixtures__/1-deployments';
+import { PodLogsDialog } from './PodLogsDialog';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn(),
+}));
+
+jest.mock('@material-ui/core', () => ({
+  ...jest.requireActual('@material-ui/core'),
+  makeStyles: () => () => {
+    return {
+      titleContainer: 'title',
+      closeButton: 'close',
+    };
+  },
+  Dialog: () => <div data-testid="dialog" />,
+}));
+
+describe('PodLogsDialog', () => {
+  it('should show Dialog & View logs', () => {
+    (useContext as jest.Mock).mockReturnValue({
+      clusters: ['OCP'],
+      selectedCluster: [0],
+    });
+    const { queryByText, queryByTestId } = render(
+      <PodLogsDialog podData={mockKubernetesResponse.pods[0] as V1Pod} />,
+    );
+    expect(queryByText(/View Logs/i)).toBeInTheDocument();
+    expect(queryByTestId('dialog')).toBeInTheDocument();
+  });
+
+  it('should not show Dialog & View logs', () => {
+    (useContext as jest.Mock).mockReturnValue({
+      clusters: [],
+    });
+    const { queryByText, queryByTestId } = render(
+      <PodLogsDialog podData={mockKubernetesResponse.pods[0] as V1Pod} />,
+    );
+    expect(queryByText(/View Logs/i)).not.toBeInTheDocument();
+    expect(queryByTestId('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/PodLogsDialog.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/PodLogsDialog.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+
+import { ErrorBoundary } from '@backstage/core-components';
+
+import { V1Pod } from '@kubernetes/client-node';
+import {
+  Box,
+  createStyles,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  makeStyles,
+  Theme,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import { Button } from '@patternfly/react-core';
+
+import ResourceName from '../../../../common/components/ResourceName';
+import { K8sResourcesContext } from '../../../../hooks/K8sResourcesContext';
+import { ContainerSelector } from './ContainerSelector';
+import { PodLogs } from './PodLogs';
+import { ContainerScope } from './types';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    titleContainer: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+    },
+    closeButton: {
+      position: 'absolute',
+      right: theme.spacing(1),
+      top: theme.spacing(1),
+      color: theme.palette.grey[500],
+    },
+  }),
+);
+
+type PodLogsDialogProps = {
+  podData: V1Pod;
+};
+
+export const PodLogsDialog = ({ podData }: PodLogsDialogProps) => {
+  const { clusters, selectedCluster } = React.useContext(K8sResourcesContext);
+  const classes = useStyles();
+  const [open, setOpen] = useState<boolean>(false);
+
+  const curCluster =
+    (clusters.length > 0 && clusters[selectedCluster || 0]) || '';
+  const { name: podName = '', namespace: podNamespace = '' } =
+    podData?.metadata || {};
+  const containersList = podData.spec?.containers || [];
+
+  const curContainer =
+    (containersList?.length && (containersList?.[0].name as string)) || '';
+
+  const [containerSelected, setContainerSelected] =
+    React.useState<string>(curContainer);
+  const [podScope, setPodScope] = React.useState<ContainerScope>({
+    containerName: curContainer,
+    podName,
+    podNamespace: podNamespace,
+    clusterName: curCluster,
+  });
+
+  const onContainerChange = (
+    event: React.ChangeEvent<{ name?: string; value: unknown }>,
+  ) => {
+    setContainerSelected(event.target.value as string);
+  };
+
+  const openDialog = () => {
+    setOpen(true);
+  };
+
+  const closeDialog = () => {
+    setOpen(false);
+  };
+
+  React.useEffect(() => {
+    if (containerSelected) {
+      setPodScope(ps => ({
+        ...ps,
+        containerName: containerSelected as string,
+      }));
+    }
+  }, [containerSelected]);
+
+  if (!podName || !podNamespace || !curCluster) {
+    return null;
+  }
+
+  return (
+    <>
+      <Dialog maxWidth="xl" fullWidth open={open} onClose={closeDialog}>
+        <DialogTitle id="dialog-title">
+          <Box className={classes.titleContainer}>
+            <ResourceName name={podName} kind={podData.kind as string} />
+            <IconButton
+              aria-label="close"
+              className={classes.closeButton}
+              onClick={closeDialog}
+            >
+              <CloseIcon />
+            </IconButton>
+            <ContainerSelector
+              containersList={containersList}
+              onContainerChange={onContainerChange}
+              containerSelected={containerSelected}
+            />
+          </Box>
+        </DialogTitle>
+        <DialogContent>
+          <ErrorBoundary>
+            <PodLogs podScope={podScope} />
+          </ErrorBoundary>
+        </DialogContent>
+      </Dialog>
+      <Button
+        style={{ padding: 0 }}
+        variant="link"
+        aria-label="view logs"
+        onClick={openDialog}
+      >
+        View Logs
+      </Button>
+    </>
+  );
+};

--- a/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/types.ts
+++ b/plugins/topology/src/components/Topology/TopologySideBar/PodLogs/types.ts
@@ -1,0 +1,6 @@
+export interface ContainerScope {
+  podName: string;
+  podNamespace: string;
+  clusterName: string;
+  containerName: string;
+}

--- a/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
+++ b/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
@@ -17,6 +17,7 @@ import {
 import { JobData } from '../../../types/jobs';
 import PodStatus from '../../Pods/PodStatus';
 import PLRlist from './PLRlist';
+import { PodLogsDialog } from './PodLogs/PodLogsDialog';
 import IngressListSidebar from './Resources/IngressListSidebar';
 import RouteListSidebar from './Resources/RouteListSidebar';
 import TopologyResourcesTabPanelItem from './TopologyResourcesTabPaneltem';
@@ -50,6 +51,7 @@ const TopologyResourcesTabPanel = ({
 
     return <IngressListSidebar ingressesData={ingressesData} />;
   };
+
   return (
     <div data-testid="resources-tab">
       <TopologyResourcesTabPanelItem
@@ -73,6 +75,9 @@ const TopologyResourcesTabPanel = ({
                 >
                   <Status status={pod.status?.phase ?? ''} />
                 </ResourceStatus>
+              </span>
+              <span style={{ flex: '1' }}>
+                <PodLogsDialog podData={pod} />
               </span>
             </li>
           ))}

--- a/plugins/topology/src/hooks/useK8sObjectsResponse.test.ts
+++ b/plugins/topology/src/hooks/useK8sObjectsResponse.test.ts
@@ -1,6 +1,6 @@
 import { useKubernetesObjects } from '@backstage/plugin-kubernetes';
 
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 
 import { watchResourcesData } from '../__fixtures__/k8sResourcesContextData';
 import { kubernetesObject } from '../__fixtures__/kubernetesObject';
@@ -43,5 +43,62 @@ describe('useK8sObjectsResponse', () => {
     expect(result.current.watchResourcesData).toEqual(watchResourcesData);
     expect(result.current.clusters).toEqual(['minikube']);
     expect(result.current.selectedClusterErrors).toEqual([]);
+  });
+
+  it('should return k8sResourcesContextData with empty clusters if it does not exist', () => {
+    mockUseKubernetesObjects.mockReturnValue({
+      kubernetesObjects: { items: [] },
+      loading: false,
+      error: '',
+    });
+    const { result } = renderHook(() =>
+      useK8sObjectsResponse(watchedResources),
+    );
+    expect(result.current.watchResourcesData).toEqual({});
+    expect(result.current.clusters).toEqual([]);
+    expect(result.current.selectedClusterErrors).toEqual([]);
+  });
+
+  it('should return k8sResourcesContextData with 2 clusters', () => {
+    mockUseKubernetesObjects.mockReturnValue({
+      kubernetesObjects: {
+        items: [{ cluster: { name: 'OCP' } }, kubernetesObject.items[0]],
+      },
+      loading: false,
+      error: '',
+    });
+    const { result } = renderHook(() =>
+      useK8sObjectsResponse(watchedResources),
+    );
+    expect(result.current.watchResourcesData).toEqual({});
+    expect(result.current.clusters).toEqual(['OCP', 'minikube']);
+    expect(result.current.selectedClusterErrors).toEqual([]);
+    expect(result.current.selectedCluster).toEqual(0);
+  });
+
+  it('should return k8sResourcesContextData with 2 clusters and update selectedCluster', () => {
+    mockUseKubernetesObjects.mockReturnValue({
+      kubernetesObjects: {
+        items: [{ cluster: { name: 'OCP' } }, kubernetesObject.items[0]],
+      },
+      loading: false,
+      error: '',
+    });
+    const { result } = renderHook(() =>
+      useK8sObjectsResponse(watchedResources),
+    );
+    expect(result.current.watchResourcesData).toEqual({});
+    expect(result.current.clusters).toEqual(['OCP', 'minikube']);
+    expect(result.current.selectedClusterErrors).toEqual([]);
+    expect(result.current.selectedCluster).toEqual(0);
+
+    act(() => {
+      result.current.setSelectedCluster(1);
+    });
+
+    expect(result.current.watchResourcesData).toEqual(watchResourcesData);
+    expect(result.current.clusters).toEqual(['OCP', 'minikube']);
+    expect(result.current.selectedClusterErrors).toEqual([]);
+    expect(result.current.selectedCluster).toEqual(1);
   });
 });

--- a/plugins/topology/src/hooks/useK8sObjectsResponse.ts
+++ b/plugins/topology/src/hooks/useK8sObjectsResponse.ts
@@ -30,5 +30,6 @@ export const useK8sObjectsResponse = (
     selectedClusterErrors: clusterErrors?.[selectedCluster] ?? [],
     clusters,
     setSelectedCluster,
+    selectedCluster,
   };
 };

--- a/plugins/topology/src/hooks/usePodLogs.test.ts
+++ b/plugins/topology/src/hooks/usePodLogs.test.ts
@@ -1,0 +1,55 @@
+import { useApi } from '@backstage/core-plugin-api';
+
+import { renderHook } from '@testing-library/react-hooks';
+
+import { usePodLogs } from './usePodLogs';
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: jest.fn(),
+}));
+
+describe('usePodLogs', () => {
+  it('should return loading as true and value as undefined initially', () => {
+    (useApi as any).mockReturnValue({
+      getPodLogs: jest.fn().mockResolvedValue({ text: 'log data...' }),
+    });
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePodLogs({
+        podScope: {
+          podName: 'node-ex-git-er56',
+          podNamespace: 'sample-app',
+          containerName: 'node-ex-git',
+          clusterName: 'OCP',
+        },
+        intervalMs: 500,
+      }),
+    );
+
+    waitForNextUpdate();
+
+    expect(result.current.loading).toEqual(true);
+    expect(result.current.value).toBeUndefined();
+  });
+
+  it('should return value as log text', async () => {
+    (useApi as any).mockReturnValue({
+      getPodLogs: jest.fn().mockResolvedValueOnce({ text: 'log data...' }),
+    });
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePodLogs({
+        podScope: {
+          podName: 'node-ex-git-er56',
+          podNamespace: 'sample-app',
+          containerName: 'node-ex-git',
+          clusterName: 'OCP',
+        },
+        intervalMs: 500,
+      }),
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.value).toEqual({ text: 'log data...' });
+  });
+});

--- a/plugins/topology/src/hooks/usePodLogs.ts
+++ b/plugins/topology/src/hooks/usePodLogs.ts
@@ -1,0 +1,51 @@
+import React from 'react';
+import useAsyncRetry from 'react-use/lib/useAsyncRetry';
+import useInterval from 'react-use/lib/useInterval';
+
+import { useApi } from '@backstage/core-plugin-api';
+import { kubernetesProxyApiRef } from '@backstage/plugin-kubernetes';
+
+import { ContainerScope } from '../components/Topology/TopologySideBar/PodLogs/types';
+
+interface PodLogsOptions {
+  podScope: ContainerScope;
+  intervalMs?: number;
+}
+
+export const usePodLogs = ({ podScope, intervalMs = 5000 }: PodLogsOptions) => {
+  const [loadingData, setLoadingData] = React.useState<boolean>(true);
+  const kubernetesProxyApi = useApi(kubernetesProxyApiRef);
+  const getLogs = React.useCallback(async (): Promise<{ text: string }> => {
+    const { podName, podNamespace, containerName, clusterName } = podScope;
+    return await kubernetesProxyApi.getPodLogs({
+      podName: podName,
+      namespace: podNamespace,
+      containerName: containerName,
+      clusterName: clusterName,
+    });
+  }, [kubernetesProxyApi, podScope]);
+
+  const { value, error, loading, retry } = useAsyncRetry(
+    () => getLogs(),
+    [getLogs],
+  );
+
+  useInterval(() => retry(), intervalMs);
+
+  React.useEffect(() => {
+    let mounted = true;
+    if (!loading && mounted) {
+      setLoadingData(prevState => {
+        if (prevState) {
+          return false;
+        }
+        return prevState;
+      });
+    }
+    return () => {
+      mounted = false;
+    };
+  }, [loading]);
+
+  return { value, error, loading: loadingData };
+};

--- a/plugins/topology/src/types/types.ts
+++ b/plugins/topology/src/types/types.ts
@@ -58,6 +58,7 @@ export type K8sResourcesContextData = {
   selectedClusterErrors?: ClusterErrors;
   clusters: string[];
   setSelectedCluster: React.Dispatch<React.SetStateAction<number>>;
+  selectedCluster?: number;
 };
 
 export type TektonResponseData = {


### PR DESCRIPTION
**Tracks:** https://github.com/janus-idp/backstage-plugins/issues/395

**Description:** Show the logs for pods associated with any k8s workload

**Screenshots/Gif**: 

<img width="1792" alt="image" src="https://github.com/janus-idp/backstage-plugins/assets/5129024/6b1a3252-2627-4914-8574-3bafb38ce41f">


<img width="1792" alt="image" src="https://github.com/janus-idp/backstage-plugins/assets/5129024/ca0d5d42-0064-4f15-b147-91eda32c4c30">

Light Theme:

<img width="1792" alt="image" src="https://github.com/janus-idp/backstage-plugins/assets/5129024/0e87aafd-9d93-478b-ac24-2155076e11fb">


**TODO:**

- [x]  Should show `view logs`  in the resources tab for workloads in the pods section for sidepanel
- [x] On click on view logs, should open a modal with logs for the selected pod
- [x]  In the log component show a filter to search and should show a dropdown to select any container for pod
- [x] UI refinement (handle error and edge cases scenarios)
- [x]  Add Unit tests

<img width="1157" alt="image" src="https://github.com/janus-idp/backstage-plugins/assets/5129024/ff372f12-de98-4fe9-934c-0a659aa7cf99">
