### PR TITLE
fix(cli): schema generator do not ignore repo root

### DIFF
--- a/packages/cli/src/lib/schema/collect.ts
+++ b/packages/cli/src/lib/schema/collect.ts
@@ -166,7 +166,10 @@ async function collectConfigSchemas(
     );
   }
 
-  await processItem({ name: packageName, parentPath: currentDir });
+  await processItem({
+    name: packageName,
+    packagePath: `${currentDir}/package.json`,
+  });
 
   const tsSchemas = await compileTsSchemas(tsSchemaPaths);
 


### PR DESCRIPTION
If we execute `janus-cli package schema` (or via export dynamic), the resulting schema can skip the top level package. In the case of monorepo, this is not an issue, but it can be issue for standalone plugins.