### PR TITLE
[WIP] fix(rbac): CSV updates no longer require server restarts

### DIFF
--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/duplicate-policies-actions.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/duplicate-policies-actions.csv
@@ -1,0 +1,3 @@
+p, role:default/catalog-writer, catalog.entity.create, use, allow
+
+p, role:default/catalog-writer, catalog.entity.create, use, deny

--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/duplicate-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/duplicate-policy.csv
@@ -1,0 +1,5 @@
+g, user:default/guest, role:default/catalog-deleter
+g, user:default/guest, role:default/catalog-deleter
+
+p, role:default/catalog-writer, catalog.entity.create, use, allow
+p, role:default/catalog-writer, catalog.entity.create, use, allow

--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/duplicate-role.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/duplicate-role.csv
@@ -1,0 +1,2 @@
+g, user:default/guest, role:default/catalog-deleter
+g, user:default/guest, role:default/catalog-deleter

--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/entityref-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/entityref-policy.csv
@@ -1,0 +1,1 @@
+g, user:default/, role:default/catalog-deleter

--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/permission-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/permission-policy.csv
@@ -1,0 +1,1 @@
+p, role:default/, catalog.entity.create, use, allow

--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/role-entityref-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/role-entityref-policy.csv
@@ -1,0 +1,1 @@
+g, user:default/test, role:default/

--- a/plugins/rbac-backend/src/__fixtures__/data/valid-csv/rbac-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/valid-csv/rbac-policy.csv
@@ -1,0 +1,8 @@
+g, user:default/guest, role:default/catalog-writer
+g, user:default/guest, role:default/catalog-reader
+g, user:default/guest, role:default/catalog-deleter
+
+p, role:default/catalog-writer, catalog-entity, update, allow
+p, role:default/catalog-writer, catalog-entity, read, allow
+p, role:default/catalog-writer, catalog.entity.create, use, allow
+p, role:default/catalog-deleter, catalog-entity, delete, deny

--- a/plugins/rbac-backend/src/__fixtures__/data/valid-csv/updated-rbac-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/valid-csv/updated-rbac-policy.csv
@@ -1,0 +1,10 @@
+g, user:default/guest, role:default/catalog-writer
+g, user:default/guest, role:default/catalog-updater
+
+g, user:default/guest, role:default/catalog-tester
+
+p, role:default/catalog-writer, catalog-entity, update, allow
+p, role:default/catalog-writer, catalog.entity.create, use, deny
+p, role:default/catalog-deleter, catalog-entity, delete, allow
+
+p, role:default/catalog-writer, catalog.entity.delete, delete, allow

--- a/plugins/rbac-backend/src/helpers/csv.test.ts
+++ b/plugins/rbac-backend/src/helpers/csv.test.ts
@@ -1,0 +1,601 @@
+import { getVoidLogger, TokenManager } from '@backstage/backend-common';
+
+import {
+  Adapter,
+  Enforcer,
+  FileAdapter,
+  Model,
+  newEnforcer,
+  newModelFromString,
+  StringAdapter,
+} from 'casbin';
+import { Logger } from 'winston';
+
+import { resolve } from 'path';
+
+import { MODEL } from '../service/permission-model';
+import { BackstageRoleManager } from '../service/role-manager';
+import {
+  loadFilteredGroupingPoliciesFromCSV,
+  loadFilteredPoliciesFromCSV,
+  loadPoliciesFromCSV,
+} from './csv';
+
+const catalogApi = {
+  getEntityAncestors: jest.fn().mockImplementation(),
+  getLocationById: jest.fn().mockImplementation(),
+  getEntities: jest.fn().mockImplementation(),
+  getEntitiesByRefs: jest.fn().mockImplementation(),
+  queryEntities: jest.fn().mockImplementation(),
+  getEntityByRef: jest.fn().mockImplementation(),
+  refreshEntity: jest.fn().mockImplementation(),
+  getEntityFacets: jest.fn().mockImplementation(),
+  addLocation: jest.fn().mockImplementation(),
+  getLocationByRef: jest.fn().mockImplementation(),
+  removeLocationById: jest.fn().mockImplementation(),
+  removeEntityByUid: jest.fn().mockImplementation(),
+  validateEntity: jest.fn().mockImplementation(),
+};
+
+const tokenManagerMock = {
+  getToken: jest.fn().mockImplementation(async () => {
+    return Promise.resolve({ token: 'some-token' });
+  }),
+  authenticate: jest.fn().mockImplementation(),
+};
+
+async function createEnforcer(
+  theModel: Model,
+  adapter: Adapter,
+  logger: Logger,
+  tokenManager: TokenManager,
+): Promise<Enforcer> {
+  const enf = await newEnforcer(theModel, adapter);
+
+  const rm = new BackstageRoleManager(catalogApi, logger, tokenManager);
+  enf.setRoleManager(rm);
+  enf.enableAutoBuildRoleLinks(false);
+  await enf.buildRoleLinks();
+
+  return enf;
+}
+
+describe('CSV file', () => {
+  let csvPermFile: string;
+  let enf: Enforcer;
+  let enfAddPolicySpy: jest.SpyInstance<Promise<boolean>, string[], any>;
+  let enfRemovePolicySpy: jest.SpyInstance<Promise<boolean>, string[], any>;
+  let enfAddGroupingSpy: jest.SpyInstance<Promise<boolean>, string[], any>;
+  let enfRemoveGroupingSpy: jest.SpyInstance<Promise<boolean>, string[], any>;
+  const user: string = 'user:default/guest';
+  const resourceType: string = 'catalog.entity.create';
+  const action: string = 'use';
+
+  beforeEach(async () => {
+    csvPermFile = resolve(
+      __dirname,
+      './../__fixtures__/data/valid-csv/rbac-policy.csv',
+    );
+    const adapter = new FileAdapter(csvPermFile);
+
+    const stringModel = newModelFromString(MODEL);
+    const logger = getVoidLogger();
+    enf = await createEnforcer(stringModel, adapter, logger, tokenManagerMock);
+    enfAddPolicySpy = jest.spyOn(enf, 'addPolicy');
+    enfRemovePolicySpy = jest.spyOn(enf, 'removePolicy');
+    enfAddGroupingSpy = jest.spyOn(enf, 'addGroupingPolicy');
+    enfRemoveGroupingSpy = jest.spyOn(enf, 'removeGroupingPolicy');
+  });
+  describe('Loading filtered policies from a CSV file', () => {
+    it('should update a policy that has changed in the file (allow -> deny)', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+      const updatedPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'deny',
+      ];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(true);
+      expect(await enf.hasPolicy(...updatedPolicy)).toBe(false);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enf,
+        user,
+        resourceType,
+        action,
+      );
+
+      expect(enfAddPolicySpy).toHaveBeenCalledWith(...updatedPolicy);
+      expect(enfRemovePolicySpy).toHaveBeenCalledWith(...originalPolicy);
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(false);
+      expect(await enf.hasPolicy(...updatedPolicy)).toBe(true);
+    });
+
+    it('should update a policy that has changed in the file (deny -> allow)', async () => {
+      const originalPolicy = [
+        'role:default/catalog-deleter',
+        'catalog-entity',
+        'delete',
+        'deny',
+      ];
+      const updatedPolicy = [
+        'role:default/catalog-deleter',
+        'catalog-entity',
+        'delete',
+        'allow',
+      ];
+
+      const denyResource = 'catalog-entity';
+      const denyAction = 'delete';
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(true);
+      expect(await enf.hasPolicy(...updatedPolicy)).toBe(false);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enf,
+        user,
+        denyResource,
+        denyAction,
+      );
+
+      expect(enfAddPolicySpy).toHaveBeenCalledWith(...updatedPolicy);
+      expect(enfRemovePolicySpy).toHaveBeenCalledWith(...originalPolicy);
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(false);
+      expect(await enf.hasPolicy(...updatedPolicy)).toBe(true);
+    });
+
+    it('should add a policy that is new in the file', async () => {
+      const newPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.delete',
+        'delete',
+        'allow',
+      ];
+
+      const newResourceType = 'catalog.entity.delete';
+      const newAction = 'delete';
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enf.hasPolicy(...newPolicy)).toBe(false);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enf,
+        user,
+        newResourceType,
+        newAction,
+      );
+
+      expect(enfAddPolicySpy).toHaveBeenCalledWith(...newPolicy);
+
+      expect(await enf.hasPolicy(...newPolicy)).toBe(true);
+    });
+
+    it('should remove a policy that is no longer in the file', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog-entity',
+        'read',
+        'allow',
+      ];
+
+      const originalResource = 'catalog-entity';
+      const originalAction = 'read';
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enf,
+        user,
+        originalResource,
+        originalAction,
+      );
+
+      expect(enfRemovePolicySpy).toHaveBeenCalledWith(...originalPolicy);
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(false);
+    });
+
+    it('should do nothing if there is no change', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+      const originalPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/rbac-policy.csv',
+      );
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredPoliciesFromCSV(
+        originalPolicyFile,
+        enf,
+        user,
+        resourceType,
+        action,
+      );
+
+      expect(enfAddPolicySpy).toHaveBeenCalledTimes(0);
+      expect(enfRemovePolicySpy).toHaveBeenCalledTimes(0);
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(true);
+    });
+
+    // Validation tests
+    it('should fail to update a policy that has changed in the file, entityRef error', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+      const updatedPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'deny',
+      ];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/permission-policy.csv',
+      );
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(true);
+      expect(await enf.hasPolicy(...updatedPolicy)).toBe(false);
+
+      await expect(() =>
+        loadFilteredPoliciesFromCSV(
+          updatedPolicyFile,
+          enf,
+          user,
+          resourceType,
+          action,
+        ),
+      ).rejects.toThrow(
+        `Failed to validate policy from file ${updatedPolicyFile}. Cause: Entity reference "role:default/" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to update a policy that has changed in the file, duplicate error', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/duplicate-policy.csv',
+      );
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(true);
+
+      await expect(() =>
+        loadFilteredPoliciesFromCSV(
+          updatedPolicyFile,
+          enf,
+          user,
+          resourceType,
+          action,
+        ),
+      ).rejects.toThrow(
+        `Duplicate policy ${originalPolicy} found in the file ${updatedPolicyFile}`,
+      );
+    });
+
+    it('should fail to update a policy that has changed in the file, duplicate error different actions', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/duplicate-policies-actions.csv',
+      );
+
+      expect(await enf.hasPolicy(...originalPolicy)).toBe(true);
+
+      await expect(() =>
+        loadFilteredPoliciesFromCSV(
+          updatedPolicyFile,
+          enf,
+          user,
+          resourceType,
+          action,
+        ),
+      ).rejects.toThrow(
+        `Duplicate policy ${originalPolicy[0]}, ${originalPolicy[1]}, ${originalPolicy[2]} with different actions found in the file ${updatedPolicyFile}`,
+      );
+    });
+  });
+
+  describe('Loading filtered grouping policies from a CSV file', () => {
+    it('should update a policy that has changed in the file', async () => {
+      const originalPolicy = [
+        'user:default/guest',
+        'role:default/catalog-reader',
+      ];
+      const updatedPolicy = [
+        'user:default/guest',
+        'role:default/catalog-updater',
+      ];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enf.hasGroupingPolicy(...originalPolicy)).toBe(true);
+      expect(await enf.hasGroupingPolicy(...updatedPolicy)).toBe(false);
+
+      await loadFilteredGroupingPoliciesFromCSV(updatedPolicyFile, enf, user);
+
+      expect(enfAddGroupingSpy).toHaveBeenCalledWith(...updatedPolicy);
+      expect(enfRemoveGroupingSpy).toHaveBeenCalledWith(...originalPolicy);
+
+      expect(await enf.hasGroupingPolicy(...originalPolicy)).toBe(false);
+      expect(await enf.hasGroupingPolicy(...updatedPolicy)).toBe(true);
+    });
+
+    it('should add a policy that is new in the file', async () => {
+      const newPolicy = ['user:default/guest', 'role:default/catalog-tester'];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enf.hasGroupingPolicy(...newPolicy)).toBe(false);
+
+      await loadFilteredGroupingPoliciesFromCSV(updatedPolicyFile, enf, user);
+
+      expect(enfAddGroupingSpy).toHaveBeenCalledWith(...newPolicy);
+
+      expect(await enf.hasGroupingPolicy(...newPolicy)).toBe(true);
+    });
+
+    it('should remove a policy that is no longer in the file', async () => {
+      const originalPolicy = [
+        'user:default/guest',
+        'role:default/catalog-deleter',
+      ];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enf.hasGroupingPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredGroupingPoliciesFromCSV(updatedPolicyFile, enf, user);
+
+      expect(enfRemoveGroupingSpy).toHaveBeenCalledWith(...originalPolicy);
+
+      expect(await enf.hasGroupingPolicy(...originalPolicy)).toBe(false);
+    });
+
+    it('should do nothing if there is no change', async () => {
+      const originalPolicy = [
+        'user:default/guest',
+        'role:default/catalog-writer',
+      ];
+      const originalPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/rbac-policy.csv',
+      );
+
+      expect(await enf.hasGroupingPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredGroupingPoliciesFromCSV(originalPolicyFile, enf, user);
+
+      expect(enfAddGroupingSpy).toHaveBeenCalledTimes(0);
+      expect(enfRemoveGroupingSpy).toHaveBeenCalledTimes(0);
+
+      expect(await enf.hasGroupingPolicy(...originalPolicy)).toBe(true);
+    });
+
+    // Validation tests
+    it('should fail to update a policy that has changed in the file, user entityRef error', async () => {
+      const originalPolicy = [
+        'user:default/guest',
+        'role:default/catalog-deleter',
+      ];
+      const updatedPolicy = [
+        'user:default/test',
+        'role:default/catalog-deleter',
+      ];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/entityref-policy.csv',
+      );
+
+      expect(await enf.hasGroupingPolicy(...originalPolicy)).toBe(true);
+      expect(await enf.hasGroupingPolicy(...updatedPolicy)).toBe(false);
+
+      await expect(() =>
+        loadFilteredGroupingPoliciesFromCSV(updatedPolicyFile, enf, user),
+      ).rejects.toThrow(
+        `Failed to validate group policy from file ${updatedPolicyFile}. Cause: Entity reference "user:default/" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to update a policy that has changed in the file, role entityRef error', async () => {
+      const newUser = 'user:default/test';
+      const newPolicy = ['user:default/test', 'role:default/catalog-reader'];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/role-entityref-policy.csv',
+      );
+
+      expect(await enf.hasGroupingPolicy(...newPolicy)).toBe(false);
+
+      await expect(() =>
+        loadFilteredGroupingPoliciesFromCSV(updatedPolicyFile, enf, newUser),
+      ).rejects.toThrow(
+        `Failed to validate group policy from file ${updatedPolicyFile}. Cause: Entity reference "role:default/" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to update a policy that has changed in the file, duplicate error', async () => {
+      const duplicate = ['user:default/guest', 'role:default/catalog-deleter'];
+
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/duplicate-role.csv',
+      );
+
+      await expect(() =>
+        loadFilteredGroupingPoliciesFromCSV(errorPolicyFile, enf, user),
+      ).rejects.toThrow(
+        `Duplicate grouping policy ${duplicate} found in the file ${errorPolicyFile}`,
+      );
+    });
+  });
+
+  describe('Loading policies from a CSV file', () => {
+    beforeEach(async () => {
+      const adapter = new StringAdapter(
+        `
+          p, user:default/known_user, test.resource.deny, use, allow
+        `,
+      );
+      csvPermFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/rbac-policy.csv',
+      );
+
+      const stringModel = newModelFromString(MODEL);
+      const logger = getVoidLogger();
+      enf = await createEnforcer(
+        stringModel,
+        adapter,
+        logger,
+        tokenManagerMock,
+      );
+    });
+    it('should add policies from the CSV file', async () => {
+      const test = [
+        'role:default/catalog-writer',
+        'catalog-entity',
+        'update',
+        'allow',
+      ];
+      await loadPoliciesFromCSV(csvPermFile, enf);
+
+      expect(await enf.hasPolicy(...test)).toBe(true);
+    });
+
+    // Validation tests
+    it('should fail to add policies from the CSV file, user entityRef group error', async () => {
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/entityref-policy.csv',
+      );
+
+      await expect(() =>
+        loadPoliciesFromCSV(errorPolicyFile, enf),
+      ).rejects.toThrow(
+        `Failed to validate group policy from file ${errorPolicyFile}. Cause: Entity reference "user:default/" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to add policies from the CSV file, role entityRef group error', async () => {
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/role-entityref-policy.csv',
+      );
+
+      await expect(() =>
+        loadPoliciesFromCSV(errorPolicyFile, enf),
+      ).rejects.toThrow(
+        `Failed to validate group policy from file ${errorPolicyFile}. Cause: Entity reference "role:default/" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to add policies from the CSV file, role entityRef permission policy error', async () => {
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/permission-policy.csv',
+      );
+
+      await expect(() =>
+        loadPoliciesFromCSV(errorPolicyFile, enf),
+      ).rejects.toThrow(
+        `Failed to validate policy from file ${errorPolicyFile}. Cause: Entity reference "role:default/" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to add policies from the CSV file, duplicate permission policies in CSV', async () => {
+      const duplicate = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/duplicate-policy.csv',
+      );
+
+      await expect(() =>
+        loadPoliciesFromCSV(errorPolicyFile, enf),
+      ).rejects.toThrow(
+        `Duplicate policy ${duplicate} found in the file ${errorPolicyFile}`,
+      );
+    });
+
+    it('should fail to add policies from the CSV file, duplicate grouping policies in CSV', async () => {
+      const duplicate = ['user:default/guest', 'role:default/catalog-deleter'];
+
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/duplicate-role.csv',
+      );
+
+      await expect(() =>
+        loadPoliciesFromCSV(errorPolicyFile, enf),
+      ).rejects.toThrow(
+        `Duplicate grouping policy ${duplicate} found in the file ${errorPolicyFile}`,
+      );
+    });
+  });
+});

--- a/plugins/rbac-backend/src/helpers/csv.ts
+++ b/plugins/rbac-backend/src/helpers/csv.ts
@@ -1,0 +1,200 @@
+import { Enforcer, FileAdapter, newEnforcer, newModelFromString } from 'casbin';
+import { isEqual } from 'lodash';
+
+import { MODEL } from '../service/permission-model';
+import {
+  validateEntityReference,
+  validatePolicy,
+} from '../service/policies-validation';
+import {
+  checkForDuplicateGroupPolicies,
+  checkForDuplicatePolicies,
+  transformArraytoPolicy,
+  updatePolicies,
+} from './utils';
+
+export const loadFilteredPoliciesFromCSV = async (
+  policyFile: string,
+  enf: Enforcer,
+  entityRef: string,
+  resourceType: string,
+  action: string,
+) => {
+  const fileEnf = await newEnforcer(
+    newModelFromString(MODEL),
+    new FileAdapter(policyFile),
+  );
+
+  const roles = await enf.getFilteredGroupingPolicy(0, entityRef);
+
+  const policies: string[][] = [];
+  const enforcerPolicies: string[][] = [];
+
+  for (const role of roles) {
+    const policyByRole = await fileEnf.getFilteredPolicy(
+      0,
+      role[1],
+      resourceType,
+      action,
+    );
+    policies.push(...policyByRole);
+    const enforcerPolicy = await enf.getFilteredPolicy(
+      0,
+      role[1],
+      resourceType,
+      action,
+    );
+    enforcerPolicies.push(...enforcerPolicy);
+  }
+
+  if (isEqual(policies, enforcerPolicies)) {
+    return;
+  }
+
+  if (policies.length === 0) {
+    policies.push(
+      ...(await fileEnf.getFilteredPolicy(1, resourceType, action)),
+    );
+  }
+
+  for (const policy of policies) {
+    const err = validatePolicy(transformArraytoPolicy(policy));
+    if (err) {
+      throw new Error(
+        `Failed to validate policy from file ${policyFile}. Cause: ${err.message}`,
+      );
+    }
+
+    await checkForDuplicatePolicies(fileEnf, policy, policyFile);
+
+    // Potential old policy that might need to be removed
+    const tempPolicy = [
+      policy.at(0)!,
+      policy.at(1)!,
+      policy.at(2)!,
+      policy.at(3) === 'deny' ? 'allow' : 'deny',
+    ];
+
+    // Ensure that the fileEnforcer also doesn't have the flip effect as well
+    if (await fileEnf.hasPolicy(...tempPolicy)) {
+      throw new Error(
+        `Duplicate policy ${policy[0]}, ${policy[1]}, ${policy[2]} with different actions found in the file ${policyFile}`,
+      );
+    }
+
+    await updatePolicies(enf, tempPolicy, policy);
+  }
+
+  // Policies that are no longer in the file need to be removed from the enforcer
+  for (const policy of enforcerPolicies) {
+    if (!(await fileEnf.hasPolicy(...policy))) {
+      await enf.removePolicy(...policy);
+    }
+  }
+};
+
+export const loadFilteredGroupingPoliciesFromCSV = async (
+  policyFile: string,
+  enf: Enforcer,
+  entityRef: string,
+) => {
+  const roleIssues: string[][] = [];
+  const fileEnf = await newEnforcer(
+    newModelFromString(MODEL),
+    new FileAdapter(policyFile),
+  );
+
+  const roles = await fileEnf.getFilteredGroupingPolicy(0, entityRef);
+
+  const enforcerRoles = await enf.getFilteredGroupingPolicy(0, entityRef);
+
+  if (isEqual(roles, enforcerRoles)) {
+    return;
+  }
+
+  for (const role of roles) {
+    await checkForDuplicateGroupPolicies(fileEnf, role, policyFile);
+
+    const err = validateEntityReference(role[1]);
+    if (err) {
+      throw new Error(
+        `Failed to validate group policy from file ${policyFile}. Cause: ${err.message}`,
+      );
+    }
+
+    // Role exists in the file but not the enforcer
+    if (!(await enf.hasGroupingPolicy(...role))) {
+      enf.addGroupingPolicy(...role);
+    }
+  }
+
+  for (const role of enforcerRoles) {
+    // This is to catch stray issues with roles that have problems with their users
+    roleIssues.push(...(await fileEnf.getFilteredGroupingPolicy(1, role[1])));
+
+    // Role exists in the enforcer but not the file
+    // Remove from enforcer
+    if (!(await fileEnf.hasGroupingPolicy(...role))) {
+      enf.removeGroupingPolicy(...role);
+    }
+  }
+
+  for (const role of roleIssues) {
+    const err = validateEntityReference(role[0]);
+    if (err) {
+      throw new Error(
+        `Failed to validate group policy from file ${policyFile}. Cause: ${err.message}`,
+      );
+    }
+  }
+};
+
+export const loadPoliciesFromCSV = async (
+  preDefinedPoliciesFile: string,
+  enf: Enforcer,
+) => {
+  const fileEnf = await newEnforcer(
+    newModelFromString(MODEL),
+    new FileAdapter(preDefinedPoliciesFile),
+  );
+  const policies = await fileEnf.getPolicy();
+  for (const policy of policies) {
+    const err = validateEntityReference(policy[0]);
+    if (err) {
+      throw new Error(
+        `Failed to validate policy from file ${preDefinedPoliciesFile}. Cause: ${err.message}`,
+      );
+    }
+
+    if (!(await enf.hasPolicy(...policy))) {
+      await enf.addPolicy(...policy);
+    } else {
+      throw new Error(
+        `Duplicate policy ${policy} found in the file ${preDefinedPoliciesFile}`,
+      );
+    }
+  }
+
+  const groupPolicies = await fileEnf.getGroupingPolicy();
+  for (const groupPolicy of groupPolicies) {
+    let err = validateEntityReference(groupPolicy[0]);
+    if (err) {
+      throw new Error(
+        `Failed to validate group policy from file ${preDefinedPoliciesFile}. Cause: ${err.message}`,
+      );
+    }
+    err = validateEntityReference(groupPolicy[1]);
+    if (err) {
+      throw new Error(
+        `Failed to validate group policy from file ${preDefinedPoliciesFile}. Cause: ${err.message}`,
+      );
+    }
+    if (!(await enf.hasGroupingPolicy(...groupPolicy))) {
+      await enf.addGroupingPolicy(...groupPolicy);
+    } else {
+      throw new Error(
+        `Duplicate grouping policy ${groupPolicy} found in the file ${preDefinedPoliciesFile}`,
+      );
+    }
+  }
+};

--- a/plugins/rbac-backend/src/helpers/utils.ts
+++ b/plugins/rbac-backend/src/helpers/utils.ts
@@ -1,0 +1,55 @@
+import { Enforcer } from 'casbin';
+
+import { RoleBasedPolicy } from '@janus-idp/backstage-plugin-rbac-common';
+
+// Update polices ->
+// remove the old policy that is no longer in the enforcer,
+// add the new policy
+export const updatePolicies = async (
+  enf: Enforcer,
+  oldPolicy: string[],
+  newPolicy: string[],
+): Promise<void> => {
+  if (await enf.hasPolicy(...oldPolicy)) {
+    await enf.removePolicy(...oldPolicy);
+  }
+
+  if (!(await enf.hasPolicy(...newPolicy))) {
+    await enf.addPolicy(...newPolicy);
+  }
+};
+
+export const checkForDuplicatePolicies = async (
+  fileEnf: Enforcer,
+  policy: string[],
+  policyFile: string,
+): Promise<void> => {
+  const duplicates = await fileEnf.getFilteredPolicy(0, ...policy);
+
+  if (duplicates.length > 1) {
+    throw new Error(
+      `Duplicate policy ${policy} found in the file ${policyFile}`,
+    );
+  }
+};
+
+export const checkForDuplicateGroupPolicies = async (
+  fileEnf: Enforcer,
+  policy: string[],
+  policyFile: string,
+): Promise<void> => {
+  const duplicates = await fileEnf.getFilteredGroupingPolicy(0, ...policy);
+
+  if (duplicates.length > 1) {
+    throw new Error(
+      `Duplicate grouping policy ${policy} found in the file ${policyFile}`,
+    );
+  }
+};
+
+export const transformArraytoPolicy = (
+  policyArray: string[],
+): RoleBasedPolicy => {
+  const [entityReference, permission, policy, effect] = policyArray;
+  return { entityReference, permission, policy, effect };
+};

--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -106,7 +106,10 @@ describe('RBACPermissionPolicy Tests', () => {
                 p, user:default/known_user, test.resource.deny, use, allow
         `,
       );
-      const csvPermFile = resolve(__dirname, './test/data/rbac-policy.csv');
+      const csvPermFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/rbac-policy.csv',
+      );
       const config = new ConfigReader({
         permission: {
           rbac: {

--- a/plugins/rbac-backend/src/service/test/data/rbac-policy.csv
+++ b/plugins/rbac-backend/src/service/test/data/rbac-policy.csv
@@ -1,6 +1,0 @@
-
-g, user:default/guest, role:default/catalog-writer
-
-p, role:default/catalog-writer, catalog-entity, update, allow
-p, user:default/guest, catalog-entity, read, allow
-p, user:default/guest, catalog.entity.create, use, allow


### PR DESCRIPTION
## Description

This PR introduces new functionality to facilitate the reloading of permission policies sourced from the CSV file. The issue at hand was the necessity of restarting the server every time there was an update to the permission policies in the CSV, which was quite inconvenient. The added feature enables the dynamic reloading of permission policies and roles directly from the CSV.

It leverages information provided by the permission framework (entity reference, permission, policy). This approach allows us to focus solely on roles associated with the entity reference in the CSV, subsequently retrieving permissions linked to that role, matching the given permission and policy. The aim is to enhance efficiency by selectively reloading relevant portions of the file, rather than the entire dataset.

## Fixes

- Fixes #908 

## How to test changes / Special notes to the reviewer

1. Create an RBAC permission policy CSV file
```csv
g, user:default/<your-user>, role:default/test

p, role:default/test, catalog-entity, read, allow
```
2. Update app-config to include your CSV file
```yaml
permission:
  enabled: true
  rbac:
    policies-csv-file: ./some/path/<permission-policy>.csv
```
3. Start the server and notice that you can read catalog entities
4. update the read permission in the CSV file from `allow` to `deny`
5. Notice that you can no longer read the catalog entities

***

The bulk of this work is finished. Nevertheless, a lingering issue with duplication still requires attention. If a permission policy initially comes from the REST API and is subsequently added in the CSV file, it triggers a problem. We anticipate that resolving [issue #776](https://github.com/janus-idp/backstage-showcase/issues/776) will give us a mechanism to determine the origin of a permission policy, whether it stems from the CSV file or the REST API.

Also, I would like to test how this works with bulk adding and editing using Casbin and the REST API. Currently, the REST API allows for the creation of roles, and will allow for the creation of permissions soon, in bulk. I want to test this after the mention issue is solved to ensure that there are no problems.

***