### PR TITLE
fix(quay): add visual indicator to security scan when it is still loading

### DIFF
--- a/plugins/quay/src/components/QuayRepository/tableHeading.tsx
+++ b/plugins/quay/src/components/QuayRepository/tableHeading.tsx
@@ -1,18 +1,15 @@
 import React from 'react';
 
-import { Link, TableColumn } from '@backstage/core-components';
+import { Link, Progress, TableColumn } from '@backstage/core-components';
 
 import makeStyles from '@material-ui/core/styles/makeStyles';
 
 import type { Layer } from '../../types';
 
-const vulnerabilitySummary = (layer?: Layer): string => {
-  if (!layer) {
-    return 'No security scan';
-  }
+const vulnerabilitySummary = (layer: Layer): string => {
   const summary: Record<string, number> = {};
 
-  layer.Features.forEach(feature => {
+  layer?.Features.forEach(feature => {
     feature.Vulnerabilities?.forEach(vulnerability => {
       const { Severity } = vulnerability;
       if (!summary[Severity]) {
@@ -44,7 +41,14 @@ export const columns: TableColumn[] = [
     title: 'Security Scan',
     field: 'securityScan',
     render: (rowData: any): React.ReactNode => {
-      const tagManifest = rowData.manifest_digest_raw as string;
+      if (!rowData.securityDetails) {
+        return (
+          <span data-testid="quay-repo-security-scan-progress">
+            <Progress />
+          </span>
+        );
+      }
+      const tagManifest = rowData.manifest_digest_raw;
       const retStr = vulnerabilitySummary(rowData.securityDetails as Layer);
       return <Link to={`tag/${tagManifest}`}>{retStr}</Link>;
     },

--- a/plugins/quay/src/hooks/quay.tsx
+++ b/plugins/quay/src/hooks/quay.tsx
@@ -64,6 +64,7 @@ export const useTags = (organization: string, repository: string) => {
       const hashFunc = tag.manifest_digest.substring(0, 6);
       const shortHash = tag.manifest_digest.substring(7, 19);
       return {
+        id: `${tag.manifest_digest}-${tag.name}`,
         name: tag.name,
         last_modified: formatDate(tag.last_modified),
         size: formatByteSize(tag.size),


### PR DESCRIPTION
**Resolves:**
https://github.com/janus-idp/backstage-plugins/issues/737

**Solution description:**
- Rendering `Progress` component
- Added `id` to remove unique row warnings

**GIF:**
https://github.com/janus-idp/backstage-plugins/assets/22490998/1e7833ae-58ec-49d1-aec5-b2501611e07b
