### PR TITLE
chore: update issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,0 +1,5 @@
+---
+name: Blank Template
+about: Create a blank issue
+labels: [status/triage]
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a bug report to help us improve
 labels: [kind/bug, status/triage]
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: kind/bug
+labels: [kind/bug, status/triage]
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Janus IDP Community Slack
+    url: https://janus-idp.slack.com/archives/C04EDTPJRK5
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: ❓ Janus IDP Community Slack
-    url: https://janus-idp.slack.com/archives/C04EDTPJRK5
+    url: https://join.slack.com/t/janus-idp/shared_invite/zt-1pxtehxom-fCFtF9rRe3vFqUiFFeAkmg
     about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,7 +1,7 @@
 ---
 name: Epic
 about: Create an epic
-labels: kind/epic
+labels: [kind/epic, status/triage]
 ---
 
 **Goal**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: kind/feature
+labels: [kind/feature, status/triage]
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/plugin.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin.yaml
@@ -1,7 +1,7 @@
 name: 🔌 Plugin
 description: 'Submit a proposal for a new Plugin'
 title: '🔌 Plugin: '
-labels: [plugin]
+labels: [plugin, status/triage]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,7 +1,7 @@
 ---
 name: Report vulnerability
 about: There's a security problem that requires our immediate attention
-labels: kind/security
+labels: [kind/security, status/triage]
 ---
 
 **Describe how is our service vulnerable**


### PR DESCRIPTION
### Description
Updated the existing issue templates to also use the `status/triage` label.
Removed the ability for users to create blank issues in favor of creating a blank issue template to enforce the usage of `status/triage` for all issues.

### Which issue(s) does this PR fix
Fixes #571 