### PR TITLE
chore: fix lint-staged on for files outside of packages

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,12 @@
     },
     "lint": {},
     "lint:fix": {},
-    "prettier:fix": {},
+    "prettier:fix": {
+      "cache": false
+    },
+    "//#prettier:fix": {
+      "cache": false
+    },
     "tsc": {
       "outputs": ["../../dist-types/**"],
       "dependsOn": ["^tsc"]


### PR DESCRIPTION
`lint-staged` together with `turbo` are not properly formatting files outside of monorepo packages. This is because we do execute this task only within those individual packages and not from the root.

https://turbo.build/repo/docs/core-concepts/monorepos/running-tasks#running-tasks-from-the-root

This PR also disables caching for both root and workspace tasks, in my experience caching was causing some files being skipped in formatting.

This PR tries to eliminate surprises that can happen when submitting a PR and `prettier:check` fails in CI.