### PR TITLE
chore: fix lint-staged on for new plugins

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint-staged
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "clean": "turbo run clean",
     "test": "turbo run test",
     "lint": "turbo run lint",
+    "lint:fix": "turbo run lint -- --fix",
     "lint-staged": "lint-staged",
     "prettier:check": "prettier --ignore-unknown --check .",
     "prettier:fix": "prettier --ignore-unknown --write .",
@@ -55,8 +56,8 @@
     "@types/react-dom": "^17.0.2"
   },
   "lint-staged": {
-    "*": "yarn run prettier:fix",
-    "*.{js,jsx,ts,tsx,mjs,cjs}": "yarn run lint -- -- --fix"
+    "*": "turbo run prettier:fix --",
+    "*.{js,jsx,ts,tsx,mjs,cjs}": "turbo run lint:fix --"
   },
   "release": {
     "branches": "main",

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,8 @@
       "dependsOn": ["build"]
     },
     "lint": {},
+    "lint:fix": {},
+    "prettier:fix": {},
     "tsc": {
       "outputs": ["../../dist-types/**"],
       "dependsOn": ["^tsc"]


### PR DESCRIPTION
After #466 `lint-staged` has issues when adding a new plugin. You end up with a cryptic error:

```
@janus-idp/shared-react:lint: ERROR: command finished with error: command (/Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/shared-react) yarn run lint -- --fix /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/.eslintrc.js /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/dev/index.tsx /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/components/ExampleComponent/ExampleComponent.test.tsx /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/components/ExampleComponent/ExampleComponent.tsx /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/components/ExampleComponent/index.ts /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/components/ExampleFetchComponent/ExampleFetchComponent.test.tsx /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/components/ExampleFetchComponent/ExampleFetchComponent.tsx /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/components/ExampleFetchComponent/index.ts /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/index.ts /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/plugin.test.ts /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/plugin.ts /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/routes.ts /Users/tcoufal/Programming/janus-idp/backstage-plugins/plugins/test/src/setupTests.ts exited (1)
```

from any random package in the monorepo (depends on which one is run the firsqt). I suspect this has something to do with https://github.com/vercel/turbo/issues/3364 and creating a tooling chain

```
husky -> npm -> lint-staged -> yarn -> turbo -> backstage-cli -> eslint
```

This PR should simplify the chain by removing one step and removing one tool to:

```
husky -> yarn -> lint-stage -> turbo -> backstage-cli -> eslint
```

PTAL

@schultzp2020 