### PR TITLE
chore: make start:backstage to ignore cli package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "preinstall": "npx only-allow yarn",
     "start": "turbo run start",
-    "start:backstage": "turbo run start --filter=...{./packages/*}",
+    "start:backstage": "turbo run start --filter=...{./packages/app} --filter=...{./packages/backend}",
     "start:plugins": "turbo run start --filter=...{./plugins/*}",
     "build": "turbo run build",
     "build:backstage": "turbo run build --filter=...{./packages/*}",


### PR DESCRIPTION
@mareklibra noticed `yarn start:backstage` also starts `@janus-idp/cli` package. This is not the desired behavior.