### PR TITLE
chore: remove node version 16 due semantic-release/github@9.0 expect >=18

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "private": true,
   "engines": {
-    "node": "16 || 18"
+    "node": "18"
   },
   "scripts": {
     "preinstall": "npx only-allow yarn",


### PR DESCRIPTION
Fix https://github.com/janus-idp/backstage-plugins/issues/570