### PR TITLE
chore(ocm,3scale): remove yn,node-fetch redundant deps

### DIFF
--- a/plugins/3scale-backend/package.json
+++ b/plugins/3scale-backend/package.json
@@ -27,9 +27,7 @@
     "@backstage/catalog-model": "^1.3.0",
     "@backstage/config": "^1.0.7",
     "@backstage/plugin-catalog-node": "^1.3.7",
-    "node-fetch": "^2.6.7",
-    "winston": "^3.2.1",
-    "yn": "^4.0.0"
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.22.7",

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -33,10 +33,8 @@
     "@kubernetes/client-node": "^0.18.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
-    "node-fetch": "^3.0.0",
     "semver": "^7.3.8",
-    "winston": "^3.2.1",
-    "yn": "^5.0.0"
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.22.7",


### PR DESCRIPTION
Replaces: https://github.com/janus-idp/backstage-plugins/pull/461 https://github.com/janus-idp/backstage-plugins/pull/460

These packages are not needed anymore. Node v18 already contains fetch + `yn` is not used at all.