### PR TITLE
fix(aap): show template name and type as it is without formatting

### DIFF
--- a/plugins/aap-backend/README.md
+++ b/plugins/aap-backend/README.md
@@ -125,8 +125,6 @@ Once the AAP Backstage provider plugin is configured successfully, it synchroniz
 
    A list of all the available templates from AAP appears on the page.
 
-   **NOTE**: The imported templates from AAP in Backstage follow the `{jobTemplateName}-{orgName}-{envNameInConfig}` naming syntax without white spaces. For example, in the Demo_Job_Template-Default-Stage, Demo_Job_Template is `jobTemplateName`, Default is `orgName`, and Stage is `envNameInConfig`.
-
 1. Select a template from the list.
 
    The **OVERVIEW** tab appears containing different cards, such as:

--- a/plugins/aap-backend/src/providers/AapResourceEntityProvider.ts
+++ b/plugins/aap-backend/src/providers/AapResourceEntityProvider.ts
@@ -152,8 +152,6 @@ export class AapResourceEntityProvider implements EntityProvider {
     const jobTemplateTransformedName = `${template.name.replace(/ /g, '_')}-${
       template.summary_fields?.organization?.name || template.id
     }-${this.env}`;
-    // format template type i.e job_template to job template
-    const templateType = template.type.split('_')?.join(' ');
 
     return {
       kind: 'Resource',
@@ -164,6 +162,7 @@ export class AapResourceEntityProvider implements EntityProvider {
           [ANNOTATION_ORIGIN_LOCATION]: this.getProviderName(),
         },
         name: `${jobTemplateTransformedName}`,
+        title: `${template.name}`,
         description: `${template.description}`,
         links: [
           {
@@ -177,7 +176,7 @@ export class AapResourceEntityProvider implements EntityProvider {
         ],
       },
       spec: {
-        type: `${templateType}`,
+        type: `${template.type}`,
         owner: `${this.owner}`,
         ...(this.system && { system: `${this.system}` }),
       },


### PR DESCRIPTION
**Tracks:** https://github.com/janus-idp/backstage-plugins/issues/709

**Screenshot:**

<img width="1727" alt="image" src="https://github.com/janus-idp/backstage-plugins/assets/5129024/5b6ad60d-b1af-438d-af16-f70ad1238f51">
