### PR TITLE
feat(nexus): support docker manifest 2 schema 1

### DIFF
--- a/plugins/nexus-repository-manager/src/__fixtures__/components/all.json
+++ b/plugins/nexus-repository-manager/src/__fixtures__/components/all.json
@@ -29,43 +29,27 @@
     },
     "rawAssets": [
       {
-        "schemaVersion": 2,
-        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-        "config": {
-          "mediaType": "application/vnd.docker.container.image.v1+json",
-          "size": 17214,
-          "digest": "sha256:b98e210da4230ea59323687f2b6678e12f00a8c82a9433f8235a02e50a06c640"
-        },
-        "layers": [
+        "schemaVersion": 1,
+        "name": "janus-idp/backstage-showcase",
+        "tag": "sha-33dfe6b",
+        "fsLayers": [
           {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 36581161,
-            "digest": "sha256:7890eb22610600843a22de84c96fab3f2d428d19e164a529d775ebbb22cc2f3e"
+            "blobSum": "sha256:7890eb22610600843a22de84c96fab3f2d428d19e164a529d775ebbb22cc2f3e"
           },
           {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 36267603,
-            "digest": "sha256:cfdca8bd8795bb3e2c17030868e88434c52d55b7727a10187c9c0b7d0884daf0"
+            "blobSum": "sha256:cfdca8bd8795bb3e2c17030868e88434c52d55b7727a10187c9c0b7d0884daf0"
           },
           {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 33954115,
-            "digest": "sha256:d47076810fbfe12fe7ffed77b6e7e314d8c2edec4d191cbf5e2297feed9bfd80"
+            "blobSum": "sha256:d47076810fbfe12fe7ffed77b6e7e314d8c2edec4d191cbf5e2297feed9bfd80"
           },
           {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 32,
-            "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
+            "blobSum": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
           },
           {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 132692565,
-            "digest": "sha256:b6c0e061017b8d76a988fe0a2e985baec96255966cf7fd71f36eae65c97d6bf4"
+            "blobSum": "sha256:b6c0e061017b8d76a988fe0a2e985baec96255966cf7fd71f36eae65c97d6bf4"
           },
           {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 132761418,
-            "digest": "sha256:f248198ee67af270e04ecac09c0bd34eb06025cd8db9e165146a78a603bc906b"
+            "blobSum": "sha256:f248198ee67af270e04ecac09c0bd34eb06025cd8db9e165146a78a603bc906b"
           }
         ]
       }

--- a/plugins/nexus-repository-manager/src/__fixtures__/repository/docker/v2/janus-idp/backstage-showcase/manifests/sha-33dfe6b.json
+++ b/plugins/nexus-repository-manager/src/__fixtures__/repository/docker/v2/janus-idp/backstage-showcase/manifests/sha-33dfe6b.json
@@ -1,41 +1,25 @@
 {
-  "schemaVersion": 2,
-  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-  "config": {
-    "mediaType": "application/vnd.docker.container.image.v1+json",
-    "size": 17214,
-    "digest": "sha256:b98e210da4230ea59323687f2b6678e12f00a8c82a9433f8235a02e50a06c640"
-  },
-  "layers": [
+  "schemaVersion": 1,
+  "name": "janus-idp/backstage-showcase",
+  "tag": "sha-33dfe6b",
+  "fsLayers": [
     {
-      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-      "size": 36581161,
-      "digest": "sha256:7890eb22610600843a22de84c96fab3f2d428d19e164a529d775ebbb22cc2f3e"
+      "blobSum": "sha256:7890eb22610600843a22de84c96fab3f2d428d19e164a529d775ebbb22cc2f3e"
     },
     {
-      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-      "size": 36267603,
-      "digest": "sha256:cfdca8bd8795bb3e2c17030868e88434c52d55b7727a10187c9c0b7d0884daf0"
+      "blobSum": "sha256:cfdca8bd8795bb3e2c17030868e88434c52d55b7727a10187c9c0b7d0884daf0"
     },
     {
-      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-      "size": 33954115,
-      "digest": "sha256:d47076810fbfe12fe7ffed77b6e7e314d8c2edec4d191cbf5e2297feed9bfd80"
+      "blobSum": "sha256:d47076810fbfe12fe7ffed77b6e7e314d8c2edec4d191cbf5e2297feed9bfd80"
     },
     {
-      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-      "size": 32,
-      "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
+      "blobSum": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
     },
     {
-      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-      "size": 132692565,
-      "digest": "sha256:b6c0e061017b8d76a988fe0a2e985baec96255966cf7fd71f36eae65c97d6bf4"
+      "blobSum": "sha256:b6c0e061017b8d76a988fe0a2e985baec96255966cf7fd71f36eae65c97d6bf4"
     },
     {
-      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-      "size": 132761418,
-      "digest": "sha256:f248198ee67af270e04ecac09c0bd34eb06025cd8db9e165146a78a603bc906b"
+      "blobSum": "sha256:f248198ee67af270e04ecac09c0bd34eb06025cd8db9e165146a78a603bc906b"
     }
   ]
 }

--- a/plugins/nexus-repository-manager/src/types.ts
+++ b/plugins/nexus-repository-manager/src/types.ts
@@ -9,20 +9,41 @@ export type Annotation = {
   query?: (str: string) => SearchServiceQuery;
 };
 
-export type RawAsset = {
-  schemaVersion: number;
-  mediaType: string;
-  config: Config;
-  layers: Layer[];
+export type RawAsset = RawAssetSchema1 | RawAssetSchema2;
+
+// https://docs.docker.com/registry/spec/manifest-v2-1/
+export type RawAssetSchema1 = {
+  schemaVersion: 1;
+  name: string;
+  tag: string;
+  architecture: string;
+  fsLayers: LayerSchema1[];
+  history: HistorySchema1[];
 };
 
-export type Config = {
+export type LayerSchema1 = {
+  blobSum: string;
+};
+
+export type HistorySchema1 = {
+  v1Compatibility: string;
+};
+
+// https://docs.docker.com/registry/spec/manifest-v2-2/
+export type RawAssetSchema2 = {
+  schemaVersion: 2;
+  mediaType: 'application/vnd.docker.distribution.manifest.v2+json';
+  config: ConfigSchema2;
+  layers: LayerSchema2[];
+};
+
+export type ConfigSchema2 = {
   mediaType: string;
   size: number;
   digest: string;
 };
 
-export type Layer = {
+export type LayerSchema2 = {
   mediaType: string;
   size: number;
   digest: string;

--- a/plugins/nexus-repository-manager/src/types.ts
+++ b/plugins/nexus-repository-manager/src/types.ts
@@ -11,7 +11,7 @@ export type Annotation = {
 
 export type RawAsset = RawAssetSchema1 | RawAssetSchema2;
 
-// https://docs.docker.com/registry/spec/manifest-v2-1/
+/** @see {@link https://docs.docker.com/registry/spec/manifest-v2-1/|Image Manifest Version 2, Schema 1} */
 export type RawAssetSchema1 = {
   schemaVersion: 1;
   name: string;
@@ -29,7 +29,7 @@ export type HistorySchema1 = {
   v1Compatibility: string;
 };
 
-// https://docs.docker.com/registry/spec/manifest-v2-2/
+/** @see {@link https://docs.docker.com/registry/spec/manifest-v2-2/|Image Manifest Version 2, Schema 2} */
 export type RawAssetSchema2 = {
   schemaVersion: 2;
   mediaType: 'application/vnd.docker.distribution.manifest.v2+json';

--- a/plugins/nexus-repository-manager/src/utils/get-file-size/get-file-size.test.ts
+++ b/plugins/nexus-repository-manager/src/utils/get-file-size/get-file-size.test.ts
@@ -14,8 +14,9 @@ describe('getFileSize', () => {
     };
     const rawAssets = [
       {
-        schemaVersion: 2,
-        mediaType: '',
+        schemaVersion: 2 as const,
+        mediaType:
+          'application/vnd.docker.distribution.manifest.v2+json' as const,
         layers: [
           {
             size: 300,
@@ -37,5 +38,34 @@ describe('getFileSize', () => {
       null,
     ];
     expect(getFileSize({ component, rawAssets })).toBe(54321);
+  });
+  it('should return the correct file size for manifest 2, schema 1', () => {
+    const component = {
+      assets: [
+        {
+          fileSize: 111,
+        },
+      ],
+    };
+    const rawAssets = [
+      {
+        schemaVersion: 1 as const,
+        name: '',
+        tag: '',
+        architecture: '',
+        fsLayers: [
+          {
+            blobSum: '',
+          },
+        ],
+        history: [
+          {
+            v1Compatibility: '',
+          },
+        ],
+      },
+      null,
+    ];
+    expect(getFileSize({ component, rawAssets })).toBe(111);
   });
 });

--- a/plugins/nexus-repository-manager/src/utils/get-file-size/get-file-size.test.ts
+++ b/plugins/nexus-repository-manager/src/utils/get-file-size/get-file-size.test.ts
@@ -1,7 +1,7 @@
 import { getFileSize } from './get-file-size';
 
 describe('getFileSize', () => {
-  it('should return the correct file size', () => {
+  it('should return the correct file size for manifest 2, schema 2', () => {
     const component = {
       assets: [
         {

--- a/plugins/nexus-repository-manager/src/utils/get-file-size/get-file-size.ts
+++ b/plugins/nexus-repository-manager/src/utils/get-file-size/get-file-size.ts
@@ -17,6 +17,10 @@ export function getFileSize({
       return acc;
     }
 
+    if (rawAsset.schemaVersion === 1) {
+      return acc;
+    }
+
     const layerSize = rawAsset.layers.reduce((layerAcc, layer) => {
       return layerAcc + layer.size;
     }, 0);


### PR DESCRIPTION
This adds support for the (deprecated) Docker [manifest v2 schema 1](https://docs.docker.com/registry/spec/manifest-v2-1/).

It may be more correct to display "unknown" for image size in this case, as the actual size cannot be calculated. If so, let me know and I will make the change.

Our nexus gives `0` for the asset size, so I assumed showing 0 for the total size makes it clear that it was unable to be calculated.

Closes https://github.com/janus-idp/backstage-plugins/issues/712