### PR TITLE
fix(cli): add default scalprum config

### DIFF
--- a/packages/cli/src/commands/export-dynamic-plugin/frontend.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/frontend.ts
@@ -26,12 +26,31 @@ export async function frontend(
   _: PackageRoleInfo,
   __: OptionValues,
 ): Promise<void> {
-  const { name, version, scalprum } = await fs.readJson(
-    paths.resolveTarget('package.json'),
-  );
+  const {
+    name,
+    version,
+    scalprum: scalprumExternal,
+  } = await fs.readJson(paths.resolveTarget('package.json'));
+
+  let scalprum = scalprumExternal;
   if (scalprum === undefined) {
-    throw new Error(
-      `Package doesn't seem to support dynamic loading. It should have a 'scalprum' key in 'package.json' containing the dynamic loading entrypoints.`,
+    let scalprumName;
+    if (name.includes('/')) {
+      const fragments = name.split('/');
+      scalprumName = `${fragments[0].replace('@', '')}.${fragments[1]}`;
+    } else {
+      scalprumName = name;
+    }
+    scalprum = {
+      name: scalprumName,
+      exposedModules: {
+        PluginRoot: './src/index.ts',
+      },
+    };
+    console.log(`No scalprum config. Using default dynamic UI configuration:`);
+    console.log(JSON.stringify(scalprum, null, 2));
+    console.log(
+      `If you wish to change the defaults, add "scalprum" configuration to plugin "package.json" file.`,
     );
   }
 

--- a/plugins/acr/package.json
+++ b/plugins/acr/package.json
@@ -62,11 +62,5 @@
     "plugin"
   ],
   "homepage": "https://janus-idp.io/",
-  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-acr",
-    "exposedModules": {
-      "AcrPlugin": "./src/index.ts"
-    }
-  }
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/dynamic-frontend-plugin/package.json
+++ b/plugins/dynamic-frontend-plugin/package.json
@@ -33,15 +33,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.22.9",
-    "@janus-idp/cli": "1.3.0",
+    "@janus-idp/cli": "1.3.2",
     "http-server": "14.1.1"
-  },
-  "scalprum": {
-    "name": "janus.dynamic-frontend-plugin",
-    "exposedModules": {
-      "TechRadar": "./src/remotes/TechRadarPage",
-      "UserSettings": "./src/remotes/UserSettingsLegacy",
-      "Scaffolder": "./src/remotes/Scaffolder"
-    }
   }
 }

--- a/plugins/jfrog-artifactory/package.json
+++ b/plugins/jfrog-artifactory/package.json
@@ -65,11 +65,5 @@
     "plugin"
   ],
   "homepage": "https://janus-idp.io/",
-  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-jfrog-artifactory",
-    "exposedModules": {
-      "JfrogArtifactoryPlugin": "./src/index.ts"
-    }
-  }
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/kiali/package.json
+++ b/plugins/kiali/package.json
@@ -65,11 +65,5 @@
     "plugin"
   ],
   "homepage": "https://janus-idp.io/",
-  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-kiali",
-    "exposedModules": {
-      "KialiPlugin": "./src/index.ts"
-    }
-  }
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/matomo/package.json
+++ b/plugins/matomo/package.json
@@ -65,11 +65,5 @@
     "plugin"
   ],
   "homepage": "https://janus-idp.io/",
-  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-matomo",
-    "exposedModules": {
-      "MatomoPlugin": "./src/index.ts"
-    }
-  }
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/nexus-repository-manager/package.json
+++ b/plugins/nexus-repository-manager/package.json
@@ -69,11 +69,5 @@
     "plugin"
   ],
   "homepage": "https://janus-idp.io/",
-  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-nexus-repository-manager",
-    "exposedModules": {
-      "NexusRepositoryManagerPlugin": "./src/index.ts"
-    }
-  }
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/ocm/package.json
+++ b/plugins/ocm/package.json
@@ -69,11 +69,5 @@
     "plugin"
   ],
   "homepage": "https://janus-idp.io/",
-  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-ocm",
-    "exposedModules": {
-      "OcmPlugin": "./src/index.ts"
-    }
-  }
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/openshift-image-registry/package.json
+++ b/plugins/openshift-image-registry/package.json
@@ -56,11 +56,5 @@
     "dist-scalprum",
     "config.d.ts"
   ],
-  "configSchema": "config.d.ts",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-openshift-image-registry",
-    "exposedModules": {
-      "OpenshiftImageRegistryPlugin": "./src/index.ts"
-    }
-  }
+  "configSchema": "config.d.ts"
 }

--- a/plugins/quay/package.json
+++ b/plugins/quay/package.json
@@ -69,11 +69,5 @@
     "plugin"
   ],
   "homepage": "https://janus-idp.io/",
-  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-quay",
-    "exposedModules": {
-      "QuayPlugin": "./src/index.ts"
-    }
-  }
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/rbac/package.json
+++ b/plugins/rbac/package.json
@@ -57,11 +57,5 @@
     "plugin"
   ],
   "homepage": "https://janus-idp.io/",
-  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-rbac",
-    "exposedModules": {
-      "RbacPlugin": "./src/index.ts"
-    }
-  }
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/tekton/package.json
+++ b/plugins/tekton/package.json
@@ -78,11 +78,5 @@
     "plugin"
   ],
   "homepage": "https://janus-idp.io/",
-  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-tekton",
-    "exposedModules": {
-      "TektonPlugin": "./src/index.ts"
-    }
-  }
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/topology/package.json
+++ b/plugins/topology/package.json
@@ -83,11 +83,5 @@
     "plugin"
   ],
   "homepage": "https://janus-idp.io/",
-  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-topology",
-    "exposedModules": {
-      "TopologyPlugin": "./src/index.ts"
-    }
-  }
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
 }

--- a/plugins/web-terminal/package.json
+++ b/plugins/web-terminal/package.json
@@ -64,11 +64,5 @@
     "setupFiles": [
       "jest-canvas-mock"
     ]
-  },
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-web-terminal",
-    "exposedModules": {
-      "WebTerminalPlugin": "./src/index.ts"
-    }
   }
 }


### PR DESCRIPTION
The `scalprum` config is no longer required. By default, CLI will use the `index.ts` as an exposed module called `PluginRoot`. 