### PR TITLE
fix(ci): auth for the `dist-dynamic` `npm publish`

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
       [
         "@semantic-release/exec",
         {
-          "successCmd": "if [ -d 'dist-dynamic' ]; then echo 'publishing backend derived package ...' && cd dist-dynamic && npm publish --ignore-scripts --access public ; fi"
+          "successCmd": "if [ -d 'dist-dynamic' ]; then echo 'publishing backend derived package ...' && cd dist-dynamic && npm publish --registry https://registry.npmjs.org/ --ignore-scripts --access public ; fi"
         }
       ]
     ]


### PR DESCRIPTION
Fix the auth for the `dist-dynamic` `npm publish` by explicitly specifying the npms registry,
to avoid it to be changed to the https://registry.yarnpkg.com/ one by default inside the yarn release process.