### PR TITLE
feat(rbac): add support for creation of role

### DIFF
--- a/plugins/rbac/dev/index.tsx
+++ b/plugins/rbac/dev/index.tsx
@@ -39,9 +39,11 @@ class MockRBACApi implements RBACAPI {
   constructor(fixtureData: Role[]) {
     this.resources = fixtureData;
   }
+
   async getRoles(): Promise<Role[]> {
     return this.resources;
   }
+
   async getPolicies(): Promise<RoleBasedPolicy[]> {
     return mockPolicies;
   }
@@ -75,6 +77,10 @@ class MockRBACApi implements RBACAPI {
     _policies: Policy[],
   ): Promise<number> {
     return 204;
+  }
+
+  async createRole(_role: Role): Promise<any> {
+    return { status: 200 };
   }
 }
 

--- a/plugins/rbac/package.json
+++ b/plugins/rbac/package.json
@@ -29,6 +29,7 @@
     "@backstage/core-components": "^0.13.6",
     "@backstage/core-plugin-api": "^1.7.0",
     "@backstage/plugin-catalog": "^1.15.1",
+    "@backstage/plugin-catalog-common": "^1.0.18",
     "@backstage/plugin-permission-react": "^0.4.16",
     "@backstage/theme": "^0.4.3",
     "@janus-idp/backstage-plugin-rbac-common": "1.2.0",
@@ -37,8 +38,11 @@
     "@material-ui/lab": "^4.0.0-alpha.45",
     "@mui/icons-material": "5.14.11",
     "@mui/material": "^5.14.18",
+    "autosuggest-highlight": "^3.3.4",
+    "formik": "^2.4.5",
+    "lodash": "^4.17.21",
     "react-use": "^17.4.0",
-    "lodash": "^4.17.21"
+    "yup": "^1.3.2"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",
@@ -54,6 +58,7 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.5.1",
+    "@types/autosuggest-highlight": "3.2.3",
     "@types/node": "18.18.5",
     "msw": "1.3.2"
   },

--- a/plugins/rbac/src/api/RBACBackendClient.ts
+++ b/plugins/rbac/src/api/RBACBackendClient.ts
@@ -22,6 +22,7 @@ export type RBACAPI = {
   getRole: (role: string) => Promise<Role[]>;
   getMembers: () => Promise<MemberEntity[]>;
   listPermissions: () => Promise<PermissionPolicy[]>;
+  createRole: (role: Role) => Promise<Response>;
 };
 
 export type Options = {
@@ -147,5 +148,19 @@ export class RBACBackendClient implements RBACAPI {
       },
     );
     return jsonResponse.json();
+  }
+
+  async createRole(role: Role) {
+    const { token: idToken } = await this.identityApi.getCredentials();
+    const backendUrl = this.configApi.getString('backend.baseUrl');
+    return fetch(`${backendUrl}/api/permission/roles`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        ...(idToken && { Authorization: `Bearer ${idToken}` }),
+      },
+      body: JSON.stringify(role),
+    });
   }
 }

--- a/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
+++ b/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { useAsync } from 'react-use';
+
+import { useApi } from '@backstage/core-plugin-api';
+
+import { LinearProgress, TextField } from '@material-ui/core';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import FormHelperText from '@mui/material/FormHelperText';
+import { FormikErrors } from 'formik';
+
+import { rbacApiRef } from '../../api/RBACBackendClient';
+import { MemberEntity } from '../../types';
+import {
+  getChildGroupsCount,
+  getMembersCount,
+  getParentGroupsCount,
+} from '../../utils/create-role-utils';
+import { MembersDropdownOption } from './MembersDropdownOption';
+import { CreateRoleFormValues, SelectedMember } from './types';
+
+type AddMembersFormProps = {
+  selectedMembers: SelectedMember[];
+  selectedMembersError?: string;
+  setFieldValue: (
+    field: string,
+    value: any,
+    shouldValidate?: boolean,
+  ) => Promise<FormikErrors<CreateRoleFormValues>> | Promise<void>;
+};
+
+export const AddMembersForm = ({
+  selectedMembers,
+  selectedMembersError,
+  setFieldValue,
+}: AddMembersFormProps) => {
+  const rbacApi = useApi(rbacApiRef);
+  const [search, setSearch] = React.useState<string>('');
+  const {
+    loading: membersLoading,
+    value: members,
+    error,
+  } = useAsync(async () => {
+    return await rbacApi.getMembers();
+  });
+
+  const getDescription = (member: MemberEntity) => {
+    const memberCount = getMembersCount(member);
+    const parentCount = getParentGroupsCount(member);
+    const childCount = getChildGroupsCount(member);
+
+    return member.kind === 'Group'
+      ? `${memberCount} members, ${parentCount} parent group, ${childCount} child groups`
+      : undefined;
+  };
+
+  const membersOptions: SelectedMember[] = members
+    ? members.map((member: MemberEntity, index) => ({
+        label: member.metadata.name,
+        description: getDescription(member),
+        etag:
+          member.metadata.etag ??
+          `${member.metadata.name}-${member.kind}-${index}`,
+        type: member.kind,
+        namespace: member.metadata.namespace,
+        members: getMembersCount(member),
+      }))
+    : [];
+
+  return (
+    <>
+      <FormHelperText>
+        Search and select users and groups to be added. Selected users and
+        groups will appear in the members table.
+      </FormHelperText>
+      <br />
+      <Autocomplete
+        options={membersOptions}
+        getOptionLabel={(option: SelectedMember) => option.label}
+        getOptionSelected={(option: SelectedMember, value: SelectedMember) =>
+          option.etag === value.etag
+        }
+        loading={membersLoading}
+        loadingText={<LinearProgress />}
+        onChange={(_e, value: SelectedMember) =>
+          setFieldValue('selectedMembers', [...selectedMembers, value])
+        }
+        disableClearable
+        getOptionDisabled={(option: SelectedMember) =>
+          !!selectedMembers.find(
+            (sm: SelectedMember) => sm.etag === option.etag,
+          )
+        }
+        renderOption={(option: SelectedMember, state) => (
+          <MembersDropdownOption option={option} state={state} />
+        )}
+        renderInput={params => (
+          <TextField
+            {...params}
+            variant="outlined"
+            label="Users and groups"
+            placeholder="Search by user name or group name"
+            error={!!selectedMembersError}
+            helperText={selectedMembersError ?? ''}
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            required
+          />
+        )}
+      />
+      <br />
+      {error?.message && (
+        <FormHelperText error={!error}>{error.message}</FormHelperText>
+      )}
+    </>
+  );
+};

--- a/plugins/rbac/src/components/CreateRole/AddedMembersTable.tsx
+++ b/plugins/rbac/src/components/CreateRole/AddedMembersTable.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { Table } from '@backstage/core-components';
+
+import { makeStyles } from '@material-ui/core';
+import { FormikErrors } from 'formik';
+
+import { getMembers } from '../../utils/rbac-utils';
+import { selectedMembersColumns } from './AddedMembersTableColumn';
+import { CreateRoleFormValues, SelectedMember } from './types';
+
+const useStyles = makeStyles(theme => ({
+  empty: {
+    padding: theme.spacing(2),
+    display: 'flex',
+    justifyContent: 'center',
+  },
+}));
+
+type AddedMembersTableProps = {
+  selectedMembers: SelectedMember[];
+  setFieldValue: (
+    field: string,
+    value: any,
+    shouldValidate?: boolean,
+  ) => Promise<FormikErrors<CreateRoleFormValues>> | Promise<void>;
+};
+
+export const AddedMembersTable = ({
+  selectedMembers,
+  setFieldValue,
+}: AddedMembersTableProps) => {
+  const classes = useStyles();
+  return (
+    <Table
+      title={
+        selectedMembers.length > 0
+          ? `Users and groups (${getMembers(selectedMembers)})`
+          : 'Users and groups'
+      }
+      data={selectedMembers}
+      columns={selectedMembersColumns(selectedMembers, setFieldValue)}
+      emptyContent={
+        <div className={classes.empty}>
+          No records. Selected users and groups appear here.
+        </div>
+      }
+    />
+  );
+};

--- a/plugins/rbac/src/components/CreateRole/AddedMembersTableColumn.tsx
+++ b/plugins/rbac/src/components/CreateRole/AddedMembersTableColumn.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import { TableColumn } from '@backstage/core-components';
+
+import { IconButton } from '@material-ui/core';
+import Delete from '@mui/icons-material/Delete';
+import { FormikErrors } from 'formik';
+
+import { CreateRoleFormValues, SelectedMember } from './types';
+
+export const selectedMembersColumns = (
+  selectedMembers: SelectedMember[],
+  setFieldValue: (
+    field: string,
+    value: any,
+    shouldValidate?: boolean,
+  ) => Promise<FormikErrors<CreateRoleFormValues>> | Promise<void>,
+): TableColumn<SelectedMember>[] => {
+  const onRemove = (etag: string) => {
+    const updatedMembers = selectedMembers.filter(
+      (mem: SelectedMember) => mem.etag !== etag,
+    );
+    setFieldValue('selectedMembers', updatedMembers);
+  };
+
+  return [
+    {
+      title: 'Name',
+      field: 'label',
+      type: 'string',
+    },
+    {
+      title: 'Type',
+      field: 'type',
+      type: 'string',
+    },
+    {
+      title: 'Members',
+      field: 'members',
+      type: 'numeric',
+      align: 'left',
+      emptyValue: '-',
+    },
+    {
+      title: 'Actions',
+      sorting: false,
+      render: (mem: SelectedMember) => {
+        return (
+          <span key={mem.etag}>
+            <IconButton
+              onClick={() => onRemove(mem.etag)}
+              aria-label="Remove"
+              title="Remove member"
+            >
+              <Delete />
+            </IconButton>
+          </span>
+        );
+      },
+    },
+  ];
+};

--- a/plugins/rbac/src/components/CreateRole/CreateRoleForm.test.tsx
+++ b/plugins/rbac/src/components/CreateRole/CreateRoleForm.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { CreateRoleForm } from './CreateRoleForm';
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: jest.fn(),
+}));
+
+jest.mock('formik', () => ({
+  ...jest.requireActual('formik'),
+  useFormik: jest.fn().mockReturnValue({
+    errors: {},
+    values: {},
+    // mocked useFormik to return formik status with submitError
+    status: { submitError: 'Unexpected error' },
+  }),
+}));
+
+describe('CreateRoleForm', () => {
+  it('renders create role form correctly', async () => {
+    render(<CreateRoleForm />);
+
+    expect(
+      screen.getByText(/enter name and description of role/i),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId(/role-name/i)).toBeInTheDocument();
+    expect(screen.getByTestId(/role-description/i)).toBeInTheDocument();
+    expect(screen.getByText(/add users and groups/i)).toBeInTheDocument();
+  });
+
+  it('shows error if there is any error in formik status', async () => {
+    render(<CreateRoleForm />);
+
+    expect(
+      screen.getByText(/unable to create role. unexpected error/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/rbac/src/components/CreateRole/CreateRoleForm.tsx
+++ b/plugins/rbac/src/components/CreateRole/CreateRoleForm.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { SimpleStepper, SimpleStepperStep } from '@backstage/core-components';
+import { useApi } from '@backstage/core-plugin-api';
+
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Divider,
+  Paper,
+} from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import { FormikHelpers, useFormik } from 'formik';
+
+import { rbacApiRef } from '../../api/RBACBackendClient';
+import { getRoleData, validationSchema } from '../../utils/create-role-utils';
+import { AddedMembersTable } from './AddedMembersTable';
+import { AddMembersForm } from './AddMembersForm';
+import { RoleDetailsForm } from './RoleDetailsForm';
+import { CreateRoleFormValues } from './types';
+
+export const CreateRoleForm = () => {
+  const [activeStep, setActiveStep] = React.useState<number>(0);
+  const navigate = useNavigate();
+  const rbacApi = useApi(rbacApiRef);
+  const formik = useFormik<CreateRoleFormValues>({
+    initialValues: {
+      name: '',
+      namespace: 'default',
+      description: '',
+      selectedMembers: [],
+    },
+    validationSchema: validationSchema,
+    onSubmit: async (
+      values: CreateRoleFormValues,
+      formikHelpers: FormikHelpers<CreateRoleFormValues>,
+    ) => {
+      try {
+        const data = getRoleData(values);
+        const res = await rbacApi.createRole(data);
+        if (res.status !== 200 && res.status !== 201) {
+          const resData = await res.json();
+          throw new Error(resData?.error?.message ?? 'Unable to create role');
+        } else {
+          navigate('/rbac');
+        }
+      } catch (e) {
+        formikHelpers.setStatus({ submitError: e });
+      }
+    },
+  });
+
+  const validateStepField = (fieldName: string) => {
+    switch (fieldName) {
+      case 'name': {
+        formik.validateField(fieldName);
+        return formik.errors.name;
+      }
+      case 'selectedMembers': {
+        formik.validateField(fieldName);
+        return formik.errors.selectedMembers;
+      }
+      default:
+        return undefined;
+    }
+  };
+
+  const handleNext = (fieldName?: string) => {
+    const error = fieldName && validateStepField(fieldName);
+    if (!fieldName || !error) {
+      formik.setErrors({});
+      const stepNum = Math.min(activeStep + 1, 3);
+      setActiveStep(stepNum);
+    }
+  };
+
+  const handleBack = () => setActiveStep(Math.max(activeStep - 1, 0));
+
+  const handleReset = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    setActiveStep(0);
+    formik.handleReset(e);
+  };
+
+  return (
+    <Card>
+      <CardHeader title="Create role" />
+      <Divider />
+      <CardContent component="form" onSubmit={formik.handleSubmit}>
+        <SimpleStepper activeStep={activeStep}>
+          <SimpleStepperStep
+            title="Enter name and description of role"
+            actions={{
+              showBack: false,
+              showNext: true,
+              nextText: 'Next',
+              canNext: () => !!formik.values.name && !formik.errors.name,
+              onNext: () => handleNext('name'),
+            }}
+          >
+            <RoleDetailsForm
+              name={formik.values.name}
+              description={formik.values.description}
+              handleBlur={formik.handleBlur}
+              handleChange={formik.handleChange}
+              nameError={formik.errors.name}
+            />
+          </SimpleStepperStep>
+          <SimpleStepperStep
+            title="Add users and groups"
+            actions={{
+              showNext: true,
+              nextText: 'Next',
+              canNext: () =>
+                formik.values.selectedMembers?.length > 0 &&
+                !formik.errors.selectedMembers,
+              onNext: () => handleNext('selectedMembers'),
+              showBack: true,
+              backText: 'Back',
+              onBack: handleBack,
+            }}
+          >
+            <Box>
+              <AddMembersForm
+                selectedMembers={formik.values.selectedMembers}
+                selectedMembersError={formik.errors.selectedMembers as string}
+                setFieldValue={formik.setFieldValue}
+              />
+              <br />
+              <AddedMembersTable
+                selectedMembers={formik.values.selectedMembers}
+                setFieldValue={formik.setFieldValue}
+              />
+            </Box>
+          </SimpleStepperStep>
+          <SimpleStepperStep title="" end>
+            <Paper elevation={0}>
+              <Button onClick={handleBack}>Back</Button>
+              <Button onClick={e => handleReset(e)}>Reset</Button>
+              <Button
+                variant="contained"
+                color="primary"
+                type="submit"
+                disabled={
+                  !!formik.errors.name || !!formik.errors.selectedMembers
+                }
+              >
+                Create
+              </Button>
+            </Paper>
+          </SimpleStepperStep>
+        </SimpleStepper>
+        {formik.status?.submitError && (
+          <Box>
+            <Alert severity="error">{`Unable to create role. ${formik.status.submitError}`}</Alert>
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/plugins/rbac/src/components/CreateRole/CreateRolePage.tsx
+++ b/plugins/rbac/src/components/CreateRole/CreateRolePage.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { Content, Header, Page } from '@backstage/core-components';
+import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
+import { RequirePermission } from '@backstage/plugin-permission-react';
+
+import { CreateRoleForm } from './CreateRoleForm';
+
+export const CreateRolePage = () => {
+  return (
+    <RequirePermission
+      permission={catalogEntityReadPermission}
+      resourceRef={catalogEntityReadPermission.resourceType}
+    >
+      <Page themeId="tool">
+        <Header title="Create role" />
+        <Content>
+          <CreateRoleForm />
+        </Content>
+      </Page>
+    </RequirePermission>
+  );
+};

--- a/plugins/rbac/src/components/CreateRole/MembersDropdownOption.tsx
+++ b/plugins/rbac/src/components/CreateRole/MembersDropdownOption.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { Box, makeStyles } from '@material-ui/core';
+import { AutocompleteRenderOptionState } from '@material-ui/lab/Autocomplete';
+import match from 'autosuggest-highlight/match';
+import parse from 'autosuggest-highlight/parse';
+
+import { SelectedMember } from './types';
+
+type MembersDropdownOptionProps = {
+  option: SelectedMember;
+  state: AutocompleteRenderOptionState;
+};
+
+const useStyles = makeStyles(theme => ({
+  optionLabel: {
+    color: theme.palette.text.primary,
+  },
+  optionDescription: {
+    color: theme.palette.text.secondary,
+  },
+}));
+
+export const MembersDropdownOption = ({
+  option,
+  state,
+}: MembersDropdownOptionProps) => {
+  const classes = useStyles();
+  const { inputValue } = state;
+  const { label, etag } = option;
+  const matches = match(label, inputValue, { insideWords: true });
+  const parts = parse(label, matches);
+
+  return (
+    <Box>
+      {parts.map(part => (
+        <span
+          key={`${part.text}-${etag}`}
+          className={classes.optionLabel}
+          style={{
+            fontWeight: part.highlight ? 400 : 700,
+          }}
+        >
+          {part.text}
+        </span>
+      ))}
+      <br />
+      <span className={classes.optionDescription}>{option.description}</span>
+    </Box>
+  );
+};

--- a/plugins/rbac/src/components/CreateRole/RoleDetailsForm.tsx
+++ b/plugins/rbac/src/components/CreateRole/RoleDetailsForm.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import { TextField } from '@material-ui/core';
+
+type RoleDetailsFormProps = {
+  name: string;
+  description?: string;
+  nameError?: string;
+  handleBlur: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  handleChange: React.ChangeEventHandler<
+    HTMLTextAreaElement | HTMLInputElement
+  >;
+};
+
+export const RoleDetailsForm = ({
+  name,
+  description,
+  nameError,
+  handleBlur,
+  handleChange,
+}: RoleDetailsFormProps) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '20px',
+      }}
+    >
+      <TextField
+        required
+        label="Name"
+        variant="outlined"
+        id="role-name"
+        data-testid="role-name"
+        aria-labelledby="name"
+        helperText={nameError ?? 'Enter name of the role'}
+        value={name}
+        name="name"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        error={!!nameError}
+      />
+      <TextField
+        label="Description"
+        variant="outlined"
+        helperText="Enter a brief description about the role (The purpose of the role)"
+        value={description}
+        data-testid="role-description"
+        id="role-description"
+        name="description"
+        aria-labelledby="description"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        multiline
+      />
+    </div>
+  );
+};

--- a/plugins/rbac/src/components/CreateRole/types.ts
+++ b/plugins/rbac/src/components/CreateRole/types.ts
@@ -1,0 +1,15 @@
+export type SelectedMember = {
+  label: string;
+  etag: string;
+  namespace?: string;
+  type: string;
+  members?: number;
+  description?: string;
+};
+
+export type CreateRoleFormValues = {
+  name: string;
+  namespace: string;
+  description?: string;
+  selectedMembers: SelectedMember[];
+};

--- a/plugins/rbac/src/components/RbacPage.test.tsx
+++ b/plugins/rbac/src/components/RbacPage.test.tsx
@@ -34,7 +34,12 @@ describe('RbacPage', () => {
   it('should render if authorized', async () => {
     RequirePermissionMock.mockImplementation(props => <>{props.children}</>);
     mockUsePermission.mockReturnValue({ loading: false, allowed: true });
-    mockUseRoles.mockReturnValue({ loading: true, data: [], retry: () => {} });
+    mockUseRoles.mockReturnValue({
+      loading: true,
+      data: [],
+      retry: () => {},
+      createRoleAllowed: false,
+    });
     await renderInTestApp(<RbacPage />);
     expect(screen.getByText('Administration')).toBeInTheDocument();
   });

--- a/plugins/rbac/src/components/RolesList.test.tsx
+++ b/plugins/rbac/src/components/RolesList.test.tsx
@@ -58,6 +58,7 @@ describe('RolesList', () => {
       loading: false,
       data: useRolesMockData,
       retry: () => {},
+      createRoleAllowed: false,
     });
     const { queryByText } = await renderInTestApp(<RolesList />);
     expect(queryByText('All roles (2)')).not.toBeNull();
@@ -69,7 +70,12 @@ describe('RolesList', () => {
   it('should show empty table when there are no roles', async () => {
     RequirePermissionMock.mockImplementation(props => <>{props.children}</>);
     mockUsePermission.mockReturnValue({ loading: false, allowed: true });
-    mockUseRoles.mockReturnValue({ loading: false, data: [], retry: () => {} });
+    mockUseRoles.mockReturnValue({
+      loading: false,
+      data: [],
+      retry: () => {},
+      createRoleAllowed: false,
+    });
     const { getByTestId } = await renderInTestApp(<RolesList />);
     expect(getByTestId('roles-table-empty')).not.toBeNull();
   });
@@ -83,6 +89,7 @@ describe('RolesList', () => {
       loading: false,
       data: useRolesMockData,
       retry: () => {},
+      createRoleAllowed: false,
     });
     const { getAllByTestId, getByText } = await renderInTestApp(<RolesList />);
     expect(getAllByTestId('delete-role')).not.toBeNull();
@@ -107,8 +114,41 @@ describe('RolesList', () => {
         },
       ],
       retry: () => {},
+      createRoleAllowed: false,
     });
     const { getAllByTestId } = await renderInTestApp(<RolesList />);
     expect(getAllByTestId('disable-delete-role')).not.toBeNull();
+  });
+
+  it('should disable create button if user is not authorized to create roles', async () => {
+    RequirePermissionMock.mockImplementation(props => <>{props.children}</>);
+    mockUsePermission.mockReturnValue({ loading: false, allowed: true });
+    mockUseRoles.mockReturnValue({
+      loading: false,
+      data: useRolesMockData,
+      retry: () => {},
+      createRoleAllowed: false,
+    });
+    const { getByTestId } = await renderInTestApp(<RolesList />);
+
+    expect(getByTestId('create-role').getAttribute('aria-disabled')).toEqual(
+      'true',
+    );
+  });
+
+  it('should enable create button if user is authorized to create roles', async () => {
+    RequirePermissionMock.mockImplementation(props => <>{props.children}</>);
+    mockUsePermission.mockReturnValue({ loading: false, allowed: true });
+    mockUseRoles.mockReturnValue({
+      loading: false,
+      data: useRolesMockData,
+      retry: () => {},
+      createRoleAllowed: true,
+    });
+    const { getByTestId } = await renderInTestApp(<RolesList />);
+
+    expect(getByTestId('create-role').getAttribute('aria-disabled')).toEqual(
+      'false',
+    );
   });
 });

--- a/plugins/rbac/src/components/RolesList.tsx
+++ b/plugins/rbac/src/components/RolesList.tsx
@@ -11,6 +11,7 @@ import { RolesData } from '../types';
 import { useDeleteDialog } from './DeleteDialogContext';
 import DeleteRoleDialog from './DeleteRoleDialog';
 import { columns } from './RolesListColumns';
+import { RolesListToolbar } from './RolesListToolbar';
 import { useToast } from './ToastContext';
 
 const useStyles = makeStyles(theme => ({
@@ -27,7 +28,7 @@ export const RolesList = () => {
 
   const [roles, setRoles] = React.useState<number | undefined>();
   const classes = useStyles();
-  const { loading, data, retry } = useRoles();
+  const { loading, data, retry, createRoleAllowed } = useRoles();
 
   const closeDialog = () => {
     setOpenDialog(false);
@@ -61,6 +62,7 @@ export const RolesList = () => {
           {toastMessage}
         </Alert>
       </Snackbar>
+      <RolesListToolbar createRoleAllowed={createRoleAllowed} />
       <Table
         title={
           !loading && data?.length

--- a/plugins/rbac/src/components/RolesListToolbar.tsx
+++ b/plugins/rbac/src/components/RolesListToolbar.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { LinkButton } from '@backstage/core-components';
+
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(_theme => ({
+  toolbar: {
+    display: 'flex',
+    justifyContent: 'end',
+    marginBottom: '24px',
+  },
+}));
+
+export const RolesListToolbar = ({
+  createRoleAllowed,
+}: {
+  createRoleAllowed: boolean;
+}) => {
+  const classes = useStyles();
+  return (
+    <span className={classes.toolbar}>
+      <LinkButton
+        to="role/new"
+        color="primary"
+        variant="contained"
+        disabled={!createRoleAllowed}
+        data-testid="create-role"
+      >
+        Create
+      </LinkButton>
+    </span>
+  );
+};

--- a/plugins/rbac/src/components/Router.tsx
+++ b/plugins/rbac/src/components/Router.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 
-import { roleRouteRef } from '../routes';
+import { RequirePermission } from '@backstage/plugin-permission-react';
+
+import { policyEntityCreatePermission } from '@janus-idp/backstage-plugin-rbac-common';
+
+import { createRoleRouteRef, roleRouteRef } from '../routes';
+import { CreateRolePage } from './CreateRole/CreateRolePage';
 import { RbacPage } from './RbacPage';
 import { RoleOverviewPage } from './RoleOverviewPage';
 
@@ -13,5 +18,16 @@ export const Router = () => (
   <Routes>
     <Route path="/" element={<RbacPage />} />
     <Route path={roleRouteRef.path} element={<RoleOverviewPage />} />
+    <Route
+      path={createRoleRouteRef.path}
+      element={
+        <RequirePermission
+          permission={policyEntityCreatePermission}
+          resourceRef={policyEntityCreatePermission.resourceType}
+        >
+          <CreateRolePage />
+        </RequirePermission>
+      }
+    />
   </Routes>
 );

--- a/plugins/rbac/src/components/index.ts
+++ b/plugins/rbac/src/components/index.ts
@@ -1,3 +1,4 @@
 export { RbacPage } from './RbacPage';
 export { Administration } from './Administration';
 export { RoleOverviewPage } from './RoleOverviewPage';
+export { Router } from './Router';

--- a/plugins/rbac/src/plugin.ts
+++ b/plugins/rbac/src/plugin.ts
@@ -8,13 +8,14 @@ import {
 } from '@backstage/core-plugin-api';
 
 import { rbacApiRef, RBACBackendClient } from './api/RBACBackendClient';
-import { roleRouteRef, rootRouteRef } from './routes';
+import { createRoleRouteRef, roleRouteRef, rootRouteRef } from './routes';
 
 export const rbacPlugin = createPlugin({
   id: 'rbac',
   routes: {
     root: rootRouteRef,
     role: roleRouteRef,
+    createRole: createRoleRouteRef,
   },
   apis: [
     createApiFactory({
@@ -32,7 +33,7 @@ export const rbacPlugin = createPlugin({
 export const RbacPage = rbacPlugin.provide(
   createRoutableExtension({
     name: 'RbacPage',
-    component: () => import('./components/Router').then(m => m.Router),
+    component: () => import('./components').then(m => m.Router),
     mountPoint: rootRouteRef,
   }),
 );

--- a/plugins/rbac/src/routes.ts
+++ b/plugins/rbac/src/routes.ts
@@ -9,3 +9,9 @@ export const roleRouteRef = createSubRouteRef({
   parent: rootRouteRef,
   path: '/roles/:roleKind/:roleName',
 });
+
+export const createRoleRouteRef = createSubRouteRef({
+  id: 'rbac-create-role',
+  parent: rootRouteRef,
+  path: '/role/new',
+});

--- a/plugins/rbac/src/utils/create-role-utils.test.ts
+++ b/plugins/rbac/src/utils/create-role-utils.test.ts
@@ -1,0 +1,81 @@
+import { mockMembers } from '../__fixtures__/mockMembers';
+import {
+  getChildGroupsCount,
+  getMembersCount,
+  getParentGroupsCount,
+  getRoleData,
+} from './create-role-utils';
+
+describe('getRoleData', () => {
+  it('should return role data object', () => {
+    const values = {
+      name: 'testRole',
+      namespace: 'default',
+      selectedMembers: [
+        { type: 'User', namespace: 'default', label: 'user1', etag: '1' },
+        { type: 'Group', namespace: 'default', label: 'group1', etag: '2' },
+      ],
+    };
+
+    const result = getRoleData(values);
+
+    expect(result).toEqual({
+      memberReferences: ['user:default/user1', 'group:default/group1'],
+      name: 'role:default/testRole',
+    });
+  });
+});
+
+describe('getMembersCount', () => {
+  it('should return the number of members for a group', () => {
+    const group = mockMembers[0];
+
+    const result = getMembersCount(group);
+
+    expect(result).toBe(2);
+  });
+
+  it('should return undefined for non-group entities', () => {
+    const user = mockMembers[2];
+
+    const result = getMembersCount(user);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('getParentGroupsCount', () => {
+  it('should return the number of parent groups for a group', () => {
+    const group = mockMembers[0];
+
+    const result = getParentGroupsCount(group);
+
+    expect(result).toBe(1);
+  });
+
+  it('should return undefined for non-group entities', () => {
+    const user = mockMembers[2];
+
+    const result = getParentGroupsCount(user);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('getChildGroupsCount', () => {
+  it('should return the number of child groups for a group', () => {
+    const group = mockMembers[8];
+
+    const result = getChildGroupsCount(group);
+
+    expect(result).toBe(2);
+  });
+
+  it('should return undefined for non-group entities', () => {
+    const user = mockMembers[2];
+
+    const result = getChildGroupsCount(user);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/plugins/rbac/src/utils/create-role-utils.ts
+++ b/plugins/rbac/src/utils/create-role-utils.ts
@@ -1,0 +1,57 @@
+import * as yup from 'yup';
+
+import {
+  CreateRoleFormValues,
+  SelectedMember,
+} from '../components/CreateRole/types';
+import { MemberEntity } from '../types';
+
+export const getRoleData = (values: CreateRoleFormValues) => {
+  return {
+    memberReferences: values.selectedMembers.map((mem: SelectedMember) =>
+      `${mem.type}:${mem.namespace}/${mem.label}`.toLowerCase(),
+    ),
+    name: `role:${values.namespace}/${values.name}`,
+  };
+};
+
+export const validationSchema = yup.object({
+  name: yup.string().required('Name is required'),
+  selectedMembers: yup.array().min(1, 'No member selected'),
+});
+
+export const getMembersCount = (member: MemberEntity) => {
+  return member.kind === 'Group'
+    ? member.relations?.reduce((acc: any, relation: { type: string }) => {
+        let temp = acc;
+        if (relation.type === 'hasMember') {
+          temp++;
+        }
+        return temp;
+      }, 0) || 1
+    : undefined;
+};
+
+export const getParentGroupsCount = (member: MemberEntity) => {
+  return member.kind === 'Group'
+    ? member.relations?.reduce((acc: any, relation: { type: string }) => {
+        let temp = acc;
+        if (relation.type === 'childOf') {
+          temp++;
+        }
+        return temp;
+      }, 0)
+    : undefined;
+};
+
+export const getChildGroupsCount = (member: MemberEntity) => {
+  return member.kind === 'Group'
+    ? member.relations?.reduce((acc: any, relation: { type: string }) => {
+        let temp = acc;
+        if (relation.type === 'parentOf') {
+          temp++;
+        }
+        return temp;
+      }, 0)
+    : undefined;
+};

--- a/plugins/rbac/src/utils/rbac-utils.ts
+++ b/plugins/rbac/src/utils/rbac-utils.ts
@@ -9,6 +9,7 @@ import {
   RoleBasedPolicy,
 } from '@janus-idp/backstage-plugin-rbac-common';
 
+import { SelectedMember } from '../components/CreateRole/types';
 import { MembersData, PermissionsData } from '../types';
 
 export const getPermissions = (
@@ -41,7 +42,9 @@ export const getMembersString = (res: {
   return membersString;
 };
 
-export const getMembers = (members: (string | MembersData)[]): string => {
+export const getMembers = (
+  members: (string | MembersData | SelectedMember)[],
+): string => {
   if (!members || members.length === 0) {
     return 'No members';
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11180,6 +11180,11 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.3.tgz#07570ebd25f9b516c910a91f7244052c9b58eabc"
   integrity sha512-0Z6Tr7wjKJIk4OUEjVUQMtyunLDy339vcMaj38Kpj6jM2OE1p3S4kXExKZ7a3uXQAPCoy3sbrP1wibDKaf39oA==
 
+"@types/autosuggest-highlight@3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@types/autosuggest-highlight/-/autosuggest-highlight-3.2.3.tgz#966b4f6b2b8fc9df2838481600500db6b3795aaa"
+  integrity sha512-8Mb21KWtpn6PvRQXjsKhrXIcxbSloGqNH50RntwGeJsGPW4xvNhfml+3kKulaKpO/7pgZfOmzsJz7VbepArlGQ==
+
 "@types/aws-lambda@^8.10.83":
   version "8.10.125"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.125.tgz#c2ba86f7d98fe1827a7b048e0d31a65a8b5aed8c"
@@ -13434,6 +13439,13 @@ autolinker@^3.11.0:
   integrity sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==
   dependencies:
     tslib "^2.3.0"
+
+autosuggest-highlight@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/autosuggest-highlight/-/autosuggest-highlight-3.3.4.tgz#d71b575ba8eab40b5adba73df9244e9ba88cc387"
+  integrity sha512-j6RETBD2xYnrVcoV1S5R4t3WxOlWZKyDQjkwnggDPSjF5L4jV98ZltBpvPvbkM1HtoSe5o+bNrTHyjPbieGeYA==
+  dependencies:
+    remove-accents "^0.4.2"
 
 available-typed-arrays@^1.0.5:
   version "1.0.5"
@@ -15961,6 +15973,11 @@ deepmerge@4.3.1, deepmerge@^4.2.2, deepmerge@^4.3.1, deepmerge@~4.3.0:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 default-browser-id@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-3.0.0.tgz#bee7bbbef1f4e75d31f98f4d3f1556a14cea790c"
@@ -18019,6 +18036,20 @@ formidable@^2.1.2:
     hexoid "^1.0.0"
     once "^1.4.0"
     qs "^6.11.0"
+
+formik@^2.4.5:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.5.tgz#f899b5b7a6f103a8fabb679823e8fafc7e0ee1b4"
+  integrity sha512-Gxlht0TD3vVdzMDHwkiNZqJ7Mvg77xQNfmBRrNtvzcHZs72TJppSTDKHpImCMJZwcWPBJ8jSQQ95GJzXFf1nAQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.1"
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^2.0.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -24909,7 +24940,7 @@ properties-reader@^2.2.0:
   dependencies:
     mkdirp "^1.0.4"
 
-property-expr@^2.0.4:
+property-expr@^2.0.4, property-expr@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.6.tgz#f77bc00d5928a6c748414ad12882e83f24aec1e8"
   integrity sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==
@@ -25409,6 +25440,11 @@ react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+
+react-fast-compare@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
 react-fast-compare@^3.1.1, react-fast-compare@^3.2.0:
   version "3.2.2"
@@ -26085,6 +26121,11 @@ remarkable@^2.0.1:
   dependencies:
     argparse "^1.0.10"
     autolinker "^3.11.0"
+
+remove-accents@^0.4.2:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.4.tgz#73704abf7dae3764295d475d2b6afac4ea23e4d9"
+  integrity sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -27971,6 +28012,11 @@ timers-browserify@^2.0.4:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
 
 tiny-emitter@^2.1.0:
   version "2.1.0"
@@ -30018,6 +30064,16 @@ yup@^0.32.11, yup@^0.32.9:
     nanoclone "^0.2.1"
     property-expr "^2.0.4"
     toposort "^2.0.2"
+
+yup@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.3.2.tgz#afffc458f1513ed386e6aaf4bcaa4e67a9e270dc"
+  integrity sha512-6KCM971iQtJ+/KUaHdrhVr2LDkfhBtFPRnsG1P8F4q3uUVQ2RfEM9xekpha9aA4GXWJevjM10eDcPQ1FfWlmaQ==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"
 
 zen-observable@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
Story: https://github.com/janus-idp/backstage-plugins/issues/941, https://github.com/janus-idp/backstage-plugins/issues/942

This PR adds support for creating a role via a create role form. It adds a create button on roles list page which takes the user to the create role form. User can provide name and description and also add  members (users/groups) to the role. On successful creation user is redirected to the roles list page.

Remaining ACs will be covered in this story - https://github.com/janus-idp/backstage-plugins/issues/975


https://github.com/janus-idp/backstage-plugins/assets/20724543/32437302-e95f-4f72-9554-4c5325587a91



Error on submit:
<img width="1792" alt="Screenshot 2023-11-30 at 9 15 21 PM" src="https://github.com/janus-idp/backstage-plugins/assets/20724543/14d54088-cbf9-4a9e-a60a-ebe457df73f3">



To Do

- [x] Add validation
- [x] Add tests
- [x] Clean up css