### PR TITLE
chore: remove post-ff labeler

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -10,15 +10,3 @@ jobs:
     with:
       project_id: 2
     secrets: inherit
-
-  # add post-FF label to every new issue, to track issues discovered after FF
-  # This is temporary and it will be removed after the release
-  add-post-ff-label:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - run: |
-          gh issue --repo ${{github.repository}} edit ${{github.event.issue.number}} --add-label "post-FF"
-        env:
-          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
we don't need this anymore