### PR TITLE
chore(renovate): update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,17 +2,23 @@
   "extends": [
     "config:js-lib",
     ":gitSignOff",
+    ":rebaseStalePrs",
     "group:allNonMajor",
     "group:linters",
-    "group:semantic-releaseMonorepo"
+    "group:test"
   ],
+  "labels": ["kind/dependency upgrade"],
   "npm": {
-    "stabilityDays": 1
+    "minimumReleaseAge": "1 day"
   },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions"
+    },
+    {
+      "matchPackagePatterns": ["^@backstage/"],
+      "groupName": ["Core Backstage packages"]
     }
   ]
 }


### PR DESCRIPTION
## Enhancement

- Remove `group:semantic-releaseMonorepo` - Already included in `config:js-lib`
- Add [`:rebaseStalePrs`](https://docs.renovatebot.com/presets-default/#rebasestaleprs) - Rebase existing PRs any time the base branch has been updated.
- Add [`group:test`](https://docs.renovatebot.com/presets-group/#grouptest) - Group all test packages together.
- Add `kind/dependency upgrade` label to all renovate pull requests
- Update `stabilityDays` to [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) 
    > This feature used to be called stabilityDays.
- Add package rule for Core Backstage packages

## Fixes

- Fixes https://github.com/janus-idp/backstage-plugins/issues/465