### PR TITLE
fix(keycloak): respect fetch size for members

### DIFF
--- a/.github/workflows/publish-backend-plugin-manager.yaml
+++ b/.github/workflows/publish-backend-plugin-manager.yaml
@@ -46,14 +46,6 @@ jobs:
           fetch-depth: 2147483647
           fetch-tags: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        env:
-          FORCE_COLOR: 0
-        with:
-          node-version: 18
-          cache: 'yarn'
-
       - name: Get sha of the latest backend-plugin-manager commit
         id: get_commit_sha
         run: |
@@ -70,6 +62,15 @@ jobs:
           if [ "_$(npm dist-tag ls $SCOPE/backend-plugin-manager | grep -e ^$COMMIT_ID || echo '')" != "_" ]; then ALREADY_PUSHED="true"; else ALREADY_PUSHED="false"; fi
           echo "ALREADY_PUSHED=$ALREADY_PUSHED" >> "$GITHUB_OUTPUT"
           echo "GH Output: " && cat $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        if: steps.test_commit_already_published.outputs.ALREADY_PUSHED == 'false'
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: 18
+          cache: 'yarn'
 
       - name: Get the version of the backend-plugin-manager package
         id: get_package_version

--- a/.github/workflows/publish-backend-plugin-manager.yaml
+++ b/.github/workflows/publish-backend-plugin-manager.yaml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
+        env:
+          FORCE_COLOR: 0
         with:
           node-version: 18
           cache: 'yarn'

--- a/plugins/keycloak-backend/src/lib/read.ts
+++ b/plugins/keycloak-backend/src/lib/read.ts
@@ -179,7 +179,7 @@ export const readKeycloakRealm = async (
       g.members = (
         await client.groups.listMembers({
           id: g.id!,
-          max: userQuerySize, // without this size, you will end up fetching only a maximum of 100 users
+          max: options?.userQuerySize,
           realm: config.realm,
         })
       ).map(m => m.username!);

--- a/plugins/keycloak-backend/src/lib/read.ts
+++ b/plugins/keycloak-backend/src/lib/read.ts
@@ -179,6 +179,7 @@ export const readKeycloakRealm = async (
       g.members = (
         await client.groups.listMembers({
           id: g.id!,
+          max: userQuerySize, // without this size, you will end up fetching only a maximum of 100 users
           realm: config.realm,
         })
       ).map(m => m.username!);


### PR DESCRIPTION
## Referenced issue:
Fixes: https://github.com/janus-idp/backstage-plugins/issues/805

## Short Conclusions about Possible Implementations
We need to pass a value for the max parameter, already present in the used keycloak api. The fetch size must be propagated, otherwise you will end up fetching only a maximum of 100 users as members of a group, causing wrong data to be used.

There are two ways:
- define a new parameter for member fetch size and pass it to the API call
- re-use the userQuerySize since a member is a user anyway

## Current Implementation
There is no possibility to fetch more than 100. It is uses the default in the keycloak server.

## Changes
We pass the userQuerySize into the fetch of members call per group to retrieve the correct data.

