### PR TITLE
fix(keycloak): embed keycloak admin dependency for dynamic export

### DIFF
--- a/plugins/keycloak-backend/dist-dynamic/package.json
+++ b/plugins/keycloak-backend/dist-dynamic/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "backstage-cli package build",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin",
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @keycloak/keycloak-admin-client",
     "lint": "backstage-cli package lint",
     "postpack": "backstage-cli package postpack",
     "postversion": "yarn run export-dynamic",
@@ -39,10 +39,15 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "<19.0.0",
     "lodash": "^4.17.21",
     "uuid": "^9.0.1",
-    "winston": "^3.11.0"
+    "winston": "^3.11.0",
+    "axios": "^0.26.1",
+    "camelize-ts": "^1.0.8",
+    "keycloak-js": "^17.0.1",
+    "query-string": "^7.0.1",
+    "url-join": "^4.0.0",
+    "url-template": "^2.0.8"
   },
   "devDependencies": {},
   "files": [

--- a/plugins/keycloak-backend/dist-dynamic/yarn.lock
+++ b/plugins/keycloak-backend/dist-dynamic/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@aws-sdk/util-utf8-browser@npm:@smithy/util-utf8@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.0.0.tgz#b4da87566ea7757435e153799df9da717262ad42"
-  integrity sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==
+"@aws-sdk/util-utf8-browser@npm:@smithy/util-utf8@~2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.0.2.tgz#626b3e173ad137208e27ed329d6bea70f4a1a7f7"
+  integrity sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==
   dependencies:
     "@smithy/util-buffer-from" "^2.0.0"
     tslib "^2.5.0"
@@ -24,19 +24,6 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@keycloak/keycloak-admin-client@<19.0.0":
-  version "18.0.2"
-  resolved "https://registry.yarnpkg.com/@keycloak/keycloak-admin-client/-/keycloak-admin-client-18.0.2.tgz#e8329830ea2bc9fc7012e31b10c06a35ab58984c"
-  integrity sha512-UCa+5FTPBzbbfCpC27Sb40XbNm27m78z+yax9kiw9aFwk+itiGId09bMzECBRDrqwvVMxo1vzLERLjAty3rTRg==
-  dependencies:
-    axios "^0.26.1"
-    camelize-ts "^1.0.8"
-    keycloak-js "^17.0.1"
-    lodash "^4.17.21"
-    query-string "^7.0.1"
-    url-join "^4.0.0"
-    url-template "^2.0.8"
-
 "@smithy/is-array-buffer@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz#8fa9b8040651e7ba0b2f6106e636a91354ff7d34"
@@ -53,9 +40,9 @@
     tslib "^2.5.0"
 
 "@types/triple-beam@^1.3.2":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.4.tgz#a1d5f480245db86e2f4777000065d4fe7467a012"
-  integrity sha512-HlJjF3wxV4R2VQkFpKe0YqJLilYNgtRtsqqZtby7RkVsSs+i+vbyzjtUwpFEdUCKcrGzCiEJE7F/0mKjh0sunA==
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
+  integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
 
 async@^3.2.3:
   version "3.2.5"

--- a/plugins/keycloak-backend/package.json
+++ b/plugins/keycloak-backend/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "backstage-cli package build",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin",
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @keycloak/keycloak-admin-client",
     "lint": "backstage-cli package lint",
     "postpack": "backstage-cli package postpack",
     "postversion": "yarn run export-dynamic",


### PR DESCRIPTION
Fixes: https://github.com/janus-idp/backstage-plugins/issues/949

It seems Keycloak library doesn't properly declare its package type. When used as dynamic plugin, the dependency is imported as CommonJS, but in reality, import resolves to:

```js
console.log(require('@keycloak/keycloak-admin-client'))
{
  __esModule: true,
  requiredAction: {
    VERIFY_EMAIL: 'VERIFY_EMAIL',
    UPDATE_PROFILE: 'UPDATE_PROFILE',
    CONFIGURE_TOTP: 'CONFIGURE_TOTP',
    UPDATE_PASSWORD: 'UPDATE_PASSWORD',
    terms_and_conditions: 'terms_and_conditions'
  },
  default: [Function: KeycloakAdminClient]
}
```

I've tried multiple hacks like:
```diff
- import KcAdminClient from '@keycloak/keycloak-admin-client';
+ import * as KcAdminClient from '@keycloak/keycloak-admin-client'; 
...
-     const kcAdminClient = new KcAdminClient({
+     const kcAdminClient = new KcAdminClient.default({
```

But it didn't work. Either we need to get more clever during the loading into the runtime or during the `export-dynamic` transpilation or something else. With all the repackaging and re-transpilation things get really tangled.

The `--embed-package @keycloak/keycloak-admin-client` is a workaround, but it seems to be the only properly working thing I've managed to come up with. It is not a solution.