### PR TITLE
chore(ci): run setup-node only if needed

### DIFF
--- a/.github/workflows/publish-backend-plugin-manager.yaml
+++ b/.github/workflows/publish-backend-plugin-manager.yaml
@@ -46,12 +46,6 @@ jobs:
           fetch-depth: 2147483647
           fetch-tags: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-
       - name: Get sha of the latest backend-plugin-manager commit
         id: get_commit_sha
         run: |
@@ -156,6 +150,13 @@ jobs:
           sed -i "s/\"name\": \"@backstage\/backend-plugin-manager\"/\"name\": \"$SCOPE\/backend-plugin-manager\"/" packages/backend-plugin-manager/package.json
           sed -i "s/\"private\": true/\"private\": false/" packages/backend-plugin-manager/package.json
           echo "Package.JSON:" && cat packages/backend-plugin-manager/package.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        if: steps.test_commit_already_published.outputs.ALREADY_PUSHED == 'false'
+        with:
+          node-version: 18
+          cache: 'yarn'
 
       - name: Install Dependencies
         env:


### PR DESCRIPTION
`setup-node` has a post hook that tries to save cache after each run. During runs where we actually do not build the package, this fails since no `node_packages` are populated. This results in run failures and a lot of noise in notifications.

Moving this step inside the conditional build phase should affect the post hook and execute it only if the we actually build the asset.

cc @davidfestal 

https://github.com/janus-idp/backstage-plugins/actions/workflows/publish-backend-plugin-manager.yaml

![image](https://github.com/janus-idp/backstage-plugins/assets/7453394/c16b6598-4023-4dc9-b7d0-c855328f3991)
![image](https://github.com/janus-idp/backstage-plugins/assets/7453394/41a84c10-eb3c-4657-b1b7-15a59d456343)
![image](https://github.com/janus-idp/backstage-plugins/assets/7453394/14539335-11af-42d3-93bf-d84994b70279)
