### PR TITLE
fix(ci): auth for the `dist-dynamic` npm publish

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -12,7 +12,6 @@ runs:
       with:
         node-version-file: '.nvmrc'
         cache: 'yarn'
-        registry-url: 'https://registry.npmjs.org'
 
     - name: Setup local Turbo cache
       uses: dtinth/setup-github-actions-caching-for-turbo@v1

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -32,6 +32,12 @@ jobs:
       - name: Build all packages
         uses: ./.github/actions/build
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Release via semantic-release
         run: |
           npm config set workspaces-update false


### PR DESCRIPTION
Fix auth for the `dist-dynamic` npm publish by adding a second, distinct `setup-node` steps.