### PR TITLE
feat(rbac): cleanup policies when a role is deleted

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -36,7 +36,7 @@
     "@backstage/plugin-search-backend-module-pg": "^0.5.15",
     "@backstage/plugin-search-backend-node": "^1.2.10",
     "@backstage/plugin-techdocs-backend": "^1.8.0",
-    "@janus-idp/backstage-plugin-rbac-backend": "^1.6.4",
+    "@janus-idp/backstage-plugin-rbac-backend": "^2.0.0",
     "better-sqlite3": "^9.0.0",
     "dockerode": "^4.0.0",
     "express": "^4.18.2",

--- a/plugins/rbac/dev/index.tsx
+++ b/plugins/rbac/dev/index.tsx
@@ -44,14 +44,14 @@ class MockRBACApi implements RBACAPI {
     return this.resources;
   }
 
-  async getPolicies(): Promise<RoleBasedPolicy[]> {
-    return mockPolicies;
-  }
-
   async getAssociatedPolicies(
     entityReference: string,
   ): Promise<RoleBasedPolicy[]> {
     return mockPolicies.filter(pol => pol.entityReference === entityReference);
+  }
+
+  async getPolicies(): Promise<RoleBasedPolicy[]> {
+    return mockPolicies;
   }
 
   async getUserAuthorization(): Promise<{ status: string }> {
@@ -90,12 +90,15 @@ class MockRBACApi implements RBACAPI {
     return mockPermissionPolicies;
   }
 
-  async deletePolicy(
+  async deletePolicies(
     _entityRef: string,
-    _permission: string,
     _policies: Policy[],
-  ): Promise<number> {
-    return 204;
+  ): Promise<Response> {
+    return {
+      ok: true,
+      status: 204,
+      statusText: 'Deleted Successfully',
+    } as Response;
   }
 
   async createRole(_role: Role): Promise<Response> {

--- a/plugins/rbac/src/components/DeleteRole.tsx
+++ b/plugins/rbac/src/components/DeleteRole.tsx
@@ -29,7 +29,7 @@ const DeleteRole = ({
     <Tooltip title={tooltip || ''}>
       <span data-testid={dataTestId}>
         <IconButton
-          color="primary"
+          color="inherit"
           onClick={() => openDialog(roleName)}
           aria-label="Delete"
           disabled={disable}

--- a/plugins/rbac/src/components/EditRole.tsx
+++ b/plugins/rbac/src/components/EditRole.tsx
@@ -27,6 +27,7 @@ const EditRole = ({
     <Tooltip title={tooltip || ''}>
       <span data-testid={dataTestId}>
         <IconButton
+          color="inherit"
           component={Link}
           aria-label="Update"
           disabled={disable}

--- a/plugins/rbac/src/components/RbacPage.test.tsx
+++ b/plugins/rbac/src/components/RbacPage.test.tsx
@@ -37,7 +37,7 @@ describe('RbacPage', () => {
     mockUseRoles.mockReturnValue({
       loading: true,
       data: [],
-      retry: () => {},
+      retry: jest.fn(),
       createRoleAllowed: false,
     });
     await renderInTestApp(<RbacPage />);

--- a/plugins/rbac/src/components/RolesList.test.tsx
+++ b/plugins/rbac/src/components/RolesList.test.tsx
@@ -63,7 +63,7 @@ describe('RolesList', () => {
     mockUseRoles.mockReturnValue({
       loading: false,
       data: useRolesMockData,
-      retry: () => {},
+      retry: jest.fn(),
       createRoleAllowed: false,
     });
     const { queryByText } = await renderInTestApp(<RolesList />);
@@ -79,7 +79,7 @@ describe('RolesList', () => {
     mockUseRoles.mockReturnValue({
       loading: false,
       data: [],
-      retry: () => {},
+      retry: jest.fn(),
       createRoleAllowed: false,
     });
     const { getByTestId } = await renderInTestApp(<RolesList />);
@@ -94,7 +94,7 @@ describe('RolesList', () => {
     mockUseRoles.mockReturnValue({
       loading: false,
       data: useRolesMockData,
-      retry: () => {},
+      retry: jest.fn(),
       createRoleAllowed: false,
     });
     const { getAllByTestId, getByText } = await renderInTestApp(<RolesList />);
@@ -125,7 +125,7 @@ describe('RolesList', () => {
           },
         },
       ],
-      retry: () => {},
+      retry: jest.fn(),
       createRoleAllowed: false,
     });
     const { getAllByTestId } = await renderInTestApp(<RolesList />);
@@ -156,7 +156,7 @@ describe('RolesList', () => {
           },
         },
       ],
-      retry: () => {},
+      retry: jest.fn(),
       createRoleAllowed: true,
     });
     const { getAllByTestId } = await renderInTestApp(<RolesList />);
@@ -170,7 +170,7 @@ describe('RolesList', () => {
     mockUseRoles.mockReturnValue({
       loading: false,
       data: useRolesMockData,
-      retry: () => {},
+      retry: jest.fn(),
       createRoleAllowed: false,
     });
     const { getByTestId } = await renderInTestApp(<RolesList />);
@@ -186,7 +186,7 @@ describe('RolesList', () => {
     mockUseRoles.mockReturnValue({
       loading: false,
       data: useRolesMockData,
-      retry: () => {},
+      retry: jest.fn(),
       createRoleAllowed: true,
     });
     const { getByTestId } = await renderInTestApp(<RolesList />);


### PR DESCRIPTION
**Resolves:**
https://github.com/janus-idp/backstage-plugins/issues/1005

**GIF/ Screenshot:**
https://github.com/janus-idp/backstage-plugins/assets/22490998/13df0b7c-a1a5-43a8-8204-cd47001bb070

When cleaning up Policies fail

<img width="1727" alt="Screenshot 2023-12-14 at 12 39 22 PM" src="https://github.com/janus-idp/backstage-plugins/assets/22490998/15601591-9f71-4933-b80d-2c1b105aac33">

When role deletion fails
<img width="1727" alt="Screenshot 2023-12-14 at 12 39 49 PM" src="https://github.com/janus-idp/backstage-plugins/assets/22490998/74b77405-f17b-4bd3-876e-2e264116b106">
