### PR TITLE
docs(jfrog): update README.md

### DIFF
--- a/plugins/jfrog-artifactory/README.md
+++ b/plugins/jfrog-artifactory/README.md
@@ -60,5 +60,5 @@ yarn workspace app add @janus-idp/backstage-plugin-jfrog-artifactory
    ```yaml title="catalog-info.yaml"
    metadata:
      annotations:
-       'jfrog-artifactory/image-name': `<IMAGE-NAME>',
+       'jfrog-artifactory/image-name': '<IMAGE-NAME>'
    ```


### PR DESCRIPTION
Update the Jfrog documentation to not use ` instead of ' in the annotation example (in case user copy pastes it)
Relates to https://github.com/janus-idp/backstage-plugins/issues/559