### PR TITLE
fix: add default 3scale schedule

### DIFF
--- a/plugins/3scale-backend/src/dynamic/alpha.ts
+++ b/plugins/3scale-backend/src/dynamic/alpha.ts
@@ -27,6 +27,10 @@ export const dynamicPluginInstaller: BackendDynamicPluginInstaller = {
             ThreeScaleApiEntityProvider.fromConfig(config, {
               logger: loggerToWinstonLogger(logger),
               scheduler: scheduler,
+              schedule: scheduler.createScheduledTaskRunner({
+                frequency: { minutes: 1 },
+                timeout: { minutes: 1 },
+              }),
             }),
           );
         },

--- a/plugins/3scale-backend/src/dynamic/index.ts
+++ b/plugins/3scale-backend/src/dynamic/index.ts
@@ -9,6 +9,10 @@ export const dynamicPluginInstaller: BackendDynamicPluginInstaller = {
       ThreeScaleApiEntityProvider.fromConfig(env.config, {
         logger: env.logger,
         scheduler: env.scheduler,
+        schedule: env.scheduler.createScheduledTaskRunner({
+          frequency: { minutes: 1 },
+          timeout: { minutes: 1 },
+        }),
       }),
     );
   },


### PR DESCRIPTION
3scale is missing default schedule when used as dynamic plugin

cc @Zaperex @davidfestal 