### PR TITLE
fix(aap+3scale+ocm): don't log sensitive data from errors

### DIFF
--- a/packages/cli/templates/default-backend-plugin/src/run.ts.hbs
+++ b/packages/cli/templates/default-backend-plugin/src/run.ts.hbs
@@ -7,7 +7,7 @@ const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 
 startStandaloneServer({ port, enableCors, logger }).catch(err => {
-  logger.error(err);
+  logger.error('Standalone server failed:', err);
   process.exit(1);
 });
 

--- a/packages/cli/templates/default-backend-plugin/src/service/standaloneServer.ts.hbs
+++ b/packages/cli/templates/default-backend-plugin/src/service/standaloneServer.ts.hbs
@@ -26,7 +26,7 @@ export async function startStandaloneServer(
   }
 
   return await service.start().catch(err => {
-    logger.error(err);
+    logger.error('Dev server failed:', err);
     process.exit(1);
   });
 }

--- a/plugins/3scale-backend/src/providers/ThreeScaleApiEntityProvider.ts
+++ b/plugins/3scale-backend/src/providers/ThreeScaleApiEntityProvider.ts
@@ -104,8 +104,19 @@ export class ThreeScaleApiEntityProvider implements EntityProvider {
         fn: async () => {
           try {
             await this.run();
-          } catch (error) {
-            this.logger.error(error);
+          } catch (error: any) {
+            // Ensure that we don't log any sensitive internal data:
+            this.logger.error(
+              `Error while syncing 3scale API from ${this.baseUrl}`,
+              {
+                // Default Error properties:
+                name: error.name,
+                message: error.message,
+                stack: error.stack,
+                // Additional status code if available:
+                status: error.response?.status,
+              },
+            );
           }
         },
       });

--- a/plugins/aap-backend/src/providers/__snapshots__/AapResourceEntityProvider.test.ts.snap
+++ b/plugins/aap-backend/src/providers/__snapshots__/AapResourceEntityProvider.test.ts.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AapResourceEntityProvider should connect and run should resolves 1`] = `
+[
+  [
+    {
+      "entities": [
+        {
+          "entity": {
+            "apiVersion": "backstage.io/v1alpha1",
+            "kind": "Resource",
+            "metadata": {
+              "annotations": {
+                "backstage.io/managed-by-location": "AapResourceEntityProvider:dev",
+                "backstage.io/managed-by-origin-location": "AapResourceEntityProvider:dev",
+              },
+              "description": "test description",
+              "links": [
+                {
+                  "title": "AAP Dashboard",
+                  "url": "http://localhost:8080",
+                },
+                {
+                  "title": "Template Details",
+                  "url": "http://localhost:8080/#/templates/job_template/undefined/details",
+                },
+              ],
+              "name": "demoJobTemplate-undefined-dev",
+              "title": "demoJobTemplate",
+            },
+            "spec": {
+              "owner": "unknown",
+              "type": "job_template",
+            },
+          },
+          "locationKey": "AapResourceEntityProvider:dev",
+        },
+        {
+          "entity": {
+            "apiVersion": "backstage.io/v1alpha1",
+            "kind": "Resource",
+            "metadata": {
+              "annotations": {
+                "backstage.io/managed-by-location": "AapResourceEntityProvider:dev",
+                "backstage.io/managed-by-origin-location": "AapResourceEntityProvider:dev",
+              },
+              "description": "test workflow description",
+              "links": [
+                {
+                  "title": "AAP Dashboard",
+                  "url": "http://localhost:8080",
+                },
+                {
+                  "title": "Template Details",
+                  "url": "http://localhost:8080/#/templates/workflow_job_template/undefined/details",
+                },
+              ],
+              "name": "demoWorkflowJobTemplate-undefined-dev",
+              "title": "demoWorkflowJobTemplate",
+            },
+            "spec": {
+              "owner": "unknown",
+              "type": "workflow_job_template",
+            },
+          },
+          "locationKey": "AapResourceEntityProvider:dev",
+        },
+      ],
+      "type": "full",
+    },
+  ],
+]
+`;
+
+exports[`AapResourceEntityProvider should connect and run should resolves even if one api call fails 1`] = `
+[
+  [
+    {
+      "entities": [
+        {
+          "entity": {
+            "apiVersion": "backstage.io/v1alpha1",
+            "kind": "Resource",
+            "metadata": {
+              "annotations": {
+                "backstage.io/managed-by-location": "AapResourceEntityProvider:dev",
+                "backstage.io/managed-by-origin-location": "AapResourceEntityProvider:dev",
+              },
+              "description": "test workflow description",
+              "links": [
+                {
+                  "title": "AAP Dashboard",
+                  "url": "http://localhost:8080",
+                },
+                {
+                  "title": "Template Details",
+                  "url": "http://localhost:8080/#/templates/workflow_job_template/undefined/details",
+                },
+              ],
+              "name": "demoWorkflowJobTemplate-undefined-dev",
+              "title": "demoWorkflowJobTemplate",
+            },
+            "spec": {
+              "owner": "unknown",
+              "type": "workflow_job_template",
+            },
+          },
+          "locationKey": "AapResourceEntityProvider:dev",
+        },
+      ],
+      "type": "full",
+    },
+  ],
+]
+`;

--- a/plugins/kiali-backend/src/run.ts
+++ b/plugins/kiali-backend/src/run.ts
@@ -9,7 +9,7 @@ const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 
 startStandaloneServer({ port, enableCors, logger }).catch(err => {
-  logger.error(err);
+  logger.error('Standalone server failed:', err);
   process.exit(1);
 });
 

--- a/plugins/kiali-backend/src/service/standaloneServer.ts
+++ b/plugins/kiali-backend/src/service/standaloneServer.ts
@@ -37,7 +37,7 @@ export async function startStandaloneServer(
   }
 
   return await service.start().catch(err => {
-    logger.error(err);
+    logger.error('Standalone server failed:', err);
     process.exit(1);
   });
 }

--- a/plugins/matomo-backend/src/run.ts
+++ b/plugins/matomo-backend/src/run.ts
@@ -9,7 +9,7 @@ const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 
 startStandaloneServer({ port, enableCors, logger }).catch(err => {
-  logger.error(err);
+  logger.error('Standalone server failed:', err);
   process.exit(1);
 });
 

--- a/plugins/matomo-backend/src/service/standaloneServer.ts
+++ b/plugins/matomo-backend/src/service/standaloneServer.ts
@@ -35,7 +35,7 @@ export async function startStandaloneServer(
   }
 
   return await service.start().catch(err => {
-    logger.error(err);
+    logger.error('Standalone server failed:', err);
     process.exit(1);
   });
 }

--- a/plugins/ocm-backend/dev/index.ts
+++ b/plugins/ocm-backend/dev/index.ts
@@ -122,7 +122,7 @@ export async function startStandaloneServer(
     .addRouter('/catalog', await catalog(catalogEnv));
 
   return await service.start().catch(err => {
-    logger.error(err);
+    logger.error('Dev server failed:', err);
     process.exit(1);
   });
 }

--- a/plugins/ocm-backend/src/providers/ManagedClusterProvider.ts
+++ b/plugins/ocm-backend/src/providers/ManagedClusterProvider.ts
@@ -119,8 +119,19 @@ export class ManagedClusterProvider implements EntityProvider {
         fn: async () => {
           try {
             await this.run();
-          } catch (error) {
-            this.logger.error(error);
+          } catch (error: any) {
+            // Ensure that we don't log any sensitive internal data:
+            this.logger.error(
+              'Error while syncing cluster resources from Open Cluster Management',
+              {
+                // Default Error properties:
+                name: error.name,
+                message: error.message,
+                stack: error.stack,
+                // Additional status code if available:
+                status: error.response?.status,
+              },
+            );
           }
         },
       });

--- a/plugins/ocm-backend/src/run.ts
+++ b/plugins/ocm-backend/src/run.ts
@@ -29,7 +29,7 @@ const server = setupServer(...handlers);
 server.listen();
 
 startStandaloneServer({ port, logger }).catch(err => {
-  logger.error(err);
+  logger.error('Standalone server failed:', err);
   server.close();
   process.exit(1);
 });

--- a/plugins/rbac-backend/src/run.ts
+++ b/plugins/rbac-backend/src/run.ts
@@ -9,7 +9,7 @@ const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 
 startStandaloneServer({ port, enableCors, logger }).catch(err => {
-  logger.error(err);
+  logger.error('Standalone server failed:', err);
   process.exit(1);
 });
 

--- a/plugins/rbac-backend/src/service/standaloneServer.ts
+++ b/plugins/rbac-backend/src/service/standaloneServer.ts
@@ -29,7 +29,7 @@ export async function startStandaloneServer(
   }
 
   return await service.start().catch(err => {
-    logger.error(err);
+    logger.error('Standalone server failed:', err);
     process.exit(1);
   });
 }


### PR DESCRIPTION
This applies a similar change as #938 to the same issues for AAP, 3Scale, and OCM providers.

Changes:
* Extract the essential error data from the error object (name, message, stack, status code).
* Updated `AapResourceEntityProvider.test.ts` where I could confirm that the auth header was logged before. 3scale and OCM don't have unit tests for the Providers to confirm the change.
* Added a message string to all `logger.error` statements. As best practice to make it easier find the right log statement and also to make it more compatible with [backstage LoggerService](https://github.com/backstage/backstage/blob/master/packages/backend-plugin-api/src/services/definitions/LoggerService.ts).
