### PR TITLE
fix(ci): remove scripts before `npm publish` in `dist-dynamic`

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
       [
         "@semantic-release/exec",
         {
-          "successCmd": "if [ -d 'dist-dynamic' ]; then echo 'publishing backend derived package ...' && cd dist-dynamic && npm publish --registry https://registry.npmjs.org/ --ignore-scripts --access public ; fi"
+          "successCmd": "if [ -d 'dist-dynamic' ]; then echo 'publishing backend derived package ...' && cd dist-dynamic && npm pkg delete scripts && npm publish --registry https://registry.npmjs.org/ --access public ; fi"
         }
       ]
     ]


### PR DESCRIPTION
The `npm publish` call in the `dist-dynamic` seems to be running the various scripts, which is not expected, and fails for some plugins. Let's remove the scripts just before pushing.