### PR TITLE
chore(ci): correctly manage upstream tag case

### DIFF
--- a/.github/workflows/publish-backend-plugin-manager.yaml
+++ b/.github/workflows/publish-backend-plugin-manager.yaml
@@ -71,11 +71,8 @@ jobs:
 
       - name: Get sha of the latest backend-plugin-manager commit
         id: get_commit_sha
-        env:
-          GIT_REF: ${{ steps.get_checkout_ref.outputs.GIT_REF }}
         run: |
-          echo "GIT_REF=$GIT_REF"
-          if [[ "$GIT_REF" == "master" ]]; then
+          if [[ ${{ steps.get_checkout_ref.outputs.GIT_REF }} == "master" ]]; then
             echo "COMMIT_ID=$(git rev-list --max-count=1 HEAD -- packages/backend-plugin-manager)" >> "$GITHUB_OUTPUT"
           else
             echo "COMMIT_ID=$(git rev-list --max-count=1 HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-backend-plugin-manager.yaml
+++ b/.github/workflows/publish-backend-plugin-manager.yaml
@@ -50,21 +50,36 @@ jobs:
           else
             GIT_REF=master
           fi
-          echo "GIT_REF=$GIT_REF" >> $GITHUB_ENV
+          echo "GIT_REF=$GIT_REF" >> $GITHUB_OUTPUT
 
-      - name: Checkout
+      - name: Checkout from master
+        if: steps.get_checkout_ref.outputs.GIT_REF == 'master'
         uses: actions/checkout@v4
         with:
           repository: backstage/backstage
-          ref: ${{ steps.get_checkout_ref.outputs.GIT_REF }}
+          ref: master
           # fetch all history, but only for the current ref
           fetch-depth: 2147483647
           fetch-tags: false
 
+      - name: Checkout from a git ref
+        if: steps.get_checkout_ref.outputs.GIT_REF != 'master'
+        uses: actions/checkout@v4
+        with:
+          repository: backstage/backstage
+          ref: '${{ steps.get_checkout_ref.outputs.GIT_REF }}'
+
       - name: Get sha of the latest backend-plugin-manager commit
         id: get_commit_sha
+        env:
+          GIT_REF: ${{ steps.get_checkout_ref.outputs.GIT_REF }}
         run: |
-          echo "COMMIT_ID=$(git rev-list --max-count=1 HEAD -- packages/backend-plugin-manager)" >> "$GITHUB_OUTPUT"
+          echo "GIT_REF=$GIT_REF"
+          if [[ "$GIT_REF" == "master" ]]; then
+            echo "COMMIT_ID=$(git rev-list --max-count=1 HEAD -- packages/backend-plugin-manager)" >> "$GITHUB_OUTPUT"
+          else
+            echo "COMMIT_ID=$(git rev-list --max-count=1 HEAD)" >> "$GITHUB_OUTPUT"
+          fi
           echo "GH Output: " && cat $GITHUB_OUTPUT
 
       - name: Test if commit is already published
@@ -199,3 +214,15 @@ jobs:
           yarn config set 'npmAuthToken' "$NPM_TOKEN"
           yarn workspace $SCOPE/backend-plugin-manager npm publish --access public --tag latest
           yarn npm tag add $SCOPE/backend-plugin-manager@$VERSION $COMMIT_ID
+
+      - name: Tag the package with backstage release tag if is a release commit
+        if:
+          steps.test_commit_already_published.outputs.ALREADY_PUSHED == 'false' &&
+          startsWith(steps.get_checkout_ref.outputs.GIT_REF, 'v')
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_REF: ${{ steps.get_checkout_ref.outputs.GIT_REF }}
+          VERSION: ${{ steps.get_new_version_to_push.outputs.VERSION }}
+        run: |
+          yarn config set 'npmAuthToken' "$NPM_TOKEN"
+          yarn npm tag add $SCOPE/backend-plugin-manager@$VERSION $GIT_REF

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -35,7 +35,7 @@
     "@backstage/plugin-search-backend-module-pg": "^0.5.8",
     "@backstage/plugin-search-backend-node": "^1.2.3",
     "@backstage/plugin-techdocs-backend": "^1.6.4",
-    "@janus-idp/backstage-plugin-rbac-backend": "^0.1.0",
+    "@janus-idp/backstage-plugin-rbac-backend": "^1.0.0",
     "better-sqlite3": "8.4.0",
     "dockerode": "3.3.5",
     "express": "4.18.2",


### PR DESCRIPTION
Correctly manage upstream tag case when publishing the `backend-plugin-manager` from a `workflow-dispatch` event with a tag git_ref. In this case the commit taken in account should be the current commit of the release.

Signed-off-by: David Festal <dfestal@redhat.com>