### PR TITLE
docs(nexus): update nexus CONTRIBUTING.md and turbo to ensure generate command is ran

### DIFF
--- a/plugins/nexus-repository-manager/CONTRIBUTING.md
+++ b/plugins/nexus-repository-manager/CONTRIBUTING.md
@@ -1,7 +1,14 @@
 # Setting up the development environment for Nexus Repository Manager plugin
 
-In [Backstage plugin terminology](https://backstage.io/docs/local-dev/cli-build-system#package-roles), the Nexus Repository Manager plugin is a front-end plugin. You can start a live development session from the repository root using the following command:
+In [Backstage plugin terminology](https://backstage.io/docs/local-dev/cli-build-system#package-roles), the Nexus Repository Manager plugin is a front-end plugin. You can start a live development session from the repository root using the following command (only works from the root directory):
 
 ```console
+yarn start --filter=@janus-idp/backstage-plugin-nexus-repository-manager
+```
+
+Alternatively, you can run the following commands from any directory in the repository:
+
+```console
+yarn workspace @janus-idp/backstage-plugin-nexus-repository-manager generate
 yarn workspace @janus-idp/backstage-plugin-nexus-repository-manager run start
 ```

--- a/plugins/nexus-repository-manager/turbo.json
+++ b/plugins/nexus-repository-manager/turbo.json
@@ -1,6 +1,9 @@
 {
   "extends": ["//"],
   "pipeline": {
+    "start": {
+      "dependsOn": ["generate"]
+    },
     "tsc": {
       "outputs": ["../../dist-types/plugins/nexus-repository-manager/**"],
       "dependsOn": ["^tsc", "generate"]


### PR DESCRIPTION
## Description

- Updates the nexus plugin `CONTRIBUTING.md` with both the turbo supported command as well as the regular `yarn workspace` command.
- Also updates the nexus plugin's `turbo.json` to ensure `generate` is always ran before a `start` when running `yarn start --filter=@janus-idp/backstage-nexus-repository-manager` from the root directory.

## What issue(s) does this fix?
Fixes #703 