### PR TITLE
feat(nexus): sort artifacts by most recent first by default

### DIFF
--- a/plugins/nexus-repository-manager/src/hooks/useNexusRepositoryManagerAppData.test.ts
+++ b/plugins/nexus-repository-manager/src/hooks/useNexusRepositoryManagerAppData.test.ts
@@ -72,6 +72,7 @@ describe('useNexusRepositoryManagerAppData', () => {
       title: 'janus-idp/backstage-showcase',
       query: {
         dockerImageName: 'janus-idp/backstage-showcase',
+        sort: 'version',
       },
     });
   });
@@ -99,6 +100,7 @@ describe('useNexusRepositoryManagerAppData', () => {
       query: {
         dockerImageName: 'janus-idp',
         dockerImageTag: 'latest',
+        sort: 'version',
       },
     });
   });
@@ -126,6 +128,7 @@ describe('useNexusRepositoryManagerAppData', () => {
       title: 'Custom Title',
       query: {
         dockerImageName: 'janus-idp/backstage-showcase',
+        sort: 'version',
       },
     });
   });

--- a/plugins/nexus-repository-manager/src/hooks/useNexusRepositoryManagerAppData.ts
+++ b/plugins/nexus-repository-manager/src/hooks/useNexusRepositoryManagerAppData.ts
@@ -25,7 +25,7 @@ export const useNexusRepositoryManagerAppData = ({
 
       acc.repositories.push(repository);
       const query = v.query
-        ? Object.assign(acc.query, v.query(repository))
+        ? Object.assign(acc.query, v.query(repository), { sort: 'version' })
         : acc.query;
 
       return {


### PR DESCRIPTION
In order to reduce clutter in the users view, when the artifact table is displayed, it should be sorted by most recent first. The nexus plugin by default does not currently do that. This pr updates the nexus api client call by including a sort parameter based on `version`.

Default - 
<img src= "https://github.com/janus-idp/backstage-plugins/assets/52285907/7ad5c348-7d7b-465c-8f03-14046d45c521" width=200 height=100></img><img src="https://github.com/janus-idp/backstage-plugins/assets/52285907/340c77d1-e21d-45ce-af61-26d30fc7678d" width=200 height=100 ></img>

After passing in the sort parameter
<img src="https://github.com/janus-idp/backstage-plugins/assets/52285907/f5ea1d1b-11d8-4aef-8769-6fdfd271e1ba" width=200 height=100 ></img><img width="200" height=100 alt="sorted_2" src="https://github.com/janus-idp/backstage-plugins/assets/52285907/9027a161-44b2-4528-844a-d243c3af8396">
