### PR TITLE
feat(keycloak): add userTransformer and groupTransformer

### DIFF
--- a/plugins/keycloak-backend/__fixtures__/data.ts
+++ b/plugins/keycloak-backend/__fixtures__/data.ts
@@ -90,4 +90,9 @@ export const users = [
   },
 ];
 
-export const groupMembers = [[], [], [], ['jamesdoe', 'joedoe', 'johndoe']];
+export const groupMembers = [
+  ['jamesdoe'],
+  [],
+  [],
+  ['jamesdoe', 'joedoe', 'johndoe'],
+];

--- a/plugins/keycloak-backend/__fixtures__/helpers.ts
+++ b/plugins/keycloak-backend/__fixtures__/helpers.ts
@@ -29,10 +29,10 @@ export class KeycloakAdminClientMock {
     count: jest.fn().mockResolvedValue(groups.length),
     listMembers: jest
       .fn()
-      .mockResolvedValueOnce(groupMembers[0])
-      .mockResolvedValueOnce(groupMembers[1])
-      .mockResolvedValueOnce(groupMembers[2])
-      .mockResolvedValueOnce(groupMembers[3]),
+      .mockResolvedValueOnce(groupMembers[0].map(username => ({ username })))
+      .mockResolvedValueOnce(groupMembers[1].map(username => ({ username })))
+      .mockResolvedValueOnce(groupMembers[2].map(username => ({ username })))
+      .mockResolvedValueOnce(groupMembers[3].map(username => ({ username }))),
   };
 
   auth = jest.fn().mockResolvedValue({});

--- a/plugins/keycloak-backend/src/index.ts
+++ b/plugins/keycloak-backend/src/index.ts
@@ -15,3 +15,5 @@
  */
 
 export * from './providers';
+export type { UserTransformer, GroupTransformer } from './lib';
+export * from './lib/transformers';

--- a/plugins/keycloak-backend/src/lib/transformers.ts
+++ b/plugins/keycloak-backend/src/lib/transformers.ts
@@ -1,0 +1,27 @@
+import { GroupTransformer, UserTransformer } from './types';
+
+export const noopGroupTransformer: GroupTransformer = async (
+  entity,
+  _user,
+  _realm,
+) => entity;
+
+export const noopUserTransformer: UserTransformer = async (
+  entity,
+  _user,
+  _realm,
+  _groups,
+) => entity;
+
+/**
+ * User transformer that sanitizes .metadata.name from email address to a valid name
+ */
+export const sanitizeEmailTransformer: UserTransformer = async (
+  entity,
+  _user,
+  _realm,
+  _groups,
+) => {
+  entity.metadata.name = entity.metadata.name.replace(/[^a-zA-Z0-9]/g, '-');
+  return entity;
+};

--- a/plugins/keycloak-backend/src/lib/types.ts
+++ b/plugins/keycloak-backend/src/lib/types.ts
@@ -19,20 +19,52 @@ import { GroupEntity, UserEntity } from '@backstage/catalog-model';
 import GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation';
 import UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation';
 
+export interface GroupRepresentationWithParent extends GroupRepresentation {
+  parent?: string;
+  members?: string[];
+}
+
+export interface GroupRepresentationWithParentAndEntity
+  extends GroupRepresentationWithParent {
+  entity: GroupEntity;
+}
+
+export interface UserRepresentationWithEntity extends UserRepresentation {
+  entity: UserEntity;
+}
+
 /**
  * Customize the ingested User entity
  *
  * @public
+ *
+ * @param {UserEntity} entity The output of the default parser
+ * @param {UserRepresentation} user Keycloak user representation
+ * @param {string} realm Realm name
+ * @param {GroupRepresentationWithParentAndEntity[]} groups Data about available groups (can be used to create additional relationships)
+ *
+ * @returns {Promise<UserEntity | undefined>} Resolve to a modified `UserEntity` object that will be ingested into the catalog or resolve to `undefined` to reject the entity
  */
 export type UserTransformer = (
+  entity: UserEntity,
   user: UserRepresentation,
+  realm: string,
+  groups: GroupRepresentationWithParentAndEntity[],
 ) => Promise<UserEntity | undefined>;
 
 /**
  * Customize the ingested Group entity
  *
  * @public
+ *
+ * @param {GroupEntity} entity The output of the default parser
+ * @param {GroupRepresentation} group Keycloak group representation
+ * @param {string} realm Realm name
+ *
+ * @returns {Promise<GroupEntity | undefined>} Resolve to a modified `GroupEntity` object that will be ingested into the catalog or resolve to `undefined` to reject the entity
  */
 export type GroupTransformer = (
-  user: GroupRepresentation,
+  entity: GroupEntity,
+  group: GroupRepresentation,
+  realm: string,
 ) => Promise<GroupEntity | undefined>;

--- a/plugins/keycloak-backend/src/providers/KeycloakOrgEntityProvider.ts
+++ b/plugins/keycloak-backend/src/providers/KeycloakOrgEntityProvider.ts
@@ -140,6 +140,8 @@ export class KeycloakOrgEntityProvider implements EntityProvider {
         id: providerConfig.id,
         provider: providerConfig,
         logger: options.logger,
+        userTransformer: options.userTransformer,
+        groupTransformer: options.groupTransformer,
       });
 
       if (taskRunner !== 'manual') {
@@ -209,6 +211,8 @@ export class KeycloakOrgEntityProvider implements EntityProvider {
     const { users, groups } = await readKeycloakRealm(kcAdminClient, provider, {
       userQuerySize: provider.userQuerySize,
       groupQuerySize: provider.groupQuerySize,
+      userTransformer: this.options.userTransformer,
+      groupTransformer: this.options.groupTransformer,
     });
 
     const { markCommitComplete } = markReadComplete({ users, groups });


### PR DESCRIPTION
Replaces: #432 

Resolves: #511

Proper implementation of `userTransformer` and `groupTransformer`.

Loosely inspired by LDAP plugin's transformers https://backstage.io/docs/integrations/ldap/org/#customize-the-provider

This allows users to specify custom functions when initializing the entity provider. These functions will run for each ingested entity providing context about the:
- The resulting entity which is the output of the default parser
- The original data from Keycloak API
- Realm name information
- For users - additional group data

Proposed workflow:
1. We (pre)process the `Group`s first
   1. We parse API response to the entity via the default parser
   2. We apply `groupTransformer`
2. We process the `User`s
   1. We parse API response to the entity via the default parser
   2. We apply `userTransformer`
4. We (post)process the `Group`s again to update memberships and group hierarchy to address any name changes in groups or users entities.

cc @paoloantinori @tanoggy @jani888 let me know what you think 🙂 