### PR TITLE
chore(ci): workaround semantic-release/npm rate limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@semantic-release/exec": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "9.0.4",
+    "@semrel-extra/npm": "1.2.2",
     "@spotify/prettier-config": "15.0.0",
     "conventional-changelog-conventionalcommits": "6.1.0",
     "husky": "8.0.3",
@@ -129,7 +130,7 @@
         }
       ],
       "@semantic-release/changelog",
-      "@semantic-release/npm",
+      "@semrel-extra/npm",
       "@semantic-release/git",
       [
         "@semantic-release/github",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6535,6 +6535,11 @@
     lodash "^4.17.4"
     read-pkg-up "^7.0.0"
 
+"@semrel-extra/npm@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@semrel-extra/npm/-/npm-1.2.2.tgz#bd754f9b13e397a70395c36f2229fd7b69f981e8"
+  integrity sha512-QoOJFUd00ORaqOQUe2wYmwPwa7NRdGGfUhzjZ9UEZqoqymXaBDVmFF2hE3h8mFaTa/iWpAyRrrjTsg8HbSpZyw==
+
 "@sinclair/typebox@^0.25.16":
   version "0.25.24"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"


### PR DESCRIPTION
Resolves: https://github.com/janus-idp/backstage-plugins/issues/521

Instead of release toolkit migration, which didn't yield sufficient results, I've tried working around the semantic-release issues instead.

This PR applies https://github.com/semrel-extra/npm workaround to the mysterious NPM rate limits.. Let's see if it helps.