### PR TITLE
fix(keycloak): fix #591: Cleanup some small code smells in Keycloak plugin

### DIFF
--- a/plugins/keycloak-backend/src/lib/read.test.ts
+++ b/plugins/keycloak-backend/src/lib/read.test.ts
@@ -88,7 +88,8 @@ describe('parseGroup', () => {
     };
     const entity = await parseGroup(groupsFixture[0], 'test', transformer);
 
-    expect(entity!.metadata.name).toEqual('biggroup_test');
+    expect(entity).toBeDefined();
+    expect(entity?.metadata.name).toEqual('biggroup_test');
   });
 });
 
@@ -134,7 +135,8 @@ describe('parseUser', () => {
     };
     const entity = await parseUser(usersFixture[0], 'test', [], transformer);
 
-    expect(entity!.metadata.name).toEqual('jamesdoe_test');
+    expect(entity).toBeDefined();
+    expect(entity?.metadata.name).toEqual('jamesdoe_test');
   });
 });
 
@@ -150,6 +152,7 @@ describe('getEntities', () => {
 
     expect(users).toHaveLength(3);
   });
+
   it('should fetch all users with pagination', async () => {
     const client = new KeycloakAdminClientMock() as unknown as KcAdminClient;
 

--- a/plugins/keycloak-backend/src/lib/read.ts
+++ b/plugins/keycloak-backend/src/lib/read.ts
@@ -42,7 +42,7 @@ export const parseGroup = async (
   realm: string,
   groupTransformer?: GroupTransformer,
 ): Promise<GroupEntity | undefined> => {
-  const transformer = groupTransformer || noopGroupTransformer;
+  const transformer = groupTransformer ?? noopGroupTransformer;
   const entity: GroupEntity = {
     apiVersion: 'backstage.io/v1beta1',
     kind: 'Group',
@@ -59,7 +59,7 @@ export const parseGroup = async (
         displayName: keycloakGroup.name!,
       },
       // children, parent and members are updated again after all group and user transformers applied.
-      children: keycloakGroup.subGroups?.map(g => g.name!) || [],
+      children: keycloakGroup.subGroups?.map(g => g.name!) ?? [],
       parent: keycloakGroup.parent,
       members: keycloakGroup.members,
     },
@@ -75,7 +75,7 @@ export const parseUser = async (
 
   userTransformer?: UserTransformer,
 ): Promise<UserEntity | undefined> => {
-  const transformer = userTransformer || noopUserTransformer;
+  const transformer = userTransformer ?? noopUserTransformer;
   const entity: UserEntity = {
     apiVersion: 'backstage.io/v1beta1',
     kind: 'User',
@@ -230,11 +230,11 @@ export const readKeycloakRealm = async (
     entity.spec.members =
       g.entity.spec.members?.map(
         m => parsedUsers.find(p => p.username === m)?.entity.metadata.name!,
-      ) || [];
+      ) ?? [];
     entity.spec.children =
       g.entity.spec.children?.map(
         c => parsedGroups.find(p => p.name === c)?.entity.metadata.name!,
-      ) || [];
+      ) ?? [];
     entity.spec.parent = parsedGroups.find(p => p.name === entity.spec.parent)
       ?.entity.metadata.name;
     return entity;

--- a/plugins/keycloak-backend/src/providers/KeycloakOrgEntityProvider.ts
+++ b/plugins/keycloak-backend/src/providers/KeycloakOrgEntityProvider.ts
@@ -203,12 +203,16 @@ export class KeycloakOrgEntityProvider implements EntityProvider {
         username: provider.username,
         password: provider.password,
       };
-    } else {
+    } else if (provider.clientId && provider.clientSecret) {
       credentials = {
         grantType: 'client_credentials',
-        clientId: provider.clientId!,
+        clientId: provider.clientId,
         clientSecret: provider.clientSecret,
       };
+    } else {
+      throw new Error(
+        `username and password or clientId and clientSecret must be provided.`,
+      );
     }
 
     await kcAdminClient.auth(credentials);


### PR DESCRIPTION
Part of #583, this PR fix #591: Cleanup 4 code smells reported by sonarcloud:

* https://sonarcloud.io/code?id=janus-idp_backstage-plugins&selected=janus-idp_backstage-plugins%3Aplugins%2Fkeycloak-backend%2Fsrc%2Flib%2Fconfig.ts
  * `readProviderConfigs` was to complex. Extracted the code that reads each config entry into `readProviderConfig`
* https://sonarcloud.io/code?id=janus-idp_backstage-plugins&selected=janus-idp_backstage-plugins%3Aplugins%2Fkeycloak-backend%2Fsrc%2Flib%2Fread.test.ts
  * used `entity?.` instead of `entity!.` to solve the sonar issue. Added a "is defined" condition.
* https://sonarcloud.io/code?id=janus-idp_backstage-plugins&selected=janus-idp_backstage-plugins%3Aplugins%2Fkeycloak-backend%2Fsrc%2Fproviders
  * replace the enforcing of the the clientId (with !), added an if statement that check that it exist 

Tested the Keycloak plugin locally and it still works as expected and imported groups and users:

![image](https://github.com/janus-idp/backstage-plugins/assets/139310/5c147374-9841-4e26-8f7c-97d8370d2a6f)

![image](https://github.com/janus-idp/backstage-plugins/assets/139310/253a9f39-553b-4fea-a335-06599bb0279d)
