### PR TITLE
fix(rbac): fix role validation

### DIFF
--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -94,7 +94,7 @@ const addPredefinedPoliciesAndGroupPolicies = async (
         `Failed to validate group policy from file ${preDefinedPoliciesFile}. Cause: ${err.message}`,
       );
     }
-    err = validateEntityReference(groupPolicy[1]);
+    err = validateEntityReference(groupPolicy[1], true);
     if (err) {
       throw new Error(
         `Failed to validate group policy from file ${preDefinedPoliciesFile}. Cause: ${err.message}`,

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -318,7 +318,7 @@ export class PolicesServer {
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403
       }
-      const roleEntityRef = this.getEntityReference(request);
+      const roleEntityRef = this.getEntityReference(request, true);
 
       const role = await this.enforcer.getFilteredGroupingPolicy(
         1,
@@ -385,7 +385,7 @@ export class PolicesServer {
       if (decision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError(); // 403
       }
-      const roleEntityRef = this.getEntityReference(request);
+      const roleEntityRef = this.getEntityReference(request, true);
 
       const oldRoleRaw = request.body.oldRole;
 
@@ -488,7 +488,7 @@ export class PolicesServer {
           throw new NotAllowedError(); // 403
         }
 
-        const roleEntityRef = this.getEntityReference(request);
+        const roleEntityRef = this.getEntityReference(request, true);
 
         if (request.query.memberReferences) {
           const memberReferences = this.getFirstQuery(
@@ -641,13 +641,13 @@ export class PolicesServer {
     return router;
   }
 
-  getEntityReference(request: Request): string {
+  getEntityReference(request: Request, role?: boolean): string {
     const kind = request.params.kind;
     const namespace = request.params.namespace;
     const name = request.params.name;
     const entityRef = `${kind}:${namespace}/${name}`;
 
-    const err = validateEntityReference(entityRef);
+    const err = validateEntityReference(entityRef, role);
     if (err) {
       throw new InputError(err.message);
     }

--- a/plugins/rbac-backend/src/service/policies-validation.ts
+++ b/plugins/rbac-backend/src/service/policies-validation.ts
@@ -35,12 +35,17 @@ export function validateRole(role: Role): Error | undefined {
     return new Error(`'name' field must not be empty`);
   }
 
+  let err = validateEntityReference(role.name, true);
+  if (err) {
+    return err;
+  }
+
   if (!role.memberReferences || role.memberReferences.length === 0) {
     return new Error(`'memberReferences' field must not be empty`);
   }
 
   for (const member of role.memberReferences) {
-    const err = validateEntityReference(member);
+    err = validateEntityReference(member);
     if (err) {
       return err;
     }
@@ -56,7 +61,10 @@ function isValidEffectValue(effect: string): boolean {
 }
 
 // We supports only full form entity reference: [<kind>:][<namespace>/]<name>
-export function validateEntityReference(entityRef?: string): Error | undefined {
+export function validateEntityReference(
+  entityRef?: string,
+  role?: boolean,
+): Error | undefined {
   if (!entityRef) {
     return new Error(`'entityReference' must not be empty`);
   }
@@ -72,6 +80,12 @@ export function validateEntityReference(entityRef?: string): Error | undefined {
   if (entityRefFull !== entityRef) {
     return new Error(
       `entity reference '${entityRef}' does not match the required format [<kind>:][<namespace>/]<name>. Provide, please, full entity reference.`,
+    );
+  }
+
+  if (role && entityRefCompound.kind !== 'role') {
+    return new Error(
+      `Unsupported kind ${entityRefCompound.kind}. Supported value should be "role"`,
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5925,6 +5925,34 @@
     "@backstage/config" "^1.1.1"
     deep-freeze "^0.0.1"
 
+"@janus-idp/backstage-plugin-rbac-backend@^1.6.4":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@janus-idp/backstage-plugin-rbac-backend/-/backstage-plugin-rbac-backend-1.7.1.tgz#dfcd6bbf5357db3c88f6223d70ab0f6051abed55"
+  integrity sha512-KWFBfFfmteA//Lq/NH79LHXOCCWBHNsoakSMhaFnACt4R1ChlmgOsg0x56jKpIfE/5RqjYetxEDDhX6Pmx2sWw==
+  dependencies:
+    "@backstage/backend-common" "^0.19.8"
+    "@backstage/backend-plugin-api" "^0.5.4"
+    "@backstage/catalog-client" "^1.4.5"
+    "@backstage/catalog-model" "^1.4.3"
+    "@backstage/config" "^1.1.1"
+    "@backstage/core-plugin-api" "^1.7.0"
+    "@backstage/errors" "^1.2.3"
+    "@backstage/plugin-auth-node" "^0.4.0"
+    "@backstage/plugin-permission-backend" "^0.5.29"
+    "@backstage/plugin-permission-common" "^0.7.9"
+    "@backstage/plugin-permission-node" "^0.7.17"
+    "@dagrejs/graphlib" "^2.1.13"
+    "@janus-idp/backstage-plugin-rbac-common" "1.2.0"
+    casbin "^5.27.1"
+    express "^4.18.2"
+    express-promise-router "^4.1.1"
+    knex "^2.0.0"
+    lodash "^4.17.21"
+    qs "^6.11.2"
+    typeorm-adapter "^1.6.1"
+    winston "^3.11.0"
+    yn "^4.0.0"
+
 "@jest/console@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.7.0.tgz#cd4822dbdb84529265c5a2bdb529a3c9cc950ffc"


### PR DESCRIPTION
## Description

This PR fixes the issue of missing validation on the role name in the POST and PUT methods for roles. This also adds a couple of additional unit tests to get `policies-rest-api.ts` to 100% test coverage.

## Fixes

- Fixes #943 

## How to test changes / Special notes to the reviewer

1. Update app-config to include your user as admin
```yaml
permission:
  enabled: true
  rbac:
    admin:
      users:
        - name: user:default/<USERNAME>
```
2. Log in using GitHub auth
3. Get token and export it in the terminal with `export token=...token...`
4. Use curl commands to test validation

wrong kind
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "x:default/test" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing name
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "role:default/" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing name and namespace
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "role:" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing namespace
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "role:/test" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing kind
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "default/test" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing kind and namespace
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "test" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

Missing kind and name
`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences": [ "user:default/test", "user:default/test2" ], "name": "default/" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`