### PR TITLE
fix: also publish the `dist-dynamic` packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,12 @@
           "successComment": false,
           "releasedLabels": false
         }
+      ],
+      [
+        "@semantic-release/exec",
+        {
+          "successCmd": "if [ -d 'dist-dynamic' ]; then echo 'publishing backend derived package ...' && cd dist-dynamic && npm publish --ignore-scripts --access public ; fi"
+        }
       ]
     ]
   }


### PR DESCRIPTION
## Description

When publishing the new release, we would like to also publish the derived `dist-dynamic` package for backend plugins.

## Which issue(s) does this PR fix

No issue. It is a new attempt at doing what was reverted in commit https://github.com/janus-idp/backstage-plugins/commit/647f7b7c04db6b694a0a0c16279dd4d18667b86a

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
