### PR TITLE
fix(rbac): fix service to service requests for RBAC CRUD

### DIFF
--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -157,6 +157,7 @@ describe('REST policies api', () => {
       ),
     };
     server = new PolicesServer(
+      mockIdentityClient,
       mockPermissionEvaluator,
       options,
       mockEnforcer as Enforcer,
@@ -178,6 +179,7 @@ describe('REST policies api', () => {
 
       expect(result.status).toBe(200);
       expect(result.body).toEqual({ status: 'Authorized' });
+      expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(0);
     });
 
     it('should return a status of Unauthorized', async () => {
@@ -286,6 +288,7 @@ describe('REST policies api', () => {
       });
 
       expect(result.statusCode).toBe(201);
+      expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(1);
     });
 
     it('should not be created permission policy, because it is has been already present', async () => {
@@ -356,6 +359,7 @@ describe('REST policies api', () => {
           effect: 'allow',
         },
       ]);
+      expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(0);
     });
     it('should be returned policies by user reference not found', async () => {
       mockEnforcer.getFilteredPolicy = jest
@@ -422,6 +426,7 @@ describe('REST policies api', () => {
           effect: 'allow',
         },
       ]);
+      expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(0);
     });
     it('should be returned list filtered policies', async () => {
       mockEnforcer.getFilteredPolicy = jest
@@ -572,6 +577,7 @@ describe('REST policies api', () => {
         .send();
 
       expect(result.statusCode).toEqual(204);
+      expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -924,6 +930,7 @@ describe('REST policies api', () => {
         });
 
       expect(result.statusCode).toEqual(200);
+      expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1011,6 +1018,7 @@ describe('REST policies api', () => {
           name: 'role:default/rbac_admin',
         },
       ]);
+      expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(0);
     });
 
     it('should be returned roles by role reference not found', async () => {
@@ -1128,6 +1136,7 @@ describe('REST policies api', () => {
         });
 
       expect(result.statusCode).toBe(201);
+      expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(1);
     });
 
     it('should not be created role, because it is has been already present', async () => {
@@ -1408,6 +1417,7 @@ describe('REST policies api', () => {
         });
 
       expect(result.statusCode).toEqual(200);
+      expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(1);
     });
 
     it('should update role where newRole has multiple roles', async () => {
@@ -1606,6 +1616,7 @@ describe('REST policies api', () => {
         .send();
 
       expect(result.statusCode).toEqual(204);
+      expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(1);
     });
 
     it('should delete a role', async () => {

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -1723,6 +1723,7 @@ describe('REST policies api', () => {
         const result = await request(app).get('/conditions').send();
         expect(result.statusCode).toBe(200);
         expect(result.body).toEqual(conditions);
+        expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(0);
       });
 
       it('should be returned condition decision by pluginId', async () => {
@@ -1837,6 +1838,7 @@ describe('REST policies api', () => {
         const result = await request(app).delete('/conditions/1').send();
 
         expect(result.statusCode).toEqual(204);
+        expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(1);
       });
 
       it('should fail to delete condition decision by id', async () => {
@@ -1909,6 +1911,7 @@ describe('REST policies api', () => {
         const result = await request(app).get('/conditions/1').send();
         expect(result.statusCode).toBe(200);
         expect(result.body).toEqual(condition);
+        expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(0);
       });
 
       it('should return return 404', async () => {
@@ -1972,6 +1975,7 @@ describe('REST policies api', () => {
 
         expect(result.statusCode).toBe(201);
         expect(result.body).toEqual({ id: 1 });
+        expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -2030,6 +2034,7 @@ describe('REST policies api', () => {
           1,
           conditionDecision,
         );
+        expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -157,7 +157,6 @@ describe('REST policies api', () => {
       ),
     };
     server = new PolicesServer(
-      mockIdentityClient,
       mockPermissionEvaluator,
       options,
       mockEnforcer as Enforcer,

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -469,14 +469,9 @@ export class PolicesServer {
     );
 
     router.get('/conditions', async (req, resp) => {
-      const decision = await this.authorize(
-        this.identity,
-        req,
-        this.permissions,
-        {
-          permission: policyEntityReadPermission,
-        },
-      );
+      const decision = await this.authorize(req, {
+        permission: policyEntityReadPermission,
+      });
 
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403
@@ -493,14 +488,9 @@ export class PolicesServer {
     });
 
     router.post('/conditions', async (req, resp) => {
-      const decision = await this.authorize(
-        this.identity,
-        req,
-        this.permissions,
-        {
-          permission: policyEntityCreatePermission,
-        },
-      );
+      const decision = await this.authorize(req, {
+        permission: policyEntityCreatePermission,
+      });
 
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403
@@ -515,14 +505,9 @@ export class PolicesServer {
     });
 
     router.get('/conditions/:id', async (req, resp) => {
-      const decision = await this.authorize(
-        this.identity,
-        req,
-        this.permissions,
-        {
-          permission: policyEntityReadPermission,
-        },
-      );
+      const decision = await this.authorize(req, {
+        permission: policyEntityReadPermission,
+      });
 
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403
@@ -542,14 +527,9 @@ export class PolicesServer {
     });
 
     router.delete('/conditions/:id', async (req, resp) => {
-      const decision = await this.authorize(
-        this.identity,
-        req,
-        this.permissions,
-        {
-          permission: policyEntityDeletePermission,
-        },
-      );
+      const decision = await this.authorize(req, {
+        permission: policyEntityDeletePermission,
+      });
 
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403
@@ -565,14 +545,9 @@ export class PolicesServer {
     });
 
     router.put('/conditions/:id', async (req, resp) => {
-      const decision = await this.authorize(
-        this.identity,
-        req,
-        this.permissions,
-        {
-          permission: policyEntityUpdatePermission,
-        },
-      );
+      const decision = await this.authorize(req, {
+        permission: policyEntityUpdatePermission,
+      });
 
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -4,10 +4,7 @@ import {
   NotAllowedError,
   NotFoundError,
 } from '@backstage/errors';
-import {
-  getBearerTokenFromAuthorizationHeader,
-  IdentityApi,
-} from '@backstage/plugin-auth-node';
+import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
 import {
   createRouter,
   RouterOptions,
@@ -47,7 +44,6 @@ import {
 
 export class PolicesServer {
   constructor(
-    private readonly identity: IdentityApi,
     private readonly permissions: PermissionEvaluator,
     private readonly options: RouterOptions,
     private readonly enforcer: Enforcer,
@@ -55,16 +51,10 @@ export class PolicesServer {
   ) {}
 
   private async authorize(
-    identity: IdentityApi,
     request: Request,
     permissionEvaluator: PermissionEvaluator,
     permission: QueryPermissionRequest,
   ) {
-    const user = await identity.getIdentity({ request });
-    if (!user) {
-      throw new NotAllowedError();
-    }
-
     const authHeader = request.header('authorization');
     const token = getBearerTokenFromAuthorizationHeader(authHeader);
 
@@ -85,14 +75,9 @@ export class PolicesServer {
     router.use(permissionsIntegrationRouter);
 
     router.get('/', async (request, response) => {
-      const decision = await this.authorize(
-        this.identity,
-        request,
-        this.permissions,
-        {
-          permission: policyEntityReadPermission,
-        },
-      );
+      const decision = await this.authorize(request, this.permissions, {
+        permission: policyEntityReadPermission,
+      });
 
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403
@@ -103,14 +88,9 @@ export class PolicesServer {
     // Policy CRUD
 
     router.get('/policies', async (request, response) => {
-      const decision = await this.authorize(
-        this.identity,
-        request,
-        this.permissions,
-        {
-          permission: policyEntityReadPermission,
-        },
-      );
+      const decision = await this.authorize(request, this.permissions, {
+        permission: policyEntityReadPermission,
+      });
 
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403
@@ -135,14 +115,9 @@ export class PolicesServer {
     router.get(
       '/policies/:kind/:namespace/:name',
       async (request, response) => {
-        const decision = await this.authorize(
-          this.identity,
-          request,
-          this.permissions,
-          {
-            permission: policyEntityReadPermission,
-          },
-        );
+        const decision = await this.authorize(request, this.permissions, {
+          permission: policyEntityReadPermission,
+        });
 
         if (decision.result === AuthorizeResult.DENY) {
           throw new NotAllowedError(); // 403
@@ -162,14 +137,9 @@ export class PolicesServer {
     router.delete(
       '/policies/:kind/:namespace/:name',
       async (request, response) => {
-        const decision = await this.authorize(
-          this.identity,
-          request,
-          this.permissions,
-          {
-            permission: policyEntityDeletePermission,
-          },
-        );
+        const decision = await this.authorize(request, this.permissions, {
+          permission: policyEntityDeletePermission,
+        });
 
         if (decision.result === AuthorizeResult.DENY) {
           throw new NotAllowedError(); // 403
@@ -203,14 +173,9 @@ export class PolicesServer {
     );
 
     router.post('/policies', async (request, response) => {
-      const decision = await this.authorize(
-        this.identity,
-        request,
-        this.permissions,
-        {
-          permission: policyEntityCreatePermission,
-        },
-      );
+      const decision = await this.authorize(request, this.permissions, {
+        permission: policyEntityCreatePermission,
+      });
 
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403
@@ -241,7 +206,6 @@ export class PolicesServer {
       '/policies/:kind/:namespace/:name',
       async (request, response) => {
         const decision = await this.authorize(
-          this.identity,
           request,
           this.permissions,
           {
@@ -315,7 +279,6 @@ export class PolicesServer {
 
     router.get('/roles', async (request, response) => {
       const decision = await this.authorize(
-        this.identity,
         request,
         this.permissions,
         {
@@ -334,7 +297,6 @@ export class PolicesServer {
 
     router.get('/roles/:kind/:namespace/:name', async (request, response) => {
       const decision = await this.authorize(
-        this.identity,
         request,
         this.permissions,
         {
@@ -361,7 +323,6 @@ export class PolicesServer {
 
     router.post('/roles', async (request, response) => {
       const decision = await this.authorize(
-        this.identity,
         request,
         this.permissions,
         {
@@ -397,14 +358,9 @@ export class PolicesServer {
     });
 
     router.put('/roles/:kind/:namespace/:name', async (request, response) => {
-      const decision = await this.authorize(
-        this.identity,
-        request,
-        this.permissions,
-        {
-          permission: policyEntityUpdatePermission,
-        },
-      );
+      const decision = await this.authorize(request, this.permissions, {
+        permission: policyEntityUpdatePermission,
+      });
 
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403
@@ -482,7 +438,6 @@ export class PolicesServer {
       async (request, response) => {
         let roles = [];
         const decision = await this.authorize(
-          this.identity,
           request,
           this.permissions,
           {

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -83,13 +83,7 @@ export class PolicyBuilder {
       ),
     };
 
-    const server = new PolicesServer(
-      env.identity,
-      env.permissions,
-      options,
-      enf,
-      conditionStorage,
-    );
+    const server = new PolicesServer(env.permissions, options, enf, conditionStorage);
     return server.serve();
   }
 }

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -88,7 +88,7 @@ export class PolicyBuilder {
       env.permissions,
       options,
       enf,
-      conditionStorage
+      conditionStorage,
     );
     return server.serve();
   }

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -83,7 +83,13 @@ export class PolicyBuilder {
       ),
     };
 
-    const server = new PolicesServer(env.permissions, options, enf, conditionStorage);
+    const server = new PolicesServer(
+      env.identity,
+      env.permissions,
+      options,
+      enf,
+      conditionStorage
+    );
     return server.serve();
   }
 }


### PR DESCRIPTION
# What does this pull request do:

PermissionEvaluator( implementation ServerPermissionClient) uses TokenManager to provide service to service requests:

https://github.com/backstage/backstage/blob/a503b2d8fae30f09cc75ab727cc57b939f92e6df/plugins/permission-node/src/ServerPermissionClient.ts#L86 or
https://github.com/backstage/backstage/blob/a503b2d8fae30f09cc75ab727cc57b939f92e6df/plugins/permission-node/src/ServerPermissionClient.ts#L95

https://github.com/backstage/backstage/blob/a503b2d8fae30f09cc75ab727cc57b939f92e6df/plugins/permission-node/src/ServerPermissionClient.ts#L117
https://github.com/backstage/backstage/blob/a503b2d8fae30f09cc75ab727cc57b939f92e6df/plugins/permission-node/src/ServerPermissionClient.ts#L106

To prevent failing code on service to service request we should remove identity.getIdentity({ request }) usage from code. This stuff any way used in the permission handler implementation under the hood:

identity: https://github.com/backstage/backstage/blob/a503b2d8fae30f09cc75ab727cc57b939f92e6df/plugins/permission-backend/src/service/router.ts#L166
https://github.com/backstage/backstage/blob/a503b2d8fae30f09cc75ab727cc57b939f92e6df/plugins/permission-backend/src/service/router.ts#L191C26-L191C34
https://github.com/backstage/backstage/blob/a503b2d8fae30f09cc75ab727cc57b939f92e6df/plugins/permission-backend/src/service/router.ts#L104
https://github.com/backstage/backstage/blob/a503b2d8fae30f09cc75ab727cc57b939f92e6df/plugins/permission-backend/src/service/router.ts#L120

# How to  test it

Generate new plugin with pluginId test: https://backstage.io/docs/plugins/backend-plugin/#creating-a-backend-plugin.  Define this test backend plugin in the backend/src/plugins folder:

```test.ts
import { Router } from 'express';

import { createRouter } from '@janus-idp/plugin-test-backend';

import { PluginEnvironment } from '../types';

export default async function createPlugin(
  env: PluginEnvironment,
): Promise<Router> {

  return await createRouter({
    logger: env.logger,
    tokenManager: env.tokenManager,
  });
}
```

Register plugin in the backend/src/index.ts:

```
import test from './plugins/test';
...

  const testEnv = useHotMemoize(module, () => createEnv('test'));
  apiRouter.use('/test', await test(testEnv));
```

Provide TokenManager for this plugin using plugin env and route options. Use this route code to call rbac-backend api method:

```ts
import { errorHandler, TokenManager } from '@backstage/backend-common';

import express from 'express';
import Router from 'express-promise-router';
import { Logger } from 'winston';

export interface RouterOptions {
  logger: Logger;
  tokenManager: TokenManager;
}

export async function createRouter(
  options: RouterOptions,
): Promise<express.Router> {
  const { logger } = options;

  const router = Router();
  router.use(express.json());

  router.get('/health', async (_, response) => {
    const { token } = await options.tokenManager.getToken(); 
    const url = 'http://localhost:7007/api/permission/policies';

    const resp = await fetch(url, {
      method: 'GET',
      headers: {
        Authorization: `Bearer ${token}`,
      },
    });

    const body = await resp.text();
    console.log(`=== ${resp.status}. Response Body: ${JSON.stringify(body)}`);

    logger.info('PONG!');
    response.json({ code: resp.status });
  });
  router.use(errorHandler());
  return router;
}

```

Launch backstage-plugins and make request:

```
 curl http://localhost:7007/api/test/health
```
 
This REST method should call backend plugin. Backend plugin should make service to service request to rbac-backend policy api.