### PR TITLE
fix(cli): use react v17 in dynamic plugins build

### DIFF
--- a/packages/cli/src/lib/bundler/scalprumConfig.ts
+++ b/packages/cli/src/lib/bundler/scalprumConfig.ts
@@ -105,6 +105,7 @@ export async function createScalprumConfig(
 
   plugins.push(
     new webpack.EnvironmentPlugin({
+      HAS_REACT_DOM_CLIENT: false,
       APP_CONFIG: options.frontendAppConfigs,
     }),
   );


### PR DESCRIPTION
SSIA

Some upstream plugin reexport has this react v18 flag flaw. Force cli to properly define `HAS_REACT_DOM_CLIENT` flag in plugins build as well.