### PR TITLE
feat(rbac): implement RBAC group support

### DIFF
--- a/plugins/rbac-backend/package.json
+++ b/plugins/rbac-backend/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.19.1",
+    "@backstage/catalog-client": "^1.4.3",
     "@backstage/catalog-model": "^1.4.1",
     "@backstage/config": "^1.0.8",
     "@backstage/core-plugin-api": "^1.5.3",

--- a/plugins/rbac-backend/package.json
+++ b/plugins/rbac-backend/package.json
@@ -33,6 +33,7 @@
     "@backstage/plugin-permission-backend": "^0.5.20",
     "@backstage/plugin-permission-common": "^0.7.7",
     "@backstage/plugin-permission-node": "^0.7.10",
+    "@dagrejs/graphlib": "^2.1.13",
     "@janus-idp/backstage-plugin-rbac-common": "1.0.0",
     "casbin": "5.27.0",
     "express": "^4.17.1",

--- a/plugins/rbac-backend/src/service/permission-model.ts
+++ b/plugins/rbac-backend/src/service/permission-model.ts
@@ -12,5 +12,5 @@ e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 g = _, _
 
 [matchers]
-m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
 `;

--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -1,4 +1,5 @@
 import { getVoidLogger } from '@backstage/backend-common';
+import { Entity } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import { BackstageIdentityResponse } from '@backstage/plugin-auth-node';
 import {
@@ -14,10 +15,26 @@ import { resolve } from 'path';
 import { MODEL } from './permission-model';
 import { RBACPermissionPolicy } from './permission-policy';
 
+const catalogApi = {
+  getEntityAncestors: jest.fn().mockImplementation(),
+  getLocationById: jest.fn().mockImplementation(),
+  getEntities: jest.fn().mockImplementation(),
+  getEntitiesByRefs: jest.fn().mockImplementation(),
+  queryEntities: jest.fn().mockImplementation(),
+  getEntityByRef: jest.fn().mockImplementation(),
+  refreshEntity: jest.fn().mockImplementation(),
+  getEntityFacets: jest.fn().mockImplementation(),
+  addLocation: jest.fn().mockImplementation(),
+  getLocationByRef: jest.fn().mockImplementation(),
+  removeLocationById: jest.fn().mockImplementation(),
+  removeEntityByUid: jest.fn().mockImplementation(),
+  validateEntity: jest.fn().mockImplementation(),
+};
+
 describe('RBACPermissionPolicy Tests', () => {
   it('should build', async () => {
     const adapter = new StringAdapter(
-      `p, known_user, test-resource, update, allow `,
+      `p, user:default/known_user, test-resource, update, allow `,
     );
     const config = newConfigReader();
     const theModel = newModelFromString(MODEL);
@@ -25,6 +42,7 @@ describe('RBACPermissionPolicy Tests', () => {
     const policy = await RBACPermissionPolicy.build(
       getVoidLogger(),
       config,
+      catalogApi,
       enf,
     );
     expect(policy).not.toBeNull();
@@ -36,7 +54,7 @@ describe('RBACPermissionPolicy Tests', () => {
     beforeEach(async () => {
       const adapter = new StringAdapter(
         `
-                p, known_user, test.resource.deny, use, allow
+                p, user:default/known_user, test.resource.deny, use, allow
         `,
       );
       const csvPermFile = resolve(__dirname, './test/data/rbac-policy.csv');
@@ -49,7 +67,13 @@ describe('RBACPermissionPolicy Tests', () => {
       });
       const theModel = newModelFromString(MODEL);
       const enf = await newEnforcer(theModel, adapter);
-      policy = await RBACPermissionPolicy.build(getVoidLogger(), config, enf);
+      policy = await RBACPermissionPolicy.build(
+        getVoidLogger(),
+        config,
+        catalogApi,
+        enf,
+      );
+      catalogApi.getEntities.mockReturnValue({ items: [] });
     });
 
     // case1
@@ -75,52 +99,66 @@ describe('RBACPermissionPolicy Tests', () => {
     });
 
     // case3
-    it('should allow deny access to resource permission for known_user', async () => {
+    it('should allow deny access to resource permission for user:default/known_user', async () => {
       const decision = await policy.handle(
         newPolicyQueryWithBasicPermission('test.resource.deny'),
-        newIdentityResponse('known_user'),
+        newIdentityResponse('user:default/known_user'),
       );
       expect(decision.result).toBe(AuthorizeResult.ALLOW);
     });
   });
 
-  describe('Policy checks', () => {
+  describe('Policy checks for users', () => {
     let policy: RBACPermissionPolicy;
 
     beforeEach(async () => {
       const adapter = new StringAdapter(
         `
-                p, known_user, test.resource.deny, use, deny
-                p, duplicated, test.resource, use, allow
-                p, duplicated, test.resource, use, deny
-                p, known_user, test.resource, use, allow
+                # basic type permission policies
+                p, user:default/known_user, test.resource.deny, use, deny
+                p, user:default/duplicated, test.resource, use, allow
+                p, user:default/duplicated, test.resource, use, deny
+                p, user:default/known_user, test.resource, use, allow
 
-                p, known_user, test-resource-deny, update, deny 
-                p, duplicated, test-resource, update, allow
-                p, duplicated, test-resource, update, deny
-                p, known_user, test-resource, update, allow 
-
-                p, group, test.resource.deny, use, deny
+                # resource type permission policies
+                p, user:default/known_user, test-resource-deny, update, deny 
+                p, user:default/duplicated, test-resource, update, allow
+                p, user:default/duplicated, test-resource, update, deny
+                p, user:default/known_user, test-resource, update, allow 
                 `,
       );
       const config = newConfigReader();
       const theModel = newModelFromString(MODEL);
       const enf = await newEnforcer(theModel, adapter);
-      policy = await RBACPermissionPolicy.build(getVoidLogger(), config, enf);
+      policy = await RBACPermissionPolicy.build(
+        getVoidLogger(),
+        config,
+        catalogApi,
+        enf,
+      );
+      policy = await RBACPermissionPolicy.build(
+        getVoidLogger(),
+        config,
+        catalogApi,
+        enf,
+      );
+      catalogApi.getEntities.mockReturnValue({ items: [] });
     });
     // +-------+------+------------------------+
     // | allow | deny |         result         |
     // +-------+------+------------------------+
     // | N     | Y    | deny                   | 1
     // | N     | N    | deny (user not listed) | 2
-    // | Y     | Y    | deny (duplicated)      | 3
+    // | Y     | Y    | deny (user:default/duplicated)      | 3
     // | Y     | N    | allow                  | 4
+
+    // Tests for Resource basic type permission
 
     // case1
     it('should deny access to basic permission for listed user with deny action', async () => {
       const decision = await policy.handle(
         newPolicyQueryWithBasicPermission('test.resource.deny'),
-        newIdentityResponse('known_user'),
+        newIdentityResponse('user:default/known_user'),
       );
       expect(decision.result).toBe(AuthorizeResult.DENY);
     });
@@ -128,7 +166,7 @@ describe('RBACPermissionPolicy Tests', () => {
     it('should deny access to basic permission for unlisted user', async () => {
       const decision = await policy.handle(
         newPolicyQueryWithBasicPermission('test.resource'),
-        newIdentityResponse('unknown_user'),
+        newIdentityResponse('unuser:default/known_user'),
       );
       expect(decision.result).toBe(AuthorizeResult.DENY);
     });
@@ -136,7 +174,7 @@ describe('RBACPermissionPolicy Tests', () => {
     it('should deny access to basic permission for listed user deny and allow', async () => {
       const decision = await policy.handle(
         newPolicyQueryWithBasicPermission('test.resource'),
-        newIdentityResponse('duplicated'),
+        newIdentityResponse('user:default/duplicated'),
       );
       expect(decision.result).toBe(AuthorizeResult.DENY);
     });
@@ -144,7 +182,7 @@ describe('RBACPermissionPolicy Tests', () => {
     it('should allow access to basic permission for user listed on policy', async () => {
       const decision = await policy.handle(
         newPolicyQueryWithBasicPermission('test.resource'),
-        newIdentityResponse('known_user'),
+        newIdentityResponse('user:default/known_user'),
       );
       expect(decision.result).toBe(AuthorizeResult.ALLOW);
     });
@@ -159,7 +197,7 @@ describe('RBACPermissionPolicy Tests', () => {
           'test-resource-deny',
           'update',
         ),
-        newIdentityResponse('known_user'),
+        newIdentityResponse('user:default/known_user'),
       );
       expect(decision.result).toBe(AuthorizeResult.DENY);
     });
@@ -171,7 +209,7 @@ describe('RBACPermissionPolicy Tests', () => {
           'test-resource',
           'update',
         ),
-        newIdentityResponse('unknown_user'),
+        newIdentityResponse('unuser:default/known_user'),
       );
       expect(decision.result).toBe(AuthorizeResult.DENY);
     });
@@ -183,7 +221,7 @@ describe('RBACPermissionPolicy Tests', () => {
           'test-resource',
           'update',
         ),
-        newIdentityResponse('duplicated'),
+        newIdentityResponse('user:default/duplicated'),
       );
       expect(decision.result).toBe(AuthorizeResult.DENY);
     });
@@ -195,7 +233,7 @@ describe('RBACPermissionPolicy Tests', () => {
           'test-resource',
           'update',
         ),
-        newIdentityResponse('known_user'),
+        newIdentityResponse('user:default/known_user'),
       );
       expect(decision.result).toBe(AuthorizeResult.ALLOW);
     });
@@ -208,7 +246,7 @@ describe('RBACPermissionPolicy Tests', () => {
           'test-resource',
           'delete',
         ),
-        newIdentityResponse('known_user'),
+        newIdentityResponse('user:default/known_user'),
       );
       expect(decision.result).toBe(AuthorizeResult.DENY);
     });
@@ -225,52 +263,461 @@ describe('RBACPermissionPolicy Tests', () => {
       );
       expect(decision.result).toBe(AuthorizeResult.ALLOW);
     });
-
-    // Tests for admin group added through app config
-    it('should allow access to permission resource for admin group added through app config', async () => {
-      const decision = await policy.handle(
-        newPolicyQueryWithResourcePermission(
-          'policy-entity.read',
-          'policy-entity',
-          'read',
-        ),
-        newIdentityResponseWithGroup(
-          'user:default/guest2',
-          'group:default/guests',
-        ),
-      );
-      expect(decision.result).toBe(AuthorizeResult.ALLOW);
-    });
-
-    // Test for group access permission
-    it('should allow access to a user in an authorized group', async () => {
-      const decision = await policy.handle(
-        newPolicyQueryWithBasicPermission('test.resource.deny'),
-        newIdentityResponseWithGroup('known_user', 'group'),
-      );
-      expect(decision.result).toBe(AuthorizeResult.DENY);
-    });
   });
 });
 
-function newPolicyQueryWithBasicPermission(
-  name: string,
-  action?: 'create' | 'read' | 'update' | 'delete' | undefined,
-): PolicyQuery {
+describe('Policy checks for users and groups', () => {
+  let policy: RBACPermissionPolicy;
+
+  beforeEach(async () => {
+    const adapter = new StringAdapter(
+      `
+      # basic type permission policies
+      ### Let's deny 'use' action for 'test.resource' for group:default/data_admin
+      p, group:default/data_admin, test.resource, use, deny
+      
+      # case1:
+      # g, user:default/alice, group:default/data_admin
+      p, user:default/alice, test.resource, use, allow
+      
+      # case2:
+      # g, user:default/akira, group:default/data_admin
+      
+      # case3:
+      # g, user:default/antey, group:default/data_admin
+      p, user:default/antey, test.resource, use, deny
+      
+      ### Let's allow 'use' action for 'test.resource' for group:default/data_read_admin
+      p, group:default/data_read_admin, test.resource, use, allow
+      
+      # case4:
+      # g, user:default/julia, group:default/data_read_admin
+      p, user:default/julia, test.resource, use, allow
+      
+      # case5:
+      # g, user:default/mike, group:default/data_read_admin
+      
+      # case6:
+      # g, user:default/tom, group:default/data_read_admin
+      p, user:default/tom, test.resource, use, deny
+      
+      
+      # resource type permission policies
+      ### Let's deny 'read' action for 'test.resource' permission for group:default/data_admin
+      p, group:default/data_admin, test-resource, read, deny
+      
+      # case1:
+      # g, user:default/alice, group:default/data_admin
+      p, user:default/alice, test-resource, read, allow
+      
+      # case2:
+      # g, user:default/akira, group:default/data_admin
+      
+      # case3:
+      # g, user:default/antey, group:default/data_admin
+      p, user:default/antey, test-resource, read, deny
+      
+      ### Let's allow 'read' action for 'test-resource' permission for group:default/data_read_admin
+      p, group:default/data_read_admin, test-resource, read, allow
+      
+      # case4:
+      # g, user:default/julia, group:default/data_read_admin
+      p, user:default/julia, test-resource, read, allow
+      
+      # case5:
+      # g, user:default/mike, group:default/data_read_admin
+      
+      # case6:
+      # g, user:default/tom, group:default/data_read_admin
+      p, user:default/tom, test-resource, read, deny
+
+
+      # group inheritance:
+      # g, group:default/data-read-admin, group:default/data_parent_admin
+      # and we know case5:
+      # g, user:default/mike, data-read-admin
+  
+      p, group:default/data_parent_admin, test.resource.2, use, allow
+      p, group:default/data_parent_admin, test-resource, create, allow
+      `,
+    );
+    const config = newConfigReader();
+    const theModel = newModelFromString(MODEL);
+    const enf = await newEnforcer(theModel, adapter);
+    policy = await RBACPermissionPolicy.build(
+      getVoidLogger(),
+      config,
+      catalogApi,
+      enf,
+    );
+    catalogApi.getEntities.mockReset();
+  });
+
+  // User inherits permissions from groups and their parent groups.
+  // This behavior can be configured with `policy_effect` in the model.
+  // Also it can be customized using casbin function.
+  // Test suite table:
+  // +-------+---------+----------+-------+
+  // | Group |  User   |  result  | case# |
+  // +-------+---------+----------+-------+
+  // | deny  |  allow  |  deny    |   1   | +
+  // | deny  |    -    |  deny    |   2   | +
+  // | deny  |  deny   |  deny    |   3   | +
+  // +-------+---------+----------+-------+
+  // | allow | allow   | allow    |   4   | +
+  // | allow |   -     | allow    |   5   | +
+  // | allow |  deny   | deny     |   6   |
+  // +-------+---------+----------+-------+
+
+  // Basic type permissions
+
+  // case1
+  it('should deny access to basic permission for user Alice with "allow" "use" action, when her group "deny" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+
+    const decision = await policy.handle(
+      newPolicyQueryWithBasicPermission('test.resource'),
+      newIdentityResponse('user:default/alice'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.DENY);
+  });
+
+  // case2
+  it('should deny access to basic permission for user Akira without("-") "use" action definition, when his group "deny" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+    const decision = await policy.handle(
+      newPolicyQueryWithBasicPermission('test.resource'),
+      newIdentityResponse('user:default/akira'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.DENY);
+  });
+
+  // case3
+  it('should deny access to basic permission for user Antey with "deny" "use" action definition, when his group "deny" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+    const decision = await policy.handle(
+      newPolicyQueryWithBasicPermission('test.resource'),
+      newIdentityResponse('user:default/antey'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.DENY);
+  });
+
+  // case4
+  it('should allow access to basic permission for user Julia with "allow" "use" action, when her group "allow" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_read_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+
+    const decision = await policy.handle(
+      newPolicyQueryWithBasicPermission('test.resource'),
+      newIdentityResponse('user:default/julia'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+
+  // case5
+  it('should allow access to basic permission for user Mike without("-") "use" action definition, when his group "allow" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_read_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+    const decision = await policy.handle(
+      newPolicyQueryWithBasicPermission('test.resource'),
+      newIdentityResponse('user:default/mike'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+
+  // case6
+  it('should deny access to basic permission for user Tom with "deny" "use" action definition, when his group "allow" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_read_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+    const decision = await policy.handle(
+      newPolicyQueryWithBasicPermission('test.resource'),
+      newIdentityResponse('user:default/tom'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.DENY);
+  });
+
+  // inheritance case
+  it('should allow access to basic permission to test.resource.2 for user Mike with "-" "use" action definition, when parent group of his group "allow" this action', async () => {
+    const groupMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_read_admin',
+        namespace: 'default',
+      },
+      spec: {
+        parent: 'group:default/data_parent_admin',
+      },
+    };
+
+    const groupParentMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_parent_admin',
+        namespace: 'default',
+      },
+    };
+
+    catalogApi.getEntities.mockImplementation(arg => {
+      const hasMember = arg.filter['relations.hasMember'];
+      if (hasMember && hasMember[0] === 'user:default/mike') {
+        return { items: [groupMock] };
+      }
+      const hasParent = arg.filter['relations.parentOf'];
+      if (hasParent && hasParent[0] === 'group:default/data_read_admin') {
+        return { items: [groupParentMock] };
+      }
+      return { items: [] };
+    });
+
+    const decision = await policy.handle(
+      newPolicyQueryWithBasicPermission('test.resource.2'),
+      newIdentityResponse('user:default/mike'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+
+  // Resource type permissions
+
+  // case1
+  it('should deny access to basic permission for user Alice with "allow" "read" action, when her group "deny" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'test.resource.read',
+        'test-resource',
+        'read',
+      ),
+      newIdentityResponse('user:default/alice'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.DENY);
+  });
+
+  // case2
+  it('should deny access to basic permission for user Akira without("-") "read" action definition, when his group "deny" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'test.resource.read',
+        'test-resource',
+        'read',
+      ),
+      newIdentityResponse('user:default/akira'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.DENY);
+  });
+
+  // case3
+  it('should deny access to basic permission for user Antey with "deny" "read" action definition, when his group "deny" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'test.resource.read',
+        'test-resource',
+        'read',
+      ),
+      newIdentityResponse('user:default/antey'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.DENY);
+  });
+
+  // case4
+  it('should allow access to basic permission for user Julia with "allow" "read" action, when her group "allow" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_read_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'test.resource.read',
+        'test-resource',
+        'read',
+      ),
+      newIdentityResponse('user:default/julia'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+
+  // case5
+  it('should allow access to basic permission for user Mike without("-") "read" action definition, when his group "allow" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_read_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'test.resource.read',
+        'test-resource',
+        'read',
+      ),
+      newIdentityResponse('user:default/mike'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+
+  // case6
+  it('should deny access to basic permission for user Tom with "deny" "read" action definition, when his group "allow" this action', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_read_admin',
+        namespace: 'default',
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'test.resource.read',
+        'test-resource',
+        'read',
+      ),
+      newIdentityResponse('user:default/tom'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.DENY);
+  });
+
+  // inheritance case
+  it('should allow access to resource permission to test-resource for user Mike with "-" "write" action definition, when parent group of his group "allow" this action', async () => {
+    const groupMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_read_admin',
+        namespace: 'default',
+      },
+      spec: {
+        parent: 'group:default/data_parent_admin',
+      },
+    };
+
+    const groupParentMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'data_parent_admin',
+        namespace: 'default',
+      },
+    };
+
+    catalogApi.getEntities.mockImplementation(arg => {
+      const hasMember = arg.filter['relations.hasMember'];
+      if (hasMember && hasMember[0] === 'user:default/mike') {
+        return { items: [groupMock] };
+      }
+      const hasParent = arg.filter['relations.parentOf'];
+      if (hasParent && hasParent[0] === 'group:default/data_read_admin') {
+        return { items: [groupParentMock] };
+      }
+      return { items: [] };
+    });
+
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'test.resource.create',
+        'test-resource',
+        'create',
+      ),
+      newIdentityResponse('user:default/mike'),
+    );
+    expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+});
+
+function newPolicyQueryWithBasicPermission(name: string): PolicyQuery {
   const mockPermission = createPermission({
     name: name,
     attributes: {},
   });
-  if (action) {
-    mockPermission.attributes.action = action;
-  }
   return { permission: mockPermission };
 }
 
 function newPolicyQueryWithResourcePermission(
   name: string,
   resource: string,
-  action?: 'create' | 'read' | 'update' | 'delete' | undefined,
+  action: 'create' | 'read' | 'update' | 'delete',
 ): PolicyQuery {
   const mockPermission = createPermission({
     name: name,
@@ -287,20 +734,6 @@ function newIdentityResponse(user: string): BackstageIdentityResponse {
   return {
     identity: {
       ownershipEntityRefs: [],
-      type: 'user',
-      userEntityRef: user,
-    },
-    token: '',
-  };
-}
-
-function newIdentityResponseWithGroup(
-  user: string,
-  group: string,
-): BackstageIdentityResponse {
-  return {
-    identity: {
-      ownershipEntityRefs: [group],
       type: 'user',
       userEntityRef: user,
     },

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -156,7 +156,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
 
     const entityRef = identity.userEntityRef;
 
-    const rm = new BackstageRoleManager(this.catalogApi);
+    const rm = new BackstageRoleManager(this.catalogApi, this.logger);
     this.enforcer.setRoleManager(rm);
     this.enforcer.enableAutoBuildRoleLinks(false);
     await this.enforcer.buildRoleLinks();

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -1,4 +1,5 @@
 import { errorHandler, getVoidLogger } from '@backstage/backend-common';
+import { CatalogApi } from '@backstage/catalog-client';
 import { ConfigReader } from '@backstage/config';
 import { InputError } from '@backstage/errors';
 import { RouterOptions } from '@backstage/plugin-permission-backend';
@@ -55,6 +56,22 @@ jest.mock('casbin', () => {
     }),
   };
 });
+
+const catalogApi: CatalogApi = {
+  getEntityAncestors: jest.fn().mockImplementation(),
+  getLocationById: jest.fn().mockImplementation(),
+  getEntities: jest.fn().mockImplementation(),
+  getEntitiesByRefs: jest.fn().mockImplementation(),
+  queryEntities: jest.fn().mockImplementation(),
+  getEntityByRef: jest.fn().mockImplementation(),
+  refreshEntity: jest.fn().mockImplementation(),
+  getEntityFacets: jest.fn().mockImplementation(),
+  addLocation: jest.fn().mockImplementation(),
+  getLocationByRef: jest.fn().mockImplementation(),
+  removeLocationById: jest.fn().mockImplementation(),
+  removeEntityByUid: jest.fn().mockImplementation(),
+  validateEntity: jest.fn().mockImplementation(),
+};
 
 describe('REST policies api', () => {
   let app: express.Express;
@@ -118,6 +135,7 @@ describe('REST policies api', () => {
       policy: await RBACPermissionPolicy.build(
         logger,
         config,
+        catalogApi,
         mockEnforcer as Enforcer,
       ),
     };

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -1,5 +1,4 @@
 import { errorHandler, getVoidLogger } from '@backstage/backend-common';
-import { CatalogApi } from '@backstage/catalog-client';
 import { ConfigReader } from '@backstage/config';
 import { InputError } from '@backstage/errors';
 import { RouterOptions } from '@backstage/plugin-permission-backend';
@@ -56,22 +55,6 @@ jest.mock('casbin', () => {
     }),
   };
 });
-
-const catalogApi: CatalogApi = {
-  getEntityAncestors: jest.fn().mockImplementation(),
-  getLocationById: jest.fn().mockImplementation(),
-  getEntities: jest.fn().mockImplementation(),
-  getEntitiesByRefs: jest.fn().mockImplementation(),
-  queryEntities: jest.fn().mockImplementation(),
-  getEntityByRef: jest.fn().mockImplementation(),
-  refreshEntity: jest.fn().mockImplementation(),
-  getEntityFacets: jest.fn().mockImplementation(),
-  addLocation: jest.fn().mockImplementation(),
-  getLocationByRef: jest.fn().mockImplementation(),
-  removeLocationById: jest.fn().mockImplementation(),
-  removeEntityByUid: jest.fn().mockImplementation(),
-  validateEntity: jest.fn().mockImplementation(),
-};
 
 describe('REST policies api', () => {
   let app: express.Express;
@@ -135,7 +118,6 @@ describe('REST policies api', () => {
       policy: await RBACPermissionPolicy.build(
         logger,
         config,
-        catalogApi,
         mockEnforcer as Enforcer,
       ),
     };

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -125,31 +125,29 @@ export class PolicesServer {
       response.json(this.transformPolicyArray(...policies));
     });
 
-    router.get(
-      '/policies/:kind/:namespace/:name',
-      async (request, response) => {
-        const decision = await this.authorize(
-          this.identity,
-          request,
-          this.permissions,
-          {
-            permission: policyEntityReadPermission,
-          },
-        );
+    router.get('/policies/:kind/:namespace/:name', async (req, response) => {
+      const decision = await this.authorize(
+        this.identity,
+        req,
+        this.permissions,
+        {
+          permission: policyEntityReadPermission,
+        },
+      );
 
-        if (decision.result === AuthorizeResult.DENY) {
-          throw new NotAllowedError(); // 403
-        }
+      if (decision.result === AuthorizeResult.DENY) {
+        throw new NotAllowedError(); // 403
+      }
 
-        const entityRef = this.getEntityReference(request);
-        const policy = await this.enforcer.getFilteredPolicy(0, entityRef);
-        if (policy.length !== 0) {
-          response.json(this.transformPolicyArray(...policy));
-        } else {
-          throw new NotFoundError(); // 404
-        }
-      },
-    );
+      const entityRef = this.getEntityReference(req);
+
+      const policy = await this.enforcer.getFilteredPolicy(0, entityRef);
+      if (policy.length !== 0) {
+        response.json(this.transformPolicyArray(...policy));
+      } else {
+        throw new NotFoundError(); // 404
+      }
+    });
 
     router.delete(
       '/policies/:kind/:namespace/:name',

--- a/plugins/rbac-backend/src/service/policies-validation.ts
+++ b/plugins/rbac-backend/src/service/policies-validation.ts
@@ -61,6 +61,12 @@ export function validateEntityReference(entityRef?: string): Error | undefined {
     );
   }
 
+  if (entityRefCompound.kind !== 'user' && entityRefCompound.kind !== 'group') {
+    return new Error(
+      `Unsupported kind ${entityRefCompound.kind}. List supported values ["user", "group"]`,
+    );
+  }
+
   return undefined;
 }
 

--- a/plugins/rbac-backend/src/service/policy-builder.test.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.test.ts
@@ -13,7 +13,10 @@ import { PolicyBuilder } from './policy-builder';
 
 const mockEnforcer: Partial<Enforcer> = {
   loadPolicy: jest.fn().mockImplementation(async () => {}),
-  enableAutoSave: jest.fn().mockImplementation((_enable: boolean) => {}),
+  enableAutoSave: jest.fn().mockImplementation(() => {}),
+  setRoleManager: jest.fn().mockImplementation(() => {}),
+  enableAutoBuildRoleLinks: jest.fn().mockImplementation(() => {}),
+  buildRoleLinks: jest.fn().mockImplementation(() => {}),
 };
 
 jest.mock('casbin', () => {

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -3,6 +3,7 @@ import {
   PluginEndpointDiscovery,
   resolvePackagePath,
 } from '@backstage/backend-common';
+import { CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { IdentityApi } from '@backstage/plugin-auth-node';
 import { RouterOptions } from '@backstage/plugin-permission-backend';
@@ -50,12 +51,19 @@ export class PolicyBuilder {
     await enf.loadPolicy();
     await enf.enableAutoSave(true);
 
+    const catalogClient = new CatalogClient({ discoveryApi: env.discovery });
+
     const options: RouterOptions = {
       config: env.config,
       logger: env.logger,
       discovery: env.discovery,
       identity: env.identity,
-      policy: await RBACPermissionPolicy.build(env.logger, env.config, enf),
+      policy: await RBACPermissionPolicy.build(
+        env.logger,
+        env.config,
+        catalogClient,
+        enf,
+      ),
     };
 
     const server = new PolicesServer(

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -17,6 +17,7 @@ import { CasbinDBAdapterFactory } from './casbin-adapter-factory';
 import { MODEL } from './permission-model';
 import { RBACPermissionPolicy } from './permission-policy';
 import { PolicesServer } from './policies-rest-api';
+import { BackstageRoleManager } from './role-manager';
 
 export class PolicyBuilder {
   public static async build(env: {
@@ -52,18 +53,17 @@ export class PolicyBuilder {
     await enf.enableAutoSave(true);
 
     const catalogClient = new CatalogClient({ discoveryApi: env.discovery });
+    const rm = new BackstageRoleManager(catalogClient, env.logger);
+    enf.setRoleManager(rm);
+    enf.enableAutoBuildRoleLinks(false);
+    await enf.buildRoleLinks();
 
     const options: RouterOptions = {
       config: env.config,
       logger: env.logger,
       discovery: env.discovery,
       identity: env.identity,
-      policy: await RBACPermissionPolicy.build(
-        env.logger,
-        env.config,
-        catalogClient,
-        enf,
-      ),
+      policy: await RBACPermissionPolicy.build(env.logger, env.config, enf),
     };
 
     const server = new PolicesServer(

--- a/plugins/rbac-backend/src/service/role-manager.test.ts
+++ b/plugins/rbac-backend/src/service/role-manager.test.ts
@@ -1,0 +1,401 @@
+import { CatalogApi } from '@backstage/catalog-client';
+import { Entity } from '@backstage/catalog-model';
+
+import { BackstageRoleManager } from './role-manager'; // Adjust the path as needed
+
+describe('BackstageRoleManager', () => {
+  const catalogApi: any = {
+    getEntities: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ items: [] })),
+  };
+
+  const roleManager = new BackstageRoleManager(catalogApi as CatalogApi);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('unimplemented methods', () => {
+    it('should throw an error for addLink', async () => {
+      await expect(
+        roleManager.addLink('user:default/role1', 'user:default/role2'),
+      ).rejects.toThrow('Method "addLink" not implemented.');
+    });
+
+    it('should throw an error for deleteLink', async () => {
+      await expect(
+        roleManager.deleteLink('user:default/role1', 'user:default/role2'),
+      ).rejects.toThrow('Method "deleteLink" not implemented.');
+    });
+
+    it('should throw an error for syncedHasLink', () => {
+      expect(() =>
+        roleManager.syncedHasLink!('user:default/role1', 'user:default/role2'),
+      ).toThrow('Method "syncedHasLink" not implemented.');
+    });
+
+    it('should throw an error for getRoles', async () => {
+      await expect(roleManager.getRoles('name')).rejects.toThrow(
+        'Method "getRoles" not implemented.',
+      );
+    });
+
+    it('should throw an error for getUsers', async () => {
+      await expect(roleManager.getUsers('name')).rejects.toThrow(
+        'Method "getUsers" not implemented.',
+      );
+    });
+  });
+
+  describe('hasLink tests', () => {
+    it('should return true for hasLink when names are the same', async () => {
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'user:default/mike',
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should return false for hasLink when name2 has a user kind', async () => {
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'user:default/some-user',
+      );
+      expect(result).toBe(false);
+    });
+
+    // user:default/mike should not inherits from group:default/somegroup?
+    //
+    //     Hierarchy:
+    //
+    // user:default/mike -> user without group
+    //
+    it('should return false for hasLink when user without group', async () => {
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'group:default/somegroup',
+      );
+      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+        filter: {
+          kind: 'Group',
+          'relations.hasMember': ['user:default/mike'],
+        },
+        fields: ['metadata.name', 'kind', 'metadata.namespace', 'spec.parent'],
+      });
+      expect(result).toBeFalsy();
+    });
+
+    // user:default/mike should inherits from group:default/somegroup?
+    //
+    //     Hierarchy:
+    //
+    // group:default/somegroup
+    //          |
+    //  user:default/mike
+    //
+    it('should return true for hasLink when user:default/mike inherits from group:default/somegroup', async () => {
+      const entityMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'somegroup',
+          namespace: 'default',
+        },
+      };
+      catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'group:default/somegroup',
+      );
+      expect(result).toBeTruthy();
+    });
+
+    // user:default/mike should not inherits from group:default/somegroup?
+    //
+    //     Hierarchy:
+    //
+    // group:default/not-matched-group
+    //         |
+    // user:default/mike
+    //
+    it('should return false for hasLink when user:default/mike does not inherits group:default/somegroup', async () => {
+      const entityMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'not-matched-group',
+          namespace: 'default',
+        },
+      };
+      catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'group:default/somegroup',
+      );
+      expect(result).toBeFalsy();
+    });
+
+    // user:default/mike should inherits from group:default/team-a?
+    //
+    //     Hierarchy:
+    //
+    // group:default/team-a
+    //       |
+    // group:default/team-b
+    //       |
+    // user:default/mike
+    //
+    it('should return true for hasLink, when user:default/mike inherits from group:default/team-b', async () => {
+      const groupMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-b',
+          namespace: 'default',
+        },
+        spec: {
+          parent: 'group:default/team-a',
+        },
+      };
+
+      const groupParentMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-a',
+          namespace: 'default',
+        },
+      };
+
+      catalogApi.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember[0] === 'user:default/mike') {
+          return { items: [groupMock] };
+        }
+        const hasParent = arg.filter['relations.parentOf'];
+        if (hasParent && hasParent[0] === 'group:default/team-b') {
+          return { items: [groupParentMock] };
+        }
+        return { items: [] };
+      });
+
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'group:default/team-b',
+      );
+      expect(result).toBeTruthy();
+    });
+
+    // user:default/mike should inherits from group:default/team-c?
+    //
+    //     Hierarchy:
+    //
+    // group:default/team-a
+    //       |
+    // group:default/team-b
+    //       |
+    // user:default/mike
+    //
+    it('should return false for hasLink, when user:default/mike does not inherits from group:default/team-c', async () => {
+      const groupMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-b',
+          namespace: 'default',
+        },
+        spec: {
+          parent: 'group:default/team-a',
+        },
+      };
+
+      const groupParentMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-a',
+          namespace: 'default',
+        },
+      };
+
+      catalogApi.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember[0] === 'user:default/mike') {
+          return { items: [groupMock] };
+        }
+        const hasParent = arg.filter['relations.parentOf'];
+        if (hasParent && hasParent[0] === 'group:default/team-b') {
+          return { items: [groupParentMock] };
+        }
+        return { items: [] };
+      });
+
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'group:default/team-c',
+      );
+      expect(result).toBeFalsy();
+    });
+
+    // user:default/mike should inherits from group:default/team-a?
+    //
+    //     Hierarchy:
+    //
+    // group:default/team-a  group:default/team-b
+    //       |                        |
+    // group:default/team-c  group:default/team-d
+    //                |              |
+    //                user:default/mike
+    //
+    it('should return true for hasLink, when user:default/mike inherits from group:default/team-a', async () => {
+      const groupCMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-c',
+          namespace: 'default',
+        },
+        spec: {
+          parent: 'group:default/team-a',
+        },
+      };
+      const groupDMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-d',
+          namespace: 'default',
+        },
+        spec: {
+          parent: 'group:default/team-b',
+        },
+      };
+
+      const groupAMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-a',
+          namespace: 'default',
+        },
+      };
+      const groupBMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-b',
+          namespace: 'default',
+        },
+      };
+
+      catalogApi.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember[0] === 'user:default/mike') {
+          return { items: [groupCMock, groupDMock] };
+        }
+        const hasParent = arg.filter['relations.parentOf'];
+        if (
+          hasParent &&
+          hasParent[0] === 'group:default/team-c' &&
+          hasParent[1] === 'group:default/team-d'
+        ) {
+          return { items: [groupAMock, groupBMock] };
+        }
+        return { items: [] };
+      });
+
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'group:default/team-a',
+      );
+      expect(result).toBeTruthy();
+    });
+
+    // user:default/mike should inherits from group:default/team-a?
+    //
+    //     Hierarchy:
+    //
+    // group:default/team-a  group:default/team-b
+    //       |                        |
+    // group:default/team-c  group:default/team-d
+    //                |              |
+    //                user:default/mike
+    //
+    it('should return true for hasLink, when user:default/mike inherits from group:default/team-e', async () => {
+      const groupCMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-c',
+          namespace: 'default',
+        },
+        spec: {
+          parent: 'group:default/team-a',
+        },
+      };
+      const groupDMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-d',
+          namespace: 'default',
+        },
+        spec: {
+          parent: 'group:default/team-b',
+        },
+      };
+
+      const groupAMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-a',
+          namespace: 'default',
+        },
+      };
+      const groupBMock: Entity = {
+        apiVersion: 'v1',
+        kind: 'Group',
+        metadata: {
+          name: 'team-b',
+          namespace: 'default',
+        },
+      };
+
+      catalogApi.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember[0] === 'user:default/mike') {
+          return { items: [groupCMock, groupDMock] };
+        }
+        const hasParent = arg.filter['relations.parentOf'];
+        if (
+          hasParent &&
+          hasParent[0] === 'group:default/team-c' &&
+          hasParent[1] === 'group:default/team-d'
+        ) {
+          return { items: [groupAMock, groupBMock] };
+        }
+        return { items: [] };
+      });
+
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'group:default/team-e',
+      );
+      expect(result).toBeFalsy();
+    });
+
+    it('should throw an error for unsupported domain', async () => {
+      await expect(
+        roleManager.hasLink(
+          'user:default/mike',
+          'group:default/somegroup',
+          'someDomain',
+        ),
+      ).rejects.toThrow('domain argument is not supported.');
+    });
+  });
+});

--- a/plugins/rbac-backend/src/service/role-manager.test.ts
+++ b/plugins/rbac-backend/src/service/role-manager.test.ts
@@ -81,7 +81,13 @@ describe('BackstageRoleManager', () => {
           kind: 'Group',
           'relations.hasMember': ['user:default/mike'],
         },
-        fields: ['metadata.name', 'kind', 'metadata.namespace', 'spec.parent'],
+        fields: [
+          'metadata.name',
+          'kind',
+          'metadata.namespace',
+          'spec.parent',
+          'spec.children',
+        ],
       });
       expect(result).toBeFalsy();
     });

--- a/plugins/rbac-backend/src/service/role-manager.test.ts
+++ b/plugins/rbac-backend/src/service/role-manager.test.ts
@@ -1,7 +1,7 @@
 import { CatalogApi } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 
-import { BackstageRoleManager } from './role-manager'; // Adjust the path as needed
+import { BackstageRoleManager } from './role-manager';
 
 describe('BackstageRoleManager', () => {
   const catalogApi: any = {
@@ -65,7 +65,7 @@ describe('BackstageRoleManager', () => {
       expect(result).toBe(false);
     });
 
-    // user:default/mike should not inherits from group:default/somegroup?
+    // user:default/mike should not inherits from group:default/somegroup
     //
     //     Hierarchy:
     //
@@ -86,7 +86,7 @@ describe('BackstageRoleManager', () => {
       expect(result).toBeFalsy();
     });
 
-    // user:default/mike should inherits from group:default/somegroup?
+    // user:default/mike should inherits from group:default/somegroup
     //
     //     Hierarchy:
     //
@@ -112,7 +112,7 @@ describe('BackstageRoleManager', () => {
       expect(result).toBeTruthy();
     });
 
-    // user:default/mike should not inherits from group:default/somegroup?
+    // user:default/mike should not inherits from group:default/somegroup
     //
     //     Hierarchy:
     //
@@ -138,7 +138,7 @@ describe('BackstageRoleManager', () => {
       expect(result).toBeFalsy();
     });
 
-    // user:default/mike should inherits from group:default/team-a?
+    // user:default/mike should inherits from group:default/team-a
     //
     //     Hierarchy:
     //
@@ -148,7 +148,7 @@ describe('BackstageRoleManager', () => {
     //       |
     // user:default/mike
     //
-    it('should return true for hasLink, when user:default/mike inherits from group:default/team-b', async () => {
+    it('should return true for hasLink, when user:default/mike inherits from group:default/team-a', async () => {
       const groupMock: Entity = {
         apiVersion: 'v1',
         kind: 'Group',
@@ -184,7 +184,7 @@ describe('BackstageRoleManager', () => {
 
       const result = await roleManager.hasLink(
         'user:default/mike',
-        'group:default/team-b',
+        'group:default/team-a',
       );
       expect(result).toBeTruthy();
     });
@@ -240,7 +240,7 @@ describe('BackstageRoleManager', () => {
       expect(result).toBeFalsy();
     });
 
-    // user:default/mike should inherits from group:default/team-a?
+    // user:default/mike should inherits from group:default/team-a
     //
     //     Hierarchy:
     //
@@ -250,7 +250,7 @@ describe('BackstageRoleManager', () => {
     //                |              |
     //                user:default/mike
     //
-    it('should return true for hasLink, when user:default/mike inherits from group:default/team-a', async () => {
+    it('should return true for hasLink, when user:default/mike inherits group tree with group:default/team-a', async () => {
       const groupCMock: Entity = {
         apiVersion: 'v1',
         kind: 'Group',
@@ -314,7 +314,7 @@ describe('BackstageRoleManager', () => {
       expect(result).toBeTruthy();
     });
 
-    // user:default/mike should inherits from group:default/team-a?
+    // user:default/mike should inherits from group:default/team-e
     //
     //     Hierarchy:
     //

--- a/plugins/rbac-backend/src/service/role-manager.ts
+++ b/plugins/rbac-backend/src/service/role-manager.ts
@@ -1,40 +1,149 @@
+import { CatalogApi } from '@backstage/catalog-client';
+import { Entity, parseEntityRef } from '@backstage/catalog-model';
+
 import { RoleManager } from 'casbin';
 
+type FilterRelations = 'relations.hasMember' | 'relations.parentOf';
+
 export class BackstageRoleManager implements RoleManager {
-  clear(): Promise<void> {
-    throw new Error('Method not implemented.');
+  constructor(private readonly catalogApi: CatalogApi) {}
+
+  /**
+   * clear clears all stored data and resets the role manager to the initial state.
+   */
+  async clear(): Promise<void> {
+    // do nothing
   }
-  addLink(_name1: string, _name2: string, ..._domain: string[]): Promise<void> {
-    throw new Error('Method not implemented.');
-  }
-  deleteLink(
+
+  /**
+   * addLink adds the inheritance link between role: name1 and role: name2.
+   * aka role: name1 inherits role: name2.
+   * domain is a prefix to the roles.
+   */
+  async addLink(
     _name1: string,
     _name2: string,
     ..._domain: string[]
   ): Promise<void> {
-    throw new Error('Method not implemented.');
+    throw new Error('Method "addLink" not implemented.');
   }
-  hasLink(
+
+  /**
+   * deleteLink deletes the inheritance link between role: name1 and role: name2.
+   * aka role: name1 does not inherit role: name2 any more.
+   * domain is a prefix to the roles.
+   */
+  async deleteLink(
     _name1: string,
     _name2: string,
     ..._domain: string[]
-  ): Promise<boolean> {
-    throw new Error('Method not implemented.');
+  ): Promise<void> {
+    throw new Error('Method "deleteLink" not implemented.');
   }
+
+  /**
+   * hasLink determines whether role: name1 inherits role: name2.
+   * domain is a prefix to the roles.
+   */
+  async hasLink(
+    name1: string,
+    name2: string,
+    ...domain: string[]
+  ): Promise<boolean> {
+    if (domain.length > 0) {
+      throw new Error('domain argument is not supported.');
+    }
+
+    if (name1 === name2) {
+      return true;
+    }
+
+    // name1 is always user in our case.
+    // name2 is user or group.
+    // user(name1) couldn't inherit user(name2).
+    // We can use this fact for optimization.
+    const { kind } = parseEntityRef(name2);
+    if (kind.toLocaleLowerCase() === 'user') {
+      return false;
+    }
+
+    // optimization: don't make request if name2 is user...
+    const role = await this.findAncestorGroup(
+      [name1],
+      name2,
+      'relations.hasMember',
+    );
+    return !!role;
+  }
+
+  /**
+   * syncedHasLink determines whether role: name1 inherits role: name2.
+   * domain is a prefix to the roles.
+   */
   syncedHasLink?(
     _name1: string,
     _name2: string,
     ..._domain: string[]
   ): boolean {
-    throw new Error('Method not implemented.');
+    throw new Error('Method "syncedHasLink" not implemented.');
   }
-  getRoles(_name: string, ..._domain: string[]): Promise<string[]> {
-    throw new Error('Method not implemented.');
+
+  /**
+   * getRoles gets the roles that a subject inherits.
+   * domain is a prefix to the roles.
+   */
+  async getRoles(_name: string, ..._domain: string[]): Promise<string[]> {
+    throw new Error('Method "getRoles" not implemented.');
   }
-  getUsers(_name: string, ..._domain: string[]): Promise<string[]> {
-    throw new Error('Method not implemented.');
+
+  /**
+   * getUsers gets the users that inherits a subject.
+   * domain is an unreferenced parameter here, may be used in other implementations.
+   */
+  async getUsers(_name: string, ..._domain: string[]): Promise<string[]> {
+    throw new Error('Method "getUsers" not implemented.');
   }
-  printRoles(): Promise<void> {
-    throw new Error('Method not implemented.');
+
+  /**
+   * printRoles prints all the roles to log.
+   */
+  async printRoles(): Promise<void> {
+    // do nothing
+  }
+
+  private async findAncestorGroup(
+    entityRefs: string[],
+    groupToSearch: string,
+    fr: FilterRelations,
+  ): Promise<Entity | undefined> {
+    const { items } = await this.catalogApi.getEntities({
+      filter: {
+        kind: 'Group',
+        [fr]: Array.from(entityRefs),
+      },
+      // Save traffic with only required information for us
+      fields: ['metadata.name', 'kind', 'metadata.namespace', 'spec.parent'],
+    });
+
+    const groupsRefs = new Set<string>();
+    for (const item of items) {
+      const groupRef = `group:default/${item.metadata.name.toLocaleLowerCase()}`;
+      if (groupRef === groupToSearch) {
+        return item;
+      }
+      if (item.spec && item.spec.parent) {
+        groupsRefs.add(groupRef);
+      }
+    }
+
+    if (groupsRefs.size > 0) {
+      return await this.findAncestorGroup(
+        Array.from(groupsRefs),
+        groupToSearch,
+        'relations.parentOf',
+      );
+    }
+
+    return undefined;
   }
 }

--- a/plugins/rbac-backend/src/service/role-manager.ts
+++ b/plugins/rbac-backend/src/service/role-manager.ts
@@ -131,7 +131,7 @@ export class BackstageRoleManager implements RoleManager {
       if (groupRef === groupToSearch) {
         return item;
       }
-      if (item.spec && item.spec.parent) {
+      if (item.spec?.parent) {
         groupsRefs.add(groupRef);
       }
     }

--- a/plugins/rbac-backend/src/service/role-manager.ts
+++ b/plugins/rbac-backend/src/service/role-manager.ts
@@ -144,7 +144,7 @@ export class BackstageRoleManager implements RoleManager {
 
       memo.hasEntityRef(name2);
 
-      this.log.warning(
+      this.log.warn(
         `Detected cycle ${
           cycles.length > 0 ? 'dependencies' : 'dependency'
         } in the Group graph: ${JSON.stringify(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5832,6 +5832,11 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@dagrejs/graphlib@^2.1.13":
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/@dagrejs/graphlib/-/graphlib-2.1.13.tgz#7d0481966e67226d0a864484524f0db933ffc753"
+  integrity sha512-calbMa7Gcyo+/t23XBaqQqon8LlgE9regey4UVoikoenKBXvUnCUL3s9RP6USCxttfr0XWVICtYUuKMdehKqMw==
+
 "@date-io/core@1.x", "@date-io/core@^1.3.13":
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"


### PR DESCRIPTION
### Referenced issue:

Fixes: janus-idp/backstage-showcase#488

 ### Demo:
 [RBAC groups support for rh-rbac-backend-plugin](https://youtu.be/2c1FLB8fJTQ)

#### Short Conclusions about Possible Implementations

To support RBAC hierarchy groups, we need to retrieve information about these groups. There are two ways:

- Retrieve all group hierarchy.
- Retrieve ancestor groups for the current user.

##### Current Implementation

In the current implementation, I used the second way: we retrieve ancestor groups for the user and evaluate permissions for requests at runtime.

##### Alternative Ways

We can retrieve all group hierarchy information at the start of the backstage instance and store this information.

There are two ways to store this information:

- We can store it in the runtime cache.
- We can store it in the rh-rbac-backend-plugin database.

But in both cases, we are facing an issue: we need to keep this information up to date. We could try to update this information using a scheduled task, but then we need to find a way to get the group hierarchy diff. This solution could have performance issues because we need to retrieve information about all groups, and information about deleted groups or changed group hierarchies will not be applied immediately. Another good alternative approach is to subscribe to the catalog API events and track all changes related to groups. However, this API has not been implemented yet (backstage/backstage/issues/8219).

# Todo:
1. discuss implementation.
2. If current solution is close to goal:
  - handle todos.
  - fix test and write new tests.

### How to test it:
#### Detailed explanation...

#### Test catalog

So I have catalog with groups and users: https://github.com/AndrienkoAleksandr/catalog-model
Group and users defined in the folder examples/acme

For testing purposes you can fork catalog: https://github.com/AndrienkoAleksandr/catalog-model or customize your own.

In this catalog I have a groups hierarchy for testing purpose:

acme-corp
    |
infrastructure
    |
backstage
    |
  team-a


#### Test users

Group team-a has some users. I used two of them:

- AndrienkoAleksandr - permission admin.
  For this user I used github auth provider to login.
  AndrienkoAleksandr is my github account user name.
  I set up github auth provider to match github account with catalog entity user with help of metadata.name:
  https://github.com/AndrienkoAleksandr/catalog-model/blob/60f2ffdfdb4cf4e0b35aa308b63c2909195cc8d5/examples/acme/team-a-group.yaml#L18
- Logarifm - simple user.
  For this user I used bitbucket auth provider to login.
  Logarifm is my bitbucket account user name.
  I set up bithbucket auth provider to match bitbucket account with catalog entity with help of annotation:
  https://github.com/AndrienkoAleksandr/catalog-model/blob/60f2ffdfdb4cf4e0b35aa308b63c2909195cc8d5/examples/acme/team-a-group.yaml#L31

I defined catalog using application config:

```app-config.local.yaml
...
catalog:
...
  rules:
    - allow: [Component, System, Group, User, Resource, Location, Template, API]
  locations:
    # Note: integrations.github[].apps must be correctly configured to read GitHub locations
    # Uncomment these lines to add more example data
    - type: url
      target: https://github.com/AndrienkoAleksandr/catalog-model/tree/rbac/examples/all.yaml

    # Uncomment these lines to add an example org
    - type: url
      target: https://github.com/AndrienkoAleksandr/catalog-model/tree/rbac/examples/acme-corp.yaml
      rules:
        - allow: [User, Group]
...
```

For two test users I defined auth providers for user login:

```app-config.local.yaml
...
auth:
  # see https://backstage.io/docs/auth/ to learn about auth providers
  environment: development
  providers:
    # Plugin: GitHub
    github:
      development:
        clientId: ${GITHUB_BUCKET_CLIENT_ID}
        clientSecret: ${GITHUB_BUCKET_SECRET}
    bitbucket:
      development:
        clientId: ${BIT_BUCKET_CLIENT_ID}
        clientSecret: ${BIT_BUCKET_SECRET}
...
```

Frontend login configuration patch with github resolver `usernameMatchingUserEntityName` and bitbucket resolver `usernameMatchingUserEntityAnnotation`:

```packages/backend/src/plugins/auth.ts
github: providers.github.create({
  signIn: {
-          resolver(_, ctx) {
-            const userRef = 'user:default/guest'; // Must be a full entity reference
-            return ctx.issueToken({
-              claims: {
-                sub: userRef, // The user's own identity
-                ent: [userRef], // A list of identities that the user claims ownership through
-              },
-            });
-          },
-          // resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
+          resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
+        },
+      }),
+      bitbucket: providers.bitbucket.create({
+        signIn: {
+          resolver:
+            providers.bitbucket.resolvers.usernameMatchingUserEntityAnnotation(),
  },
}),
...
```

Backend configuration patch:

```App.tsx
const app = createApp({
+  components: {
+    SignInPage: props => (
+      <SignInPage
+        {...props}
+        auto
+        providers={[
+          {
+            id: 'bitbucket-auth-provider',
+            title: 'Bitbucket',
+            message: 'Sign In using Bitbucket',
+            apiRef: bitbucketAuthApiRef,
+          },
+          {
+            id: 'github-auth-provider',
+            title: 'GitHub',
+            message: 'Sign in using GitHub',
+            apiRef: githubAuthApiRef,
+          },
+        ]}
+      />
+    ),
+  },
```

Enable rh-rback-backend-plugin plugin in the application configuration and
define your permission admin user/s with help of entity reference
(https://backstage.io/docs/features/software-catalog/references/#string-references):

```app-config.local.yaml
...
permission:
  enabled: true
  rbac:
    # Configuration with list predefined permission policies in casbin format.
    # policies-csv-file: /some/path/rbac-policy.csv
    database:
      enabled: true
    admin:
      users:
        - name: user:default/andrienkoaleksandr
...
```

Demo script:

1. Login like permission admin using github auth.
2. Retrieve admin user token. Copy it to terminal:

export token='...token...value'

3. Logout. Login like bitbucket user. Go to the catalog tab. It should be empty.
4. Provide read catalog permission policy for team-a:

curl -X POST "http://localhost:7007/api/permission/policies" -d '{"entityReference": "group:default/team-a", "permission": "catalog-entity", "policy": "read", "effect":"allow"}' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v

5. Go to catalog tab. List catalogs should appear, because user inherits permission policies from team-a
6. Select group filter. Select team-a group. Try to refresh button. Backstage should fail.
7. Provide refresh catalog entity permission, but for user:

curl -X POST "http://localhost:7007/api/permission/policies" -d '{"entityReference": "user:default/logarifm", "permission": "catalog-entity", "policy": "update", "effect":"allow"}' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v

8. Check the refresh button. It should work.
9. Check unregister catalog entity option. It should be disabled.
10. Provide catalog entity unregister permission policy, but for group backstage:

curl -X POST "http://localhost:7007/api/permission/policies" -d '{"entityReference": "group:default/backstage", "permission": "catalog-entity", "policy": "delete", "effect":"allow"}' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v

11. Check unregister catalog entity option. It should work.
12. Go to github: https://github.com/AndrienkoAleksandr/catalog-model/blob/rbac/examples/acme/team-a-group.yaml#L12 . Change team-a parent from backstage to infrastructure. Commit changes.
13. Go to github: https://github.com/AndrienkoAleksandr/catalog-model/blob/rbac/examples/acme/backstage-group.yaml#L13. Remove team-a children.
14. Back to backstage instance, check in the catalogs group team-a and backstage. Since some period of time changes from github should appear in the
backstage.
15. Check: bitbucket user should lose unregister catalog entity permission policy.
