### PR TITLE
feat(ocm-backend): add support for new backend system

### DIFF
--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -25,6 +25,7 @@
   "configSchema": "config.d.ts",
   "dependencies": {
     "@backstage/backend-common": "^0.19.1",
+    "@backstage/backend-plugin-api": "^0.5.2",
     "@backstage/backend-tasks": "^0.5.4",
     "@backstage/catalog-client": "^1.4.3",
     "@backstage/catalog-model": "^1.4.1",

--- a/plugins/ocm-backend/src/service/router.ts
+++ b/plugins/ocm-backend/src/service/router.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { errorHandler } from '@backstage/backend-common';
+import { errorHandler, loggerToWinstonLogger } from '@backstage/backend-common';
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 
 import express from 'express';
@@ -50,23 +54,19 @@ export interface RouterOptions {
   config: Config;
 }
 
-export async function createRouter(
-  options: RouterOptions,
-): Promise<express.Router> {
-  const { logger, config } = options;
+const buildRouter = (config: Config, logger: Logger) => {
+  const router = Router();
+  router.use(express.json());
 
   const clients = Object.fromEntries(
     readOcmConfigs(config).map(provider => [
       provider.id,
       {
-        client: hubApiClient(provider, options.logger),
+        client: hubApiClient(provider, logger),
         hubResourceName: provider.hubResourceName,
       },
     ]),
   );
-
-  const router = Router();
-  router.use(express.json());
 
   router.get(
     '/status/:providerId/:clusterName',
@@ -136,6 +136,30 @@ export async function createRouter(
   });
 
   router.use(errorHandler({ logClientErrors: true }));
-
   return router;
+};
+
+export async function createRouter(
+  options: RouterOptions,
+): Promise<express.Router> {
+  const { logger } = options;
+  const { config } = options;
+
+  return buildRouter(config, logger);
 }
+
+export const ocmPlugin = createBackendPlugin({
+  pluginId: 'ocm',
+  register(env) {
+    env.registerInit({
+      deps: {
+        logger: coreServices.logger,
+        config: coreServices.config,
+        http: coreServices.httpRouter,
+      },
+      async init({ config, logger, http }) {
+        http.use(buildRouter(config, loggerToWinstonLogger(logger)));
+      },
+    });
+  },
+});

--- a/plugins/ocm/README.md
+++ b/plugins/ocm/README.md
@@ -229,6 +229,16 @@ If you are interested in Resource discovery and do not want any of the front-end
 
    For more information about the default owner configuration, see [upstream string references documentation](https://backstage.io/docs/features/software-catalog/references/#string-references).
 
+#### Setting up the OCM backend package using the new backend system
+
+The OCM plugin supports integration with the [new backend system](https://backstage.io/docs/backend-system/). In order to install the plugin follow the first 2 configuration steps described [here](#setting-up-the-ocm-backend-package). Then add the following lines to the `packages/backend/src/index.ts` file.
+
+```ts
+import { ocmPlugin } from '@janus-idp/backstage-plugin-ocm-backend';
+
+backend.add(ocmPlugin());
+```
+
 #### Setting up the OCM frontend package
 
 1. Install the OCM frontend plugin using the following command:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2573,7 +2573,7 @@
   resolved "https://registry.yarnpkg.com/@backstage/backend-dev-utils/-/backend-dev-utils-0.1.1.tgz#5a10998436df08adb86066f1d685421de5d05f1c"
   integrity sha512-5emcwuBp7WtJlUkuS5Ex7bJVaZUJkU330J24QMqwYmd+/ujf2S7m6aLUyE+lr5yH5xQ7kZY27u9QZv6hWmLytw==
 
-"@backstage/backend-plugin-api@^0.5.4":
+"@backstage/backend-plugin-api@^0.5.2", "@backstage/backend-plugin-api@^0.5.4":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@backstage/backend-plugin-api/-/backend-plugin-api-0.5.4.tgz#de750d44a37d827605bf813e7a126de6457a3bd0"
   integrity sha512-ehTRoDsTlCXHNyb850FaoBTMlAfXoRH7do6uot+C/kB50z+nqRB9fRwtHahWK3fKXb0G/r/fk5h5RTmvN5j7bw==
@@ -9068,7 +9068,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@17.0.20", "@types/react-dom@<18.0.0", "@types/react-dom@^17.0.2":
+"@types/react-dom@17.0.20", "@types/react-dom@<18.0.0":
   version "17.0.20"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"
   integrity sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==
@@ -9120,10 +9120,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.60", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^17", "@types/react@^17.0.2":
+"@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^17":
   version "17.0.62"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.62.tgz#2efe8ddf8533500ec44b1334dd1a97caa2f860e3"
   integrity sha512-eANCyz9DG8p/Vdhr0ZKST8JV12PhH2ACCDYlFw6DIO+D+ca+uP4jtEDEpVqXZrh/uZdXQGwk7whJa3ah5DtyLw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@17.0.60":
+  version "17.0.60"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.60.tgz#a4a97dcdbebad76612c188fc06440e4995fd8ad2"
+  integrity sha512-pCH7bqWIfzHs3D+PDs3O/COCQJka+Kcw3RnO9rFA2zalqoXg7cNjJDh6mZ7oRtY1wmY4LVwDdAbA1F7Z8tv3BQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
Reupload of PR #459

Part of #238
Add support for the new backend system for the OCM plugin. It can still be used with the old backend system without any issue. The only change that happened is that the package now contains a new export that can be used in the new backend system.

Co-authored-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
Signed-off-by: SamoKopecky <skopecky@redhat.com>
