### PR TITLE
Add admin role for RBAC

### DIFF
--- a/packages/backend/src/plugins/permissions.ts
+++ b/packages/backend/src/plugins/permissions.ts
@@ -12,5 +12,6 @@ export default async function createPlugin(
     logger: env.logger,
     discovery: env.discovery,
     identity: env.identity,
+    permissions: env.permissions,
   });
 }

--- a/plugins/rh-rbac-backend/config.d.ts
+++ b/plugins/rh-rbac-backend/config.d.ts
@@ -1,0 +1,30 @@
+export interface Config {
+  permission: {
+    /**
+     * Optional configuration for admins, can declare individual users and / or groups
+     * @visibility frontend
+     */
+    admin?: {
+      /**
+       * The list of users with admin access
+       * @visibility frontend
+       */
+      users?: Array<{
+        /**
+         * @visibility frontend
+         */
+        name: string;
+      }>;
+      /**
+       * @visibility frontend
+       * The list of groups with admin access
+       */
+      groups?: Array<{
+        /**
+         * @visibility frontend
+         */
+        name: string;
+      }>;
+    };
+  };
+}

--- a/plugins/rh-rbac-backend/package.json
+++ b/plugins/rh-rbac-backend/package.json
@@ -17,7 +17,7 @@
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",
     "lint": "backstage-cli package lint",
-    "test": "backstage-cli package test",
+    "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack"
@@ -25,6 +25,7 @@
   "dependencies": {
     "@backstage/backend-common": "^0.18.4",
     "@backstage/config": "^1.0.7",
+    "@backstage/core-plugin-api": "^1.5.2",
     "@backstage/plugin-auth-node": "^0.2.14",
     "@backstage/plugin-permission-backend": "^0.5.20",
     "@backstage/plugin-permission-common": "^0.7.5",

--- a/plugins/rh-rbac-backend/src/permissions.ts
+++ b/plugins/rh-rbac-backend/src/permissions.ts
@@ -1,0 +1,68 @@
+import {
+  createPermission,
+  ResourcePermission,
+} from '@backstage/plugin-permission-common';
+
+export const RESOURCE_TYPE_PERMISSION_ENTITY = 'permission-entity';
+
+/**
+ * Convenience type for permission entity
+ */
+export type PermissionEntityPermission = ResourcePermission<
+  typeof RESOURCE_TYPE_PERMISSION_ENTITY
+>;
+
+/**
+ * This permission is used to authorize actions that involve reading
+ * permission policies.
+ */
+export const permissionEntityReadPermission = createPermission({
+  name: 'permission.entity.read',
+  attributes: {
+    action: 'read',
+  },
+  resourceType: RESOURCE_TYPE_PERMISSION_ENTITY,
+});
+
+/**
+ * This permission is used to authorize the creation of new permission policies.
+ */
+export const permissionEntityCreatePermission = createPermission({
+  name: 'permission.entity.create',
+  attributes: {
+    action: 'create',
+  },
+});
+
+/**
+ * This permission is used to authorize actions that involve removing permission
+ * policies.
+ */
+export const permissionEntityDeletePermission = createPermission({
+  name: 'permission.entity.delete',
+  attributes: {
+    action: 'delete',
+  },
+  resourceType: RESOURCE_TYPE_PERMISSION_ENTITY,
+});
+
+/**
+ * This permission is used to authorize refreshing permission policies
+ */
+export const permissionEntityRefreshPermission = createPermission({
+  name: 'permission.entity.refresh',
+  attributes: {
+    action: 'update',
+  },
+  resourceType: RESOURCE_TYPE_PERMISSION_ENTITY,
+});
+
+/**
+ * List of all permissions on permission polices.
+ */
+export const permissionEntityPermissions = [
+  permissionEntityReadPermission,
+  permissionEntityCreatePermission,
+  permissionEntityDeletePermission,
+  permissionEntityRefreshPermission,
+];

--- a/plugins/rh-rbac-backend/src/service/policy-builder.test.ts
+++ b/plugins/rh-rbac-backend/src/service/policy-builder.test.ts
@@ -1,23 +1,89 @@
 // import { getVoidLogger } from '@backstage/backend-common';
+import { getVoidLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+
+import express from 'express';
+import request from 'supertest';
+
+import { permissionEntityReadPermission } from '../permissions';
 import { PolicyBuilder } from './policy-builder';
 
-describe('policyBuilder', () => {
-  beforeAll(async () => {});
+jest.mock('@backstage/plugin-auth-node', () => ({
+  getBearerTokenFromAuthorizationHeader: () => 'token',
+}));
 
-  beforeEach(() => {
-    jest.resetAllMocks();
+describe('PolicyBuilder', () => {
+  let app: express.Express;
+
+  const mockedAuthorize = jest.fn().mockImplementation(async () => [
+    {
+      result: AuthorizeResult.ALLOW,
+    },
+  ]);
+
+  const mockedAuthorizeConditional = jest.fn().mockImplementation(async () => [
+    {
+      result: AuthorizeResult.ALLOW,
+    },
+  ]);
+
+  const mockPermissionEvaluator = {
+    authorize: mockedAuthorize,
+    authorizeConditional: mockedAuthorizeConditional,
+  };
+
+  const mockUser = {
+    type: 'User',
+    userEntityRef: 'user:default/guest',
+    ownershipEntityRefs: ['guest'],
+  };
+
+  const mockIdentityClient = {
+    getIdentity: jest.fn().mockImplementation(async () => ({
+      identity: mockUser,
+    })),
+  };
+
+  beforeEach(async () => {
+    const router = await PolicyBuilder.build({
+      config: new ConfigReader({ permission: { enabled: true } }),
+      logger: getVoidLogger(),
+      discovery: {
+        getBaseUrl: jest.fn(),
+        getExternalBaseUrl: jest.fn(),
+      },
+      identity: mockIdentityClient,
+      permissions: mockPermissionEvaluator,
+    });
+    app = express().use(router);
+    jest.clearAllMocks();
   });
 
-  describe('PolicyBuilder', () => {
-    it('should build', () => {
-      expect(PolicyBuilder).toBeTruthy();
-      // PolicyBuilder.build({
-      //     config:
-      //     logger: getVoidLogger(),
-      //     discovery: env.discovery,
-      //     identity: env.identity,
-      //   }
-      // )
+  it('should build', () => {
+    expect(app).toBeTruthy();
+  });
+
+  describe('GET /', () => {
+    it('should return a status of Authorized', async () => {
+      const result = await request(app).get('/').send();
+
+      expect(result.status).toBe(200);
+      expect(result.body).toEqual({ status: 'Authorized' });
+    });
+
+    it('should return a status of Unauthorized', async () => {
+      mockedAuthorizeConditional.mockImplementationOnce(async () => [
+        { result: AuthorizeResult.DENY },
+      ]);
+      const result = await request(app).get('/').send();
+
+      expect(mockedAuthorizeConditional).toHaveBeenCalledWith(
+        [{ permission: permissionEntityReadPermission }],
+        { token: 'token' },
+      );
+      expect(result.status).toBe(403);
+      expect(result.body).toEqual({ status: 'Unauthorized' });
     });
   });
 });

--- a/plugins/rh-rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rh-rbac-backend/src/service/policy-builder.ts
@@ -3,16 +3,29 @@ import {
   resolvePackagePath,
 } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
-import { IdentityApi } from '@backstage/plugin-auth-node';
+import {
+  getBearerTokenFromAuthorizationHeader,
+  IdentityApi,
+} from '@backstage/plugin-auth-node';
 import {
   createRouter,
   RouterOptions,
 } from '@backstage/plugin-permission-backend';
+import {
+  AuthorizeResult,
+  PermissionEvaluator,
+} from '@backstage/plugin-permission-common';
+import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 
 import { FileAdapter } from 'casbin';
 import { Router } from 'express';
 import { Logger } from 'winston';
 
+import {
+  permissionEntityPermissions,
+  permissionEntityReadPermission,
+  RESOURCE_TYPE_PERMISSION_ENTITY,
+} from '../permissions';
 import { RBACPermissionPolicy } from './permission-policy';
 
 export class PolicyBuilder {
@@ -21,6 +34,7 @@ export class PolicyBuilder {
     logger: Logger;
     discovery: PluginEndpointDiscovery;
     identity: IdentityApi;
+    permissions: PermissionEvaluator;
   }): Promise<Router> {
     // TODO: Replace with a DB adapter.
     const fileAdapter = new FileAdapter(
@@ -30,13 +44,51 @@ export class PolicyBuilder {
       ),
     );
 
+    const permissions = env.permissions;
+
     const options: RouterOptions = {
       config: env.config,
       logger: env.logger,
       discovery: env.discovery,
       identity: env.identity,
-      policy: await RBACPermissionPolicy.build(env.logger, fileAdapter),
+      policy: await RBACPermissionPolicy.build(
+        env.logger,
+        fileAdapter,
+        env.config,
+      ),
     };
-    return createRouter(options);
+
+    const router = await createRouter(options);
+
+    const permissionsIntergrationRouter = createPermissionIntegrationRouter({
+      resourceType: RESOURCE_TYPE_PERMISSION_ENTITY,
+      permissions: permissionEntityPermissions,
+    });
+
+    router.use(permissionsIntergrationRouter);
+
+    router.get('/', async (request, response) => {
+      const token = getBearerTokenFromAuthorizationHeader(
+        request.header('authorization'),
+      );
+
+      const decision = (
+        await permissions.authorizeConditional(
+          [{ permission: permissionEntityReadPermission }],
+          {
+            token,
+          },
+        )
+      )[0];
+
+      if (decision.result === AuthorizeResult.DENY) {
+        response.status(403);
+        response.send({ status: 'Unauthorized' });
+      } else {
+        response.send({ status: 'Authorized' });
+      }
+    });
+
+    return router;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2661,6 +2661,14 @@
     "@backstage/types" "^1.0.2"
     lodash "^4.17.21"
 
+"@backstage/config@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.0.8.tgz#283a4900c7aae216bd4e3dce4389ce060f989884"
+  integrity sha512-Y7JLnBrXX0G7z+Zj4vRwp/Mb8fLhCc1K/LqRRQUHMmnTDb3T7xMgpM3+0ZPpedWqslWrC2OYRrOE5PQxpFnmdg==
+  dependencies:
+    "@backstage/types" "^1.1.0"
+    lodash "^4.17.21"
+
 "@backstage/core-app-api@1.8.0", "@backstage/core-app-api@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@backstage/core-app-api/-/core-app-api-1.8.0.tgz#b027cb069954041714be6bb0fba2802c10fa073a"
@@ -2732,6 +2740,19 @@
   dependencies:
     "@backstage/config" "^1.0.7"
     "@backstage/types" "^1.0.2"
+    "@backstage/version-bridge" "^1.0.4"
+    "@types/react" "^16.13.1 || ^17.0.0"
+    history "^5.0.0"
+    prop-types "^15.7.2"
+    zen-observable "^0.10.0"
+
+"@backstage/core-plugin-api@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@backstage/core-plugin-api/-/core-plugin-api-1.5.2.tgz#98e31acd1938de4bdcc090b0bd5ee185e5bfe705"
+  integrity sha512-NiX/0a/Bbiy5GprEEfhe06fU1NEQ3DLpOhHqey47FwGFPzXo3C6OSFCygLsHMqGQNt9eRStBDsZlaINAo0wSlQ==
+  dependencies:
+    "@backstage/config" "^1.0.8"
+    "@backstage/types" "^1.1.0"
     "@backstage/version-bridge" "^1.0.4"
     "@types/react" "^16.13.1 || ^17.0.0"
     history "^5.0.0"
@@ -3799,6 +3820,11 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.0.2.tgz#a12cdc7c1ec7e0d99cb2e30903b9dfd97c1050c9"
   integrity sha512-wE4AAP3je00UlVNV5faIto414aOUNv30CmvNmxgImNKelPRYJsMEicM9slwkrNMyFLqTMITeXJvQvMofUk3Wxg==
+
+"@backstage/types@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.1.0.tgz#cf33e0c20584e329308acca2e5fa0435f04d4ea5"
+  integrity sha512-lpzZD52WHCg+i7anibmIwC3045KVOAUJ8Reoeh74+14SAQ8DTT9aUAxmH8mOFnWzDSr7XnbY5ms8Y8qWRzn2VA==
 
 "@backstage/version-bridge@^1.0.4":
   version "1.0.4"


### PR DESCRIPTION
# Description
Adds an Admin role to the RBAC plugin. This PR allows for admins to be defined within the `app-config` as either individual users or groups. There are also administrator permissions that have been added for checking if there are appropriate permissions before performing sensitive actions. The permissions are used within the RBAC router to handle access to route that we plan to create for the plugin. Currently there is only a single route exposed that will return 'Authorized' or 'Unauthorized'. 


# Which issue(s) does this PR fix
- Fixes [issue 357](https://github.com/janus-idp/backstage-showcase/issues/357)

# How to test changes / Special notes to the reviewer
- There needs to be some form of authentication so that backstage assigns you to a user and gives you an appropriate token. Without it, you will come up as undefined and the checks will fail.
- There will also need to be a user imported into backstage so that backstage has a user to assign you to.
- Within the `app-config` you will need to add the following under the permission section
```
permission:
  enabled: true
  admin:
    users:
      - name: <USER_WITH_ADMIN_PERMISSIONS
    groups:
      - name: <GROUP_WITH_ADMIN_PERMISSIONS
```