### PR TITLE
fix(rbac): add role validation for create role

### DIFF
--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -1175,7 +1175,7 @@ describe('REST policies api', () => {
       expect(result.statusCode).toBe(400);
       expect(result.body.error).toEqual({
         name: 'InputError',
-        message: `Invalid role definition. Cause: Unsupported kind x. List supported values ["user", "group", "role"]`,
+        message: `Invalid role definition. Cause: Unsupported kind x. Supported value should be "role"`,
       });
     });
 

--- a/plugins/rbac-backend/src/service/policies-validation.ts
+++ b/plugins/rbac-backend/src/service/policies-validation.ts
@@ -37,12 +37,17 @@ export function validateRole(role: Role): Error | undefined {
     return new Error(`'name' field must not be empty`);
   }
 
+  let err = validateEntityReference(role.name);
+  if (err) {
+    return err;
+  }
+
   if (!role.memberReferences || role.memberReferences.length === 0) {
     return new Error(`'memberReferences' field must not be empty`);
   }
 
   for (const member of role.memberReferences) {
-    const err = validateEntityReference(member);
+    err = validateEntityReference(member);
     if (err) {
       return err;
     }


### PR DESCRIPTION
## Description

This PR fixes the issue of missing validation on the role name in the POST and PUT methods for roles. This also adds a couple of additional unit tests to get `policies-rest-api.ts` to 100% test coverage.

## Fixes

- Fixes #943 

## How to test changes / Special notes to the reviewer

1. Update app-config to include your user as admin
```yaml
permission:
  enabled: true
  rbac:
    admin:
      users:
        - name: user:default/<USERNAME>
```
2. Log in using GitHub auth
3. Get token and export it in the terminal with `export token=...token...`
4. Use curl commands to test validation

wrong kind
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "x:default/test" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing name
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "role:default/" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing name and namespace
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "role:" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing namespace
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "role:/test" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing kind
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "default/test" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing kind and namespace
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "test" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing kind and name
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "default/" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`