### PR TITLE
chore: remove tracked but ignored file

### DIFF
--- a/app-config.local.yaml
+++ b/app-config.local.yaml
@@ -1,1 +1,0 @@
-# Backstage override configuration for your local development environment


### PR DESCRIPTION
Since app-config.local.yaml is checked in it isn't ignored even though the .gitignore file is set up to ignore it.  This change rectifies this problem, ensuring that someone doesn't accidentally commit some local configuration to this file.