### PR TITLE
chore: simplify a tiny bit and optimize release process

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
     },
     {
       "matchPackagePatterns": ["^@backstage/"],
-      "groupName": ["Core Backstage packages"]
+      "groupName": "Core Backstage packages"
     },
     {
       "matchFileNames": ["packages/**"],
@@ -27,6 +27,14 @@
     {
       "matchFileNames": ["plugins/**"],
       "extends": [":pinOnlyDevDependencies"]
+    },
+    {
+      "matchPackagePatterns": [
+        "^@semantic-release/",
+        "^@semrel-extra/",
+        "^multi-semantic-release$"
+      ],
+      "groupName": "semantic-release monorepo"
     }
   ]
 }

--- a/.github/workflows/pr-semantic.yaml
+++ b/.github/workflows/pr-semantic.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54 # v5
+        id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -38,9 +39,34 @@ jobs:
             doesn't start with an uppercase character.
           ignoreLabels: |
             ignore-semantic-pull-request
-          # If the PR only contains a single commit, the action will validate that
-          # it matches the configured pattern.
-          validateSingleCommit: true
-          # Related to `validateSingleCommit` you can opt-in to validate that the PR
-          # title matches a single commit to avoid confusion.
-          validateSingleCommitMatchesPrTitle: true
+          # For work-in-progress PRs you can typically use draft pull requests
+          # from GitHub. However, private repositories on the free plan don't have
+          # this option and therefore this action allows you to opt-in to using the
+          # special "[WIP]" prefix to indicate this state. This will avoid the
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: true
+
+      - uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd # v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd # v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -39,3 +39,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_OPTIONS: '--max-old-space-size=8192'

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@semantic-release/github": "9.0.4",
     "@semrel-extra/npm": "1.2.2",
     "@spotify/prettier-config": "15.0.0",
-    "conventional-changelog-conventionalcommits": "7.0.2",
+    "conventional-changelog-conventionalcommits": "<7.0.0",
     "husky": "8.0.3",
     "eslint-plugin-jest": "27.4.0",
     "lint-staged": "14.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13765,10 +13765,10 @@ conventional-changelog-angular@^5.0.0:
     compare-func "^2.0.0"
     q "^1.5.1"
 
-conventional-changelog-conventionalcommits@7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz#aa5da0f1b2543094889e8cf7616ebe1a8f5c70d5"
-  integrity sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==
+conventional-changelog-conventionalcommits@<7.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz#3bad05f4eea64e423d3d90fc50c17d2c8cf17652"
+  integrity sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==
   dependencies:
     compare-func "^2.0.0"
 


### PR DESCRIPTION
`conventional-changelog-conventionalcommits` v7 seems to be causing troubles since new  `semantic-release` require ESM and drops CommonJS. We use `semantic-release` via `multi-semantic-release` that doesn't support ESM just yet. (`@semrel-extra/npm` also doesn't support ESM at the moment)

This PR also adds a better user experience for PR title validation - a comment is posted/removed based on the CI result. We also do not enforce PR title and commit matching when there's a single commit only and in addition we've enabled support for `[WIP]` PRs, so we don't see failing CI on those anymore.

