### PR TITLE
fix(tekton): fix pipelinerun task status info

### DIFF
--- a/plugins/tekton/src/components/Charts/PipelineBars.tsx
+++ b/plugins/tekton/src/components/Charts/PipelineBars.tsx
@@ -8,7 +8,7 @@ import { PipelineRunKind } from '../../types/pipelineRun';
 import { getRunStatusColor } from '../../utils/tekton-status';
 import {
   getTaskRunsForPipelineRun,
-  getTaskStatus,
+  getTaskStatusOfPLR,
 } from '../../utils/tekton-utils';
 import HorizontalStackedBars from './HorizontalStackedBars';
 import TaskStatusToolTip from './TaskStatusTooltip';
@@ -21,7 +21,7 @@ export const PipelineBars = ({ pipelinerun }: PipelineBarProps) => {
   const { watchResourcesData } = React.useContext(TektonResourcesContext);
   const taskRuns = watchResourcesData?.taskruns?.data || [];
   const plrTasks = getTaskRunsForPipelineRun(pipelinerun, taskRuns);
-  const taskStatus = getTaskStatus(pipelinerun, plrTasks);
+  const taskStatus = getTaskStatusOfPLR(pipelinerun, plrTasks);
   return (
     <Tooltip content={<TaskStatusToolTip taskStatus={taskStatus} />}>
       <HorizontalStackedBars

--- a/plugins/tekton/src/utils/tekton-utils.test.ts
+++ b/plugins/tekton/src/utils/tekton-utils.test.ts
@@ -7,7 +7,7 @@ import {
   calculateDuration,
   getClusters,
   getDuration,
-  getTaskStatus,
+  getTaskStatusOfPLR,
   getTektonResources,
   pipelineRunDuration,
   totalPipelineRunTasks,
@@ -77,13 +77,13 @@ describe('tekton-utils', () => {
     });
   });
 
-  it('updateTaskStatus should return the updated task status if none exists', () => {
+  it('updateTaskStatus should return the updated task status if no taskrun exist', () => {
     const mockPipelineRun = {
       ...kubernetesObjects.items[0].resources[0].resources[0],
       status: {},
     };
     const updatedTaskStatus = updateTaskStatus(mockPipelineRun, [
-      mockKubernetesPlrResponse.taskruns[0],
+      mockKubernetesPlrResponse.taskruns[1],
     ]);
     expect(updatedTaskStatus).toEqual({
       PipelineNotStarted: 0,
@@ -96,8 +96,8 @@ describe('tekton-utils', () => {
     });
   });
 
-  it('getTaskStatus should return the updated task status', () => {
-    const updatedTaskStatus = getTaskStatus(
+  it('getTaskStatusOfPLR should return the updated task status', () => {
+    const updatedTaskStatus = getTaskStatusOfPLR(
       mockKubernetesPlrResponse.pipelineruns[0],
       [mockKubernetesPlrResponse.taskruns[0]],
     );
@@ -112,13 +112,13 @@ describe('tekton-utils', () => {
     });
   });
 
-  it('getTaskStatus should return the updated task status if none exists', () => {
+  it('getTaskStatusOfPLR should return the updated task status if no taskrun exist', () => {
     const mockPipelineRun = {
       ...kubernetesObjects.items[0].resources[0].resources[0],
       status: {},
     };
-    const updatedTaskStatus = getTaskStatus(mockPipelineRun, [
-      mockKubernetesPlrResponse.taskruns[0],
+    const updatedTaskStatus = getTaskStatusOfPLR(mockPipelineRun, [
+      mockKubernetesPlrResponse.taskruns[1],
     ]);
     expect(updatedTaskStatus).toEqual({
       PipelineNotStarted: 1,

--- a/plugins/tekton/src/utils/tekton-utils.ts
+++ b/plugins/tekton/src/utils/tekton-utils.ts
@@ -102,6 +102,7 @@ export const updateTaskStatus = (
   pipelinerun: PipelineRunKind,
   taskRuns: TaskRunKind[],
 ): TaskStatus => {
+  const plrTasks = getTaskRunsForPipelineRun(pipelinerun, taskRuns);
   const skippedTaskLength = pipelinerun?.status?.skippedTasks?.length || 0;
   const taskStatus: TaskStatus = {
     PipelineNotStarted: 0,
@@ -112,11 +113,12 @@ export const updateTaskStatus = (
     Cancelled: 0,
     Skipped: skippedTaskLength,
   };
-  if (!pipelinerun?.status?.taskRuns) {
+
+  if (plrTasks.length === 0) {
     return taskStatus;
   }
 
-  taskRuns.forEach((taskRun: TaskRunKind) => {
+  plrTasks.forEach((taskRun: TaskRunKind) => {
     const status = taskRun && pipelineRunFilterReducer(taskRun);
     if (status === 'Succeeded') {
       taskStatus[ComputedStatus.Succeeded]++;
@@ -136,17 +138,18 @@ export const updateTaskStatus = (
   };
 };
 
-export const getTaskStatus = (
+export const getTaskStatusOfPLR = (
   pipelinerun: PipelineRunKind,
   taskRuns: TaskRunKind[],
 ) => {
   const totalTasks = totalPipelineRunTasks(pipelinerun);
-  const plrTaskLength = taskRuns.length;
+  const plrTasks = getTaskRunsForPipelineRun(pipelinerun, taskRuns);
+  const plrTaskLength = plrTasks.length;
   const skippedTaskLength = pipelinerun?.status?.skippedTasks?.length || 0;
 
-  const taskStatus: TaskStatus = updateTaskStatus(pipelinerun, taskRuns);
+  const taskStatus: TaskStatus = updateTaskStatus(pipelinerun, plrTasks);
 
-  if (pipelinerun?.status?.taskRuns) {
+  if (plrTasks?.length > 0) {
     const pipelineRunHasFailure = taskStatus[ComputedStatus.Failed] > 0;
     const pipelineRunIsCancelled =
       pipelineRunFilterReducer(pipelinerun) === ComputedStatus.Cancelled;


### PR DESCRIPTION
**Fixes:**
https://github.com/janus-idp/backstage-plugins/issues/487

**Root analysis:**

With the new Pipelines Operator updates, the `taskRuns` property in the pipelineRun status has been deprecated and our code was relying on this deprecated property to visualize the Task Status. 

**Screenshot:**
![Screenshot 2023-06-26 at 5 11 01 PM](https://github.com/janus-idp/backstage-plugins/assets/22490998/efaf99c3-25d0-4079-be10-a7e7b4356319)
