### PR TITLE
feat(rbac)!: add support for multiple policies CRUD

### DIFF
--- a/plugins/rbac-backend/src/service/policies-validation.test.ts
+++ b/plugins/rbac-backend/src/service/policies-validation.test.ts
@@ -3,7 +3,6 @@ import { RoleBasedPolicy } from '@janus-idp/backstage-plugin-rbac-common';
 import {
   validateEntityReference,
   validatePolicy,
-  validateQueries,
   validateRole,
 } from './policies-validation';
 
@@ -175,45 +174,6 @@ describe('rest data validation', () => {
         const err = validateEntityReference(entityRef);
         expect(err).toBeFalsy();
       }
-    });
-  });
-
-  describe('validatePolicyQueries', () => {
-    it('should return an error when "permission" query param is missing', () => {
-      const request = { query: { policy: 'read', effect: 'allow' } } as any;
-      const err = validateQueries(request);
-      expect(err).toBeTruthy();
-      expect(err?.message).toEqual('specify "permission" query param.');
-    });
-
-    it('should return an error when "policy" query param is missing', () => {
-      const request = {
-        query: { permission: 'user:default/guest', effect: 'allow' },
-      } as any;
-      const err = validateQueries(request);
-      expect(err).toBeTruthy();
-      expect(err?.message).toEqual('specify "policy" query param.');
-    });
-
-    it('should return an error when "effect" query param is missing', () => {
-      const request = {
-        query: { permission: 'user:default/guest', policy: 'read' },
-      } as any;
-      const err = validateQueries(request);
-      expect(err).toBeTruthy();
-      expect(err?.message).toEqual('specify "effect" query param.');
-    });
-
-    it('should pass validation when all required query params are present', () => {
-      const request = {
-        query: {
-          permission: 'user:default/guest',
-          policy: 'read',
-          effect: 'allow',
-        },
-      } as any;
-      const err = validateQueries(request);
-      expect(err).toBeUndefined();
     });
   });
 

--- a/plugins/rbac-backend/src/service/policies-validation.ts
+++ b/plugins/rbac-backend/src/service/policies-validation.ts
@@ -1,8 +1,6 @@
 import { CompoundEntityRef, parseEntityRef } from '@backstage/catalog-model';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
-import { Request } from 'express-serve-static-core';
-
 import { Role, RoleBasedPolicy } from '@janus-idp/backstage-plugin-rbac-common';
 
 export function validatePolicy(policy: RoleBasedPolicy): Error | undefined {
@@ -85,22 +83,6 @@ export function validateEntityReference(entityRef?: string): Error | undefined {
     return new Error(
       `Unsupported kind ${entityRefCompound.kind}. List supported values ["user", "group", "role"]`,
     );
-  }
-
-  return undefined;
-}
-
-export function validateQueries(request: Request): Error | undefined {
-  if (!request.query.permission) {
-    return new Error('specify "permission" query param.');
-  }
-
-  if (!request.query.policy) {
-    return new Error('specify "policy" query param.');
-  }
-
-  if (!request.query.effect) {
-    return new Error('specify "effect" query param.');
   }
 
   return undefined;


### PR DESCRIPTION
## Description

This PR enhances the permission policy CRUD to handle multiple permission policies at a time. This change aims to decrease the number of calls users need to make to the permission policy API when dealing with permission policies.

## Fixes

- Fixes #899 

## How to test changes / Special notes to the reviewer

---

**UPDATES**:
- Have added a mechanism for checking if there are duplicate permission policies or roles being created or updated
- Added an additional error in the event that oldPolicy has more permissions compared to newPolicy
- Added additional test coverage for the above scenarios
- Update the commit message and title as this is considered a breaking change

---

1. Update app-config.yaml to include your user as admin

```
permission:
  enabled: true
  rbac:
    admin:
      users:
        - name: user:default/<USERNAME>
```

2. Log in using GitHub auth.
3. Retrieve user token. Copy it to terminal: `export token=...token...value`
4. Ensure that there is a role named `role:default/test`

Create multiple permissions

```
curl -X POST "http://localhost:7007/api/permission/policies" -d '[ { "entityReference": "role:default/test", "permission": "catalog.entity.create", "policy": "create", "effect": "allow" }, { "entityReference": "role:default/test", "permission": "catalog-entity", "policy": "delete", "effect": "allow" } ]' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
```

Update multiple permissions

```
curl -X PUT "http://localhost:7007/api/permission/policies/role/default/test" -d '{ "oldPolicy": [ { "entityReference": "role:default/test", "permission": "catalog.entity.create", "policy": "create", "effect": "allow" }, { "entityReference": "role:default/test", "permission": "catalog-entity", "policy": "delete", "effect": "allow" } ], "newPolicy": [ { "entityReference": "role:default/test", "permission": "catalog.entity.create", "policy": "create", "effect": "deny" }, { "entityReference": "role:default/test", "permission": "catalog-entity", "policy": "delete", "effect": "deny" } ] }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
```

Delete multiple permissions

```
curl -X DELETE "http://localhost:7007/api/permission/policies/role/default/test" -d '[ { "permission": "catalog.entity.create", "policy": "create", "effect": "deny" }, { "permission": "catalog-entity", "policy": "delete", "effect": "deny" } ]' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
```
