### PR TITLE
chore(jfrog): update dev environment to not crash on load

### DIFF
--- a/plugins/jfrog-artifactory/dev/index.tsx
+++ b/plugins/jfrog-artifactory/dev/index.tsx
@@ -1,13 +1,36 @@
 import React from 'react';
 
+import { Entity } from '@backstage/catalog-model';
 import { createDevApp } from '@backstage/dev-utils';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
 
 import { JfrogArtifactoryPage, jfrogArtifactoryPlugin } from '../src/plugin';
+
+const mockEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'backstage',
+    description: 'backstage.io',
+    annotations: {
+      'jfrog-artifactory/image-name': 'backstage',
+    },
+  },
+  spec: {
+    lifecycle: 'production',
+    type: 'service',
+    owner: 'user:guest',
+  },
+};
 
 createDevApp()
   .registerPlugin(jfrogArtifactoryPlugin)
   .addPage({
-    element: <JfrogArtifactoryPage />,
+    element: (
+      <EntityProvider entity={mockEntity}>
+        <JfrogArtifactoryPage />
+      </EntityProvider>
+    ),
     title: 'Root Page',
     path: '/artifactory',
   })


### PR DESCRIPTION
## Description
Updates the JFrog dev environment to not crash on load

## Which issue(s) does this PR fix
Fixes #647 

## Special Notes to Reviewers
This PR doesn't populate the JFrog dev environment with any data as I currently don't have an instance setup to provide obtain the mock data with, so the table will be empty.