### PR TITLE
fix(openshift-image-registry): fix #596: Add mock data for test page and cleanup some small code smells

### DIFF
--- a/plugins/openshift-image-registry/README.md
+++ b/plugins/openshift-image-registry/README.md
@@ -4,6 +4,30 @@ The OpenShift Image Registry plugin displays all ImageStreams in an Openshift cl
 
 ## For administrators
 
+### Prerequisites
+
+The OpenShift Image Registry plugin requires read access to **_all_** `ImageStreams` and `ImageStreamTags` on a cluster. (Currently only a single cluster is supported.)
+
+You can create a `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding` with this commands.
+
+Please notice that the ServiceAccount will be created in your current namespace while the `ClusterRole` and `ClusterRoleBinding` giving access to all namespaces are cluster-wide resources.
+
+Additional information on these commands could be found in the [OpenShift Container Platform authentication and authorization documentation](https://docs.openshift.com/container-platform/latest/authentication/index.html).
+
+```console
+oc create serviceaccount janus-idp-openshift-image-registry-reader
+
+oc create clusterrole janus-idp-openshift-image-registry-reader --verb=get,watch,list --resource=imagestreams --resource=imagestreamtags
+
+oc adm policy add-cluster-role-to-user janus-idp-openshift-image-registry-reader -z janus-idp-openshift-image-registry-reader
+```
+
+And finally you can use this command to create a token that is valid for one week:
+
+```console
+oc create token --duration=168h janus-idp-openshift-image-registry-reader
+```
+
 ### Installation
 
 Run the following command to install the OpenShift Image Registry plugin:
@@ -46,7 +70,7 @@ yarn workspace app add @janus-idp/backstage-plugin-openshift-image-registry
              to="openshift-image-registry"
              text="Image Registry"
            />
-           ;{/* highlight-add-end */}
+           {/* highlight-add-end */}
          </SidebarGroup>
          {/* ... */}
        </Sidebar>

--- a/plugins/openshift-image-registry/dev/index.tsx
+++ b/plugins/openshift-image-registry/dev/index.tsx
@@ -1,17 +1,97 @@
 import React from 'react';
 
 import { createDevApp } from '@backstage/dev-utils';
+import { TestApiProvider } from '@backstage/test-utils';
 
+import {
+  openshiftImageRegistryApiRef,
+  OpenshiftImageRegistryApiV1,
+} from '../src/api';
 import {
   OpenshiftImageRegistryPage,
   openshiftImageRegistryPlugin,
 } from '../src/plugin';
+// Contains just the openshift namespace for now
+import namespaces from './namespaces.json';
+// Extracted from an OpenShift 4.13 cluster, reduced to Go, Java, Node.js and Python entries
+// oc get -n openshift \
+//   imagestream/golang \
+//   imagestream/java \
+//   imagestream/nodejs \
+//   imagestream/python \
+//   -o json | jq . \
+//   > plugins/openshift-image-registry/dev/openshift-imagestreams.json
+import openshiftImageStreams from './openshift-imagestreams.json';
+// The origin list view doesn't contain all neccessary infomation, so this list view
+// is build from three API calls to match the data in openshift-imagestreams.json
+//
+// oc get -n openshift \
+//   imagestreamtag/golang:1.18-ubi7 \
+//   imagestreamtag/java:11 \
+//   imagestreamtag/nodejs:14-ubi7 \
+//   imagestreamtag/python:2.7-ubi8 \
+//   -o json | jq . \
+//   > plugins/openshift-image-registry/dev/openshift-imagestreamtags.json
+import openshiftImageStreamTags from './openshift-imagestreamtags.json';
+
+class MockOpenshiftImageRegistryApi implements OpenshiftImageRegistryApiV1 {
+  async getAllImageStreams(): Promise<any> {
+    return openshiftImageStreams.items;
+  }
+  async getImageStreams(ns: string): Promise<any> {
+    return openshiftImageStreams.items.filter(
+      item => item.metadata.namespace === ns,
+    );
+  }
+  async getImageStream(ns: string, imageName: string): Promise<any> {
+    return openshiftImageStreams.items.find(
+      item =>
+        item.metadata.namespace === ns && item.metadata.name === imageName,
+    );
+  }
+  async getImageStreamTags(ns: string, imageName: string): Promise<any> {
+    if (imageName.includes(':')) {
+      return openshiftImageStreamTags.items.find(
+        item =>
+          item.metadata.namespace === ns && item.metadata.name === imageName,
+      );
+    }
+    return openshiftImageStreamTags.items.find(
+      item =>
+        item.metadata.namespace === ns &&
+        (item.metadata.name === imageName ||
+          item.metadata.name.startsWith(`${imageName}:`)),
+    );
+  }
+  async getImageStreamTag(
+    ns: string,
+    imageName: string,
+    tag: string,
+  ): Promise<any> {
+    return openshiftImageStreamTags.items.find(
+      item =>
+        item.metadata.namespace === ns &&
+        item.metadata.name === `${imageName}:${tag}`,
+    );
+  }
+  async getNamespaces(): Promise<any> {
+    return namespaces.items;
+  }
+}
 
 createDevApp()
   .registerPlugin(openshiftImageRegistryPlugin)
   .addPage({
-    element: <OpenshiftImageRegistryPage />,
-    title: 'Root Page',
+    element: (
+      <TestApiProvider
+        apis={[
+          [openshiftImageRegistryApiRef, new MockOpenshiftImageRegistryApi()],
+        ]}
+      >
+        <OpenshiftImageRegistryPage />
+      </TestApiProvider>
+    ),
+    title: 'Image Registry',
     path: '/openshift-image-registry',
   })
   .render();

--- a/plugins/openshift-image-registry/dev/namespaces.json
+++ b/plugins/openshift-image-registry/dev/namespaces.json
@@ -1,0 +1,26 @@
+{
+  "kind": "NamespaceList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "81626349"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "openshift",
+        "uid": "e9c1249f-b300-4b43-8c10-cd8473280844",
+        "resourceVersion": "75916512",
+        "creationTimestamp": "2023-07-26T18:44:09Z",
+        "labels": {
+          "kubernetes.io/metadata.name": "openshift"
+        }
+      },
+      "spec": {
+        "finalizers": ["kubernetes"]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    }
+  ]
+}

--- a/plugins/openshift-image-registry/dev/openshift-imagestreams.json
+++ b/plugins/openshift-image-registry/dev/openshift-imagestreams.json
@@ -1,0 +1,1111 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "image.openshift.io/v1",
+      "kind": "ImageStream",
+      "metadata": {
+        "annotations": {
+          "openshift.io/display-name": "Go",
+          "openshift.io/image.dockerRepositoryCheck": "2023-07-26T18:56:46Z",
+          "samples.operator.openshift.io/version": "4.13.6"
+        },
+        "creationTimestamp": "2023-07-26T18:56:22Z",
+        "generation": 2,
+        "labels": {
+          "samples.operator.openshift.io/managed": "true"
+        },
+        "name": "golang",
+        "namespace": "openshift",
+        "resourceVersion": "14813",
+        "uid": "693949d1-2093-49ed-ae56-929acc790182"
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
+        },
+        "tags": [
+          {
+            "annotations": {
+              "description": "Build and run Go applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
+              "iconClass": "icon-go-gopher",
+              "openshift.io/display-name": "Go 1.18 (UBI 7)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/golang-ex.git",
+              "supports": "golang",
+              "tags": "builder,golang,go"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi7/go-toolset:1.18"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "1.18-ubi7",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Go applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
+              "iconClass": "icon-go-gopher",
+              "openshift.io/display-name": "Go 1.18 (UBI 8)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/golang-ex.git",
+              "supports": "golang",
+              "tags": "builder,golang,go"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/go-toolset:1.18"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "1.18-ubi8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Go applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
+              "iconClass": "icon-go-gopher",
+              "openshift.io/display-name": "Go 1.18 (UBI 9)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/golang-ex.git",
+              "supports": "golang",
+              "tags": "builder,golang,go"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi9/go-toolset:1.18"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "1.18-ubi9",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Go applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major version updates.",
+              "iconClass": "icon-go-gopher",
+              "openshift.io/display-name": "Go (Latest)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/golang-ex.git",
+              "supports": "golang",
+              "tags": "builder,golang,go"
+            },
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "1.18-ubi8"
+            },
+            "generation": 1,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "latest",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": "image-registry.openshift-image-registry.svc:5000/openshift/golang",
+        "publicDockerImageRepository": "default-route-openshift-image-registry.apps-crc.testing/openshift/golang",
+        "tags": [
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:46Z",
+                "dockerImageReference": "registry.redhat.io/ubi7/go-toolset@sha256:07addbabcfd72212a82efce053a70362a06925ee1522c4dd783be878ffad46cb",
+                "generation": 2,
+                "image": "sha256:07addbabcfd72212a82efce053a70362a06925ee1522c4dd783be878ffad46cb"
+              }
+            ],
+            "tag": "1.18-ubi7"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:46Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/go-toolset@sha256:6740d72db4de99ecb4652cff89a239242afd150d6ccf6ed0ebff89ffcbbc649e",
+                "generation": 2,
+                "image": "sha256:6740d72db4de99ecb4652cff89a239242afd150d6ccf6ed0ebff89ffcbbc649e"
+              }
+            ],
+            "tag": "1.18-ubi8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:46Z",
+                "dockerImageReference": "registry.redhat.io/ubi9/go-toolset@sha256:2861514e125903261aa0004883a7f7aeeb4c189b2d0d175372d1edc111942eda",
+                "generation": 2,
+                "image": "sha256:2861514e125903261aa0004883a7f7aeeb4c189b2d0d175372d1edc111942eda"
+              }
+            ],
+            "tag": "1.18-ubi9"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:46Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/go-toolset@sha256:6740d72db4de99ecb4652cff89a239242afd150d6ccf6ed0ebff89ffcbbc649e",
+                "generation": 2,
+                "image": "sha256:6740d72db4de99ecb4652cff89a239242afd150d6ccf6ed0ebff89ffcbbc649e"
+              }
+            ],
+            "tag": "latest"
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "image.openshift.io/v1",
+      "kind": "ImageStream",
+      "metadata": {
+        "annotations": {
+          "openshift.io/display-name": "Red Hat OpenJDK",
+          "openshift.io/image.dockerRepositoryCheck": "2023-07-26T18:56:48Z",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "samples.operator.openshift.io/version": "4.13.6",
+          "version": "1.4.17"
+        },
+        "creationTimestamp": "2023-07-26T18:56:22Z",
+        "generation": 2,
+        "labels": {
+          "samples.operator.openshift.io/managed": "true",
+          "xpaas": "1.4.17"
+        },
+        "name": "java",
+        "namespace": "openshift",
+        "resourceVersion": "14860",
+        "uid": "210e1300-206b-4f15-a169-edbeadca5d88"
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
+        },
+        "tags": [
+          {
+            "annotations": {
+              "description": "Build and run Java applications using Maven and OpenJDK 11.",
+              "iconClass": "icon-rh-openjdk",
+              "openshift.io/display-name": "Red Hat OpenJDK 11",
+              "sampleContextDir": "undertow-servlet",
+              "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+              "supports": "java:11,java",
+              "tags": "builder,java,openjdk,hidden",
+              "version": "11"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "11",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Java applications using Maven and OpenJDK 8.",
+              "iconClass": "icon-rh-openjdk",
+              "openshift.io/display-name": "Red Hat OpenJDK 8",
+              "sampleContextDir": "undertow-servlet",
+              "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+              "supports": "java:8,java",
+              "tags": "builder,java,openjdk,hidden",
+              "version": "8"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Java applications using Maven.",
+              "iconClass": "icon-rh-openjdk",
+              "openshift.io/display-name": "Java (Latest)",
+              "sampleContextDir": "undertow-servlet",
+              "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+              "supports": "java",
+              "tags": "builder,java,openjdk",
+              "version": "latest"
+            },
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "openjdk-17-ubi8"
+            },
+            "generation": 1,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "latest",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Java applications using Maven and OpenJDK 11.",
+              "iconClass": "icon-rh-openjdk",
+              "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL 7)",
+              "sampleContextDir": "undertow-servlet",
+              "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+              "supports": "java:11,java",
+              "tags": "builder,java,openjdk",
+              "version": "11"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "openjdk-11-el7",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Java applications using Maven and OpenJDK 11.",
+              "iconClass": "icon-rh-openjdk",
+              "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI 8)",
+              "sampleContextDir": "undertow-servlet",
+              "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+              "supports": "java:11,java",
+              "tags": "builder,java,openjdk",
+              "version": "11"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/openjdk-11:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "openjdk-11-ubi8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Java applications using Maven and OpenJDK 17.",
+              "iconClass": "icon-rh-openjdk",
+              "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI 8)",
+              "sampleContextDir": "undertow-servlet",
+              "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+              "supports": "java:17,java",
+              "tags": "builder,java,openjdk",
+              "version": "17"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/openjdk-17:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "openjdk-17-ubi8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Java applications using Maven and OpenJDK 8.",
+              "iconClass": "icon-rh-openjdk",
+              "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL 7)",
+              "sampleContextDir": "undertow-servlet",
+              "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+              "supports": "java:8,java",
+              "tags": "builder,java,openjdk",
+              "version": "8"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "openjdk-8-el7",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Java applications using Maven and OpenJDK 8.",
+              "iconClass": "icon-rh-openjdk",
+              "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI 8)",
+              "sampleContextDir": "undertow-servlet",
+              "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+              "supports": "java:8,java",
+              "tags": "builder,java,openjdk",
+              "version": "8"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/openjdk-8:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "openjdk-8-ubi8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": "image-registry.openshift-image-registry.svc:5000/openshift/java",
+        "publicDockerImageRepository": "default-route-openshift-image-registry.apps-crc.testing/openshift/java",
+        "tags": [
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:48Z",
+                "dockerImageReference": "registry.redhat.io/openjdk/openjdk-11-rhel7@sha256:a9158f829df4163cd1c25ab02b7e8a85fd968d15a24f3e8494e53a116b9d3bb6",
+                "generation": 2,
+                "image": "sha256:a9158f829df4163cd1c25ab02b7e8a85fd968d15a24f3e8494e53a116b9d3bb6"
+              }
+            ],
+            "tag": "11"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:48Z",
+                "dockerImageReference": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift@sha256:ea11ce0cc12305edec4b417799e657a1fddf0e05274dac2c92f5c00f1f6ada5c",
+                "generation": 2,
+                "image": "sha256:ea11ce0cc12305edec4b417799e657a1fddf0e05274dac2c92f5c00f1f6ada5c"
+              }
+            ],
+            "tag": "8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:48Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/openjdk-17@sha256:3b94ccfa422b8ba0014302a3cfc6916b69f0f5a9dfd757b6704049834d4ff0ae",
+                "generation": 2,
+                "image": "sha256:3b94ccfa422b8ba0014302a3cfc6916b69f0f5a9dfd757b6704049834d4ff0ae"
+              }
+            ],
+            "tag": "latest"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:48Z",
+                "dockerImageReference": "registry.redhat.io/openjdk/openjdk-11-rhel7@sha256:a9158f829df4163cd1c25ab02b7e8a85fd968d15a24f3e8494e53a116b9d3bb6",
+                "generation": 2,
+                "image": "sha256:a9158f829df4163cd1c25ab02b7e8a85fd968d15a24f3e8494e53a116b9d3bb6"
+              }
+            ],
+            "tag": "openjdk-11-el7"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:48Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/openjdk-11@sha256:425e2c7c355bea32be238aa2c7bdd363b6ab3709412bdf095efe28a8f6c07d84",
+                "generation": 2,
+                "image": "sha256:425e2c7c355bea32be238aa2c7bdd363b6ab3709412bdf095efe28a8f6c07d84"
+              }
+            ],
+            "tag": "openjdk-11-ubi8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:48Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/openjdk-17@sha256:3b94ccfa422b8ba0014302a3cfc6916b69f0f5a9dfd757b6704049834d4ff0ae",
+                "generation": 2,
+                "image": "sha256:3b94ccfa422b8ba0014302a3cfc6916b69f0f5a9dfd757b6704049834d4ff0ae"
+              }
+            ],
+            "tag": "openjdk-17-ubi8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:48Z",
+                "dockerImageReference": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift@sha256:ea11ce0cc12305edec4b417799e657a1fddf0e05274dac2c92f5c00f1f6ada5c",
+                "generation": 2,
+                "image": "sha256:ea11ce0cc12305edec4b417799e657a1fddf0e05274dac2c92f5c00f1f6ada5c"
+              }
+            ],
+            "tag": "openjdk-8-el7"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:48Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/openjdk-8@sha256:2f59ad75b66a3169b0b03032afb09aa3cfa531dbd844e3d3a562246e7d09c282",
+                "generation": 2,
+                "image": "sha256:2f59ad75b66a3169b0b03032afb09aa3cfa531dbd844e3d3a562246e7d09c282"
+              }
+            ],
+            "tag": "openjdk-8-ubi8"
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "image.openshift.io/v1",
+      "kind": "ImageStream",
+      "metadata": {
+        "annotations": {
+          "openshift.io/display-name": "Node.js",
+          "openshift.io/image.dockerRepositoryCheck": "2023-07-26T18:56:51Z",
+          "samples.operator.openshift.io/version": "4.13.6"
+        },
+        "creationTimestamp": "2023-07-26T18:56:22Z",
+        "generation": 2,
+        "labels": {
+          "samples.operator.openshift.io/managed": "true"
+        },
+        "name": "nodejs",
+        "namespace": "openshift",
+        "resourceVersion": "14915",
+        "uid": "9f67482c-1e83-42d5-a8eb-04099005ea27"
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
+        },
+        "tags": [
+          {
+            "annotations": {
+              "description": "Build and run Node.js 14 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+              "iconClass": "icon-nodejs",
+              "openshift.io/display-name": "Node.js 14 (UBI 7)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+              "tags": "builder,nodejs,hidden",
+              "version": "14"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi7/nodejs-14:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "14-ubi7",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Node.js 14 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+              "iconClass": "icon-nodejs",
+              "openshift.io/display-name": "Node.js 14 (UBI 8)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+              "tags": "builder,nodejs",
+              "version": "14"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/nodejs-14:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "14-ubi8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Node.js 14 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14-minimal/README.md.",
+              "iconClass": "icon-nodejs",
+              "openshift.io/display-name": "Node.js 14 (UBI 8 Minimal)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+              "tags": "builder,nodejs",
+              "version": "14"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/nodejs-14-minimal:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "14-ubi8-minimal",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Node.js 16 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
+              "iconClass": "icon-nodejs",
+              "openshift.io/display-name": "Node.js 16 (UBI 8)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+              "tags": "builder,nodejs",
+              "version": "16"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/nodejs-16:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "16-ubi8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Node.js 16 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
+              "iconClass": "icon-nodejs",
+              "openshift.io/display-name": "Node.js 16 (UBI 8 Minimal)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+              "tags": "builder,nodejs",
+              "version": "16"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/nodejs-16-minimal:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "16-ubi8-minimal",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Node.js 16 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
+              "iconClass": "icon-nodejs",
+              "openshift.io/display-name": "Node.js 16 (UBI 9)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+              "tags": "builder,nodejs",
+              "version": "16"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi9/nodejs-16:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "16-ubi9",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Node.js 16 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
+              "iconClass": "icon-nodejs",
+              "openshift.io/display-name": "Node.js 16 (UBI 9 Minimal)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+              "tags": "builder,nodejs",
+              "version": "16"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi9/nodejs-16-minimal:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "16-ubi9-minimal",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
+              "iconClass": "icon-nodejs",
+              "openshift.io/display-name": "Node.js (Latest)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+              "supports": "nodejs",
+              "tags": "builder,nodejs"
+            },
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "16-ubi8"
+            },
+            "generation": 1,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "latest",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": "image-registry.openshift-image-registry.svc:5000/openshift/nodejs",
+        "publicDockerImageRepository": "default-route-openshift-image-registry.apps-crc.testing/openshift/nodejs",
+        "tags": [
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:51Z",
+                "dockerImageReference": "registry.redhat.io/ubi7/nodejs-14@sha256:9a6eb662ac0c2f8f94d35b162553c3d8b81ea001cb7a9022e1d52e339da98b09",
+                "generation": 2,
+                "image": "sha256:9a6eb662ac0c2f8f94d35b162553c3d8b81ea001cb7a9022e1d52e339da98b09"
+              }
+            ],
+            "tag": "14-ubi7"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:51Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/nodejs-14@sha256:b646b221151acc36356a79a1c81094ffa17d9016ae1ceb81c175e634d7bde894",
+                "generation": 2,
+                "image": "sha256:b646b221151acc36356a79a1c81094ffa17d9016ae1ceb81c175e634d7bde894"
+              }
+            ],
+            "tag": "14-ubi8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:51Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/nodejs-14-minimal@sha256:1dd31294b75abe17fec7b5f87f0ddee2e6256359da2559b063a5a5b44e0c9784",
+                "generation": 2,
+                "image": "sha256:1dd31294b75abe17fec7b5f87f0ddee2e6256359da2559b063a5a5b44e0c9784"
+              }
+            ],
+            "tag": "14-ubi8-minimal"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:51Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/nodejs-16@sha256:e92d96b0d409c14f7a36ec11b62d9d79c102fa4610e764d75c64b56469b83de8",
+                "generation": 2,
+                "image": "sha256:e92d96b0d409c14f7a36ec11b62d9d79c102fa4610e764d75c64b56469b83de8"
+              }
+            ],
+            "tag": "16-ubi8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:51Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/nodejs-16-minimal@sha256:ce6faef8fc1560faa4f22fe8a19b6386c799c0820bd35c237263f5536570538a",
+                "generation": 2,
+                "image": "sha256:ce6faef8fc1560faa4f22fe8a19b6386c799c0820bd35c237263f5536570538a"
+              }
+            ],
+            "tag": "16-ubi8-minimal"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:51Z",
+                "dockerImageReference": "registry.redhat.io/ubi9/nodejs-16@sha256:fe0d986de49351344ee52336bbe7a0d95f1cc3ace9131c37793503a0e13128ba",
+                "generation": 2,
+                "image": "sha256:fe0d986de49351344ee52336bbe7a0d95f1cc3ace9131c37793503a0e13128ba"
+              }
+            ],
+            "tag": "16-ubi9"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:51Z",
+                "dockerImageReference": "registry.redhat.io/ubi9/nodejs-16-minimal@sha256:73e550cfb4359b0b9689ee6b7658cee192cd07bf7a1f903e82a12bef7335ffef",
+                "generation": 2,
+                "image": "sha256:73e550cfb4359b0b9689ee6b7658cee192cd07bf7a1f903e82a12bef7335ffef"
+              }
+            ],
+            "tag": "16-ubi9-minimal"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:51Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/nodejs-16@sha256:e92d96b0d409c14f7a36ec11b62d9d79c102fa4610e764d75c64b56469b83de8",
+                "generation": 2,
+                "image": "sha256:e92d96b0d409c14f7a36ec11b62d9d79c102fa4610e764d75c64b56469b83de8"
+              }
+            ],
+            "tag": "latest"
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "image.openshift.io/v1",
+      "kind": "ImageStream",
+      "metadata": {
+        "annotations": {
+          "openshift.io/display-name": "Python",
+          "openshift.io/image.dockerRepositoryCheck": "2023-07-26T18:56:50Z",
+          "samples.operator.openshift.io/version": "4.13.6"
+        },
+        "creationTimestamp": "2023-07-26T18:56:23Z",
+        "generation": 2,
+        "labels": {
+          "samples.operator.openshift.io/managed": "true"
+        },
+        "name": "python",
+        "namespace": "openshift",
+        "resourceVersion": "14907",
+        "uid": "ef07a854-3ba3-4325-9c09-d40cafa55d87"
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
+        },
+        "tags": [
+          {
+            "annotations": {
+              "description": "Build and run Python 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
+              "iconClass": "icon-python",
+              "openshift.io/display-name": "Python 2.7 (UBI 8)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/django-ex.git",
+              "supports": "python:2.7,python",
+              "tags": "builder,python",
+              "version": "2.7"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/python-27:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "2.7-ubi8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Python 3.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.",
+              "iconClass": "icon-python",
+              "openshift.io/display-name": "Python 3.6 (UBI 8)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/django-ex.git",
+              "supports": "python:3.6,python",
+              "tags": "builder,python",
+              "version": "3.6"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/python-36:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "3.6-ubi8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Python 3.8 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
+              "iconClass": "icon-python",
+              "openshift.io/display-name": "Python 3.8",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/django-ex.git",
+              "supports": "python:3.8,python",
+              "tags": "builder,python,hidden",
+              "version": "3.8"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/rhscl/python-38-rhel7:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "3.8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Python 3.8 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
+              "iconClass": "icon-python",
+              "openshift.io/display-name": "Python 3.8 (UBI 7)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/django-ex.git",
+              "supports": "python:3.8,python",
+              "tags": "builder,python",
+              "version": "3.8"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi7/python-38:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "3.8-ubi7",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Python 3.8 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
+              "iconClass": "icon-python",
+              "openshift.io/display-name": "Python 3.8 (UBI 8)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/django-ex.git",
+              "supports": "python:3.8,python",
+              "tags": "builder,python",
+              "version": "3.8"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/python-38:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "3.8-ubi8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Python 3.9 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
+              "iconClass": "icon-python",
+              "openshift.io/display-name": "Python 3.9 (UBI 8)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/django-ex.git",
+              "supports": "python:3.9,python",
+              "tags": "builder,python",
+              "version": "3.9"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi8/python-39:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "3.9-ubi8",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Python 3.9 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
+              "iconClass": "icon-python",
+              "openshift.io/display-name": "Python 3.9 (UBI 9)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/django-ex.git",
+              "supports": "python:3.9,python",
+              "tags": "builder,python",
+              "version": "3.9"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/ubi9/python-39:latest"
+            },
+            "generation": 2,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "3.9-ubi9",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.",
+              "iconClass": "icon-python",
+              "openshift.io/display-name": "Python (Latest)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/django-ex.git",
+              "supports": "python",
+              "tags": "builder,python"
+            },
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "3.9-ubi8"
+            },
+            "generation": 1,
+            "importPolicy": {
+              "importMode": "Legacy"
+            },
+            "name": "latest",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": "image-registry.openshift-image-registry.svc:5000/openshift/python",
+        "publicDockerImageRepository": "default-route-openshift-image-registry.apps-crc.testing/openshift/python",
+        "tags": [
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:50Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/python-27@sha256:190ea81f2f64ccf7f7c8cb9dc4612eda59eb9e3d2e17f71727a270f078f5114a",
+                "generation": 2,
+                "image": "sha256:190ea81f2f64ccf7f7c8cb9dc4612eda59eb9e3d2e17f71727a270f078f5114a"
+              }
+            ],
+            "tag": "2.7-ubi8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:50Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/python-36@sha256:971dcd27c3d53f58eb59c946f123223b95662841c1214a394a445380beb75f59",
+                "generation": 2,
+                "image": "sha256:971dcd27c3d53f58eb59c946f123223b95662841c1214a394a445380beb75f59"
+              }
+            ],
+            "tag": "3.6-ubi8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:50Z",
+                "dockerImageReference": "registry.redhat.io/rhscl/python-38-rhel7@sha256:8896e5ded8b15b1746261d1bfe421dc53621d7fbc8568b74d76bdedab30da62f",
+                "generation": 2,
+                "image": "sha256:8896e5ded8b15b1746261d1bfe421dc53621d7fbc8568b74d76bdedab30da62f"
+              }
+            ],
+            "tag": "3.8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:50Z",
+                "dockerImageReference": "registry.redhat.io/ubi7/python-38@sha256:8896e5ded8b15b1746261d1bfe421dc53621d7fbc8568b74d76bdedab30da62f",
+                "generation": 2,
+                "image": "sha256:8896e5ded8b15b1746261d1bfe421dc53621d7fbc8568b74d76bdedab30da62f"
+              }
+            ],
+            "tag": "3.8-ubi7"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:50Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/python-38@sha256:4a1d451e1d513115ff54c6e80299e761f60454b5f2f091f3c9ddb9fc1d61f5c4",
+                "generation": 2,
+                "image": "sha256:4a1d451e1d513115ff54c6e80299e761f60454b5f2f091f3c9ddb9fc1d61f5c4"
+              }
+            ],
+            "tag": "3.8-ubi8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:50Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/python-39@sha256:aace8817af3c1c92b10abfa9f1e027340d53d13fb97e2f4ce960cf9947041578",
+                "generation": 2,
+                "image": "sha256:aace8817af3c1c92b10abfa9f1e027340d53d13fb97e2f4ce960cf9947041578"
+              }
+            ],
+            "tag": "3.9-ubi8"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:50Z",
+                "dockerImageReference": "registry.redhat.io/ubi9/python-39@sha256:0c2f708b4977469d090719d939778eb95b42c02c1da6476aa95f2e875920652b",
+                "generation": 2,
+                "image": "sha256:0c2f708b4977469d090719d939778eb95b42c02c1da6476aa95f2e875920652b"
+              }
+            ],
+            "tag": "3.9-ubi9"
+          },
+          {
+            "items": [
+              {
+                "created": "2023-07-26T18:56:50Z",
+                "dockerImageReference": "registry.redhat.io/ubi8/python-39@sha256:aace8817af3c1c92b10abfa9f1e027340d53d13fb97e2f4ce960cf9947041578",
+                "generation": 2,
+                "image": "sha256:aace8817af3c1c92b10abfa9f1e027340d53d13fb97e2f4ce960cf9947041578"
+              }
+            ],
+            "tag": "latest"
+          }
+        ]
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": ""
+  }
+}

--- a/plugins/openshift-image-registry/dev/openshift-imagestreamtags.json
+++ b/plugins/openshift-image-registry/dev/openshift-imagestreamtags.json
@@ -1,0 +1,650 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "image.openshift.io/v1",
+      "generation": 2,
+      "image": {
+        "dockerImageLayers": [
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:2e449f0d8596b91719b366a7f134954cd2a03e99408e3899b004182af82a6979",
+            "size": 79829956
+          },
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:7fff4c4748a270604546349c7386ae461ba01a71b193d651cfcb0abc5fa88a34",
+            "size": 7552327
+          },
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:0b8fa8a9a8dc81f189373242af953709ea22ffa2b0a9c6d6070dc5027c12d432",
+            "size": 106012003
+          },
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:126a494c3c5f3513f4482bdcc5f0608a41c2f413c33b350e3ef2daef61cbe07c",
+            "size": 164861497
+          }
+        ],
+        "dockerImageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "dockerImageMetadata": {
+          "Architecture": "amd64",
+          "Author": "Red Hat, Inc.",
+          "Config": {
+            "Cmd": ["/bin/sh", "-c", "$STI_SCRIPTS_PATH/usage"],
+            "Entrypoint": ["container-entrypoint"],
+            "Env": [
+              "container=oci",
+              "STI_SCRIPTS_URL=image:///usr/libexec/s2i",
+              "STI_SCRIPTS_PATH=/usr/libexec/s2i",
+              "APP_ROOT=/opt/app-root",
+              "HOME=/opt/app-root/src",
+              "PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+              "PLATFORM=el7",
+              "BASH_ENV=/opt/app-root/etc/scl_enable",
+              "ENV=/opt/app-root/etc/scl_enable",
+              "PROMPT_COMMAND=. /opt/app-root/etc/scl_enable",
+              "NODEJS_SCL=rh-nodejs14",
+              "NAME=golang",
+              "VERSION=1.18.10",
+              "SUMMARY=Platform for building and running Go applications",
+              "DESCRIPTION=Go Toolset available as a container is a base platform for building and running various Go applications and frameworks. Go is an easy to learn, powerful, statically typed language in the C/C++ tradition with garbage collection, concurrent programming support, and memory safety features."
+            ],
+            "Labels": {
+              "architecture": "x86_64",
+              "build-date": "2023-04-12T16:30:01",
+              "com.redhat.component": "go-toolset-container",
+              "com.redhat.license_terms": "https://www.redhat.com/agreements",
+              "description": "Go Toolset available as a container is a base platform for building and running various Go applications and frameworks. Go is an easy to learn, powerful, statically typed language in the C/C++ tradition with garbage collection, concurrent programming support, and memory safety features.",
+              "distribution-scope": "public",
+              "io.buildah.version": "1.27.3",
+              "io.k8s.description": "Go Toolset available as a container is a base platform for building and running various Go applications and frameworks. Go is an easy to learn, powerful, statically typed language in the C/C++ tradition with garbage collection, concurrent programming support, and memory safety features.",
+              "io.k8s.display-name": "Go 1.18.10",
+              "io.openshift.s2i.scripts-url": "image:///usr/libexec/s2i",
+              "io.openshift.tags": "builder,golang,golang117,rh-golang117,go",
+              "io.s2i.scripts-url": "image:///usr/libexec/s2i",
+              "maintainer": "Red Hat, Inc.",
+              "name": "devtools/go-toolset-rhel7",
+              "release": "6.1681314820",
+              "summary": "Platform for building and running Go applications",
+              "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/devtools/go-toolset-rhel7/images/1.18.10-6.1681314820",
+              "vcs-ref": "10d1ace5725c33abb5ceaf9c297d54bd34a13de9",
+              "vcs-type": "git",
+              "vendor": "Red Hat, Inc.",
+              "version": "1.18.10"
+            },
+            "User": "1001",
+            "WorkingDir": "/opt/app-root/src"
+          },
+          "ContainerConfig": {},
+          "Created": "2023-04-12T16:32:45Z",
+          "Id": "sha256:524410e529e4a936dfcc37a6f8fa90f068ff9b3419fe5e9a264e8e359c11531b",
+          "Size": 358277196,
+          "apiVersion": "image.openshift.io/1.0",
+          "kind": "DockerImage"
+        },
+        "dockerImageMetadataVersion": "1.0",
+        "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/golang@sha256:07addbabcfd72212a82efce053a70362a06925ee1522c4dd783be878ffad46cb",
+        "metadata": {
+          "annotations": {
+            "description": "Build and run Go applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
+            "iconClass": "icon-go-gopher",
+            "image.openshift.io/dockerLayersOrder": "ascending",
+            "openshift.io/display-name": "Go 1.18 (UBI 7)",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "sampleRepo": "https://github.com/sclorg/golang-ex.git",
+            "supports": "golang",
+            "tags": "builder,golang,go"
+          },
+          "creationTimestamp": "2023-07-26T18:56:46Z",
+          "name": "sha256:07addbabcfd72212a82efce053a70362a06925ee1522c4dd783be878ffad46cb",
+          "resourceVersion": "14809",
+          "uid": "d973c923-e8d6-4ced-822b-46f00dcf3049"
+        }
+      },
+      "kind": "ImageStreamTag",
+      "lookupPolicy": {
+        "local": false
+      },
+      "metadata": {
+        "annotations": {
+          "description": "Build and run Go applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
+          "iconClass": "icon-go-gopher",
+          "openshift.io/display-name": "Go 1.18 (UBI 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/golang-ex.git",
+          "supports": "golang",
+          "tags": "builder,golang,go"
+        },
+        "creationTimestamp": "2023-07-26T18:56:46Z",
+        "labels": {
+          "samples.operator.openshift.io/managed": "true"
+        },
+        "name": "golang:1.18-ubi7",
+        "namespace": "openshift",
+        "resourceVersion": "14813",
+        "uid": "693949d1-2093-49ed-ae56-929acc790182"
+      },
+      "tag": {
+        "annotations": {
+          "description": "Build and run Go applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
+          "iconClass": "icon-go-gopher",
+          "openshift.io/display-name": "Go 1.18 (UBI 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/golang-ex.git",
+          "supports": "golang",
+          "tags": "builder,golang,go"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi7/go-toolset:1.18"
+        },
+        "generation": 2,
+        "importPolicy": {
+          "importMode": "Legacy"
+        },
+        "name": "1.18-ubi7",
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    },
+    {
+      "apiVersion": "image.openshift.io/v1",
+      "generation": 2,
+      "image": {
+        "dockerImageLayers": [
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:c6f9a461b2c17715e19e293f43e21c9734c699fb1df0c2c20c75ffb87551f7cb",
+            "size": 79785956
+          },
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:ca4f917972b4a900e5c352b3b6272879fa384dd413b70d1d7e4356c3c752da12",
+            "size": 115594803
+          }
+        ],
+        "dockerImageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "dockerImageMetadata": {
+          "Architecture": "amd64",
+          "Author": "Red Hat, Inc.",
+          "Config": {
+            "Cmd": ["/usr/local/s2i/run"],
+            "Env": [
+              "container=oci",
+              "HOME=/home/jboss",
+              "JAVA_HOME=/usr/lib/jvm/java-11",
+              "JAVA_VENDOR=openjdk",
+              "JAVA_VERSION=11",
+              "JBOSS_CONTAINER_OPENJDK_JDK_MODULE=/opt/jboss/container/openjdk/jdk",
+              "AB_PROMETHEUS_JMX_EXPORTER_CONFIG=/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml",
+              "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus",
+              "AB_JOLOKIA_AUTH_OPENSHIFT=true",
+              "AB_JOLOKIA_HTTPS=true",
+              "AB_JOLOKIA_PASSWORD_RANDOM=true",
+              "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/container/jolokia",
+              "JOLOKIA_VERSION=1.6.2",
+              "LD_PRELOAD=libnss_wrapper.so",
+              "NSS_WRAPPER_GROUP=/etc/group",
+              "NSS_WRAPPER_PASSWD=/home/jboss/passwd",
+              "S2I_SOURCE_DEPLOYMENTS_FILTER=*.jar",
+              "JBOSS_CONTAINER_S2I_CORE_MODULE=/opt/jboss/container/s2i/core/",
+              "JBOSS_CONTAINER_JAVA_PROXY_MODULE=/opt/jboss/container/java/proxy",
+              "JBOSS_CONTAINER_JAVA_JVM_MODULE=/opt/jboss/container/java/jvm",
+              "JBOSS_CONTAINER_MAVEN_36_MODULE=/opt/jboss/container/maven/36/",
+              "MAVEN_VERSION=3.6",
+              "JBOSS_CONTAINER_UTIL_LOGGING_MODULE=/opt/jboss/container/util/logging/",
+              "JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE=/opt/jboss/container/maven/default/",
+              "JBOSS_CONTAINER_MAVEN_S2I_MODULE=/opt/jboss/container/maven/s2i",
+              "JAVA_DATA_DIR=/deployments/data",
+              "JBOSS_CONTAINER_JAVA_RUN_MODULE=/opt/jboss/container/java/run",
+              "JBOSS_CONTAINER_JAVA_S2I_MODULE=/opt/jboss/container/java/s2i",
+              "JBOSS_IMAGE_NAME=openjdk/openjdk-11-rhel7",
+              "JBOSS_IMAGE_VERSION=1.15",
+              "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/s2i"
+            ],
+            "ExposedPorts": {
+              "8080/tcp": {},
+              "8443/tcp": {},
+              "8778/tcp": {}
+            },
+            "Labels": {
+              "architecture": "x86_64",
+              "build-date": "2023-07-20T08:08:13",
+              "com.redhat.component": "openjdk-11-rhel7-container",
+              "com.redhat.license_terms": "https://www.redhat.com/agreements",
+              "description": "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11",
+              "distribution-scope": "public",
+              "io.buildah.version": "1.29.0",
+              "io.cekit.version": "4.7.0",
+              "io.fabric8.s2i.version.jolokia": "1.6.2-redhat-00002",
+              "io.fabric8.s2i.version.maven": "3.6",
+              "io.k8s.description": "Platform for building and running plain Java applications (fat-jar and flat classpath)",
+              "io.k8s.display-name": "Java Applications",
+              "io.openshift.s2i.destination": "/tmp",
+              "io.openshift.s2i.scripts-url": "image:///usr/local/s2i",
+              "io.openshift.tags": "builder,java",
+              "maintainer": "Red Hat OpenJDK <openjdk@redhat.com>",
+              "name": "openjdk/openjdk-11-rhel7",
+              "org.jboss.container.deployments-dir": "/deployments",
+              "org.jboss.product": "openjdk",
+              "org.jboss.product.openjdk.version": "11",
+              "org.jboss.product.version": "11",
+              "release": "9",
+              "summary": "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11",
+              "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/openjdk/openjdk-11-rhel7/images/1.15-9",
+              "usage": "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/",
+              "vcs-ref": "bc2e8cbed5194676f5e562e97468861dc04c055f",
+              "vcs-type": "git",
+              "vendor": "Red Hat, Inc.",
+              "version": "1.15"
+            },
+            "User": "185",
+            "WorkingDir": "/home/jboss"
+          },
+          "ContainerConfig": {},
+          "Created": "2023-07-20T08:14:33Z",
+          "Id": "sha256:9c63b4dc2dc9e3aff2d0981ecfa512f8a4f5a584097f3b20a3bc44d247e4acf3",
+          "Size": 195410705,
+          "apiVersion": "image.openshift.io/1.0",
+          "kind": "DockerImage"
+        },
+        "dockerImageMetadataVersion": "1.0",
+        "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/java@sha256:a9158f829df4163cd1c25ab02b7e8a85fd968d15a24f3e8494e53a116b9d3bb6",
+        "metadata": {
+          "annotations": {
+            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+            "iconClass": "icon-rh-openjdk",
+            "image.openshift.io/dockerLayersOrder": "ascending",
+            "openshift.io/display-name": "Red Hat OpenJDK 11",
+            "sampleContextDir": "undertow-servlet",
+            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+            "supports": "java:11,java",
+            "tags": "builder,java,openjdk,hidden",
+            "version": "11"
+          },
+          "creationTimestamp": "2023-07-26T18:56:48Z",
+          "name": "sha256:a9158f829df4163cd1c25ab02b7e8a85fd968d15a24f3e8494e53a116b9d3bb6",
+          "resourceVersion": "14855",
+          "uid": "7c5ad778-ed25-437b-a07a-c65764781b2a"
+        }
+      },
+      "kind": "ImageStreamTag",
+      "lookupPolicy": {
+        "local": false
+      },
+      "metadata": {
+        "annotations": {
+          "description": "Build and run Java applications using Maven and OpenJDK 11.",
+          "iconClass": "icon-rh-openjdk",
+          "openshift.io/display-name": "Red Hat OpenJDK 11",
+          "sampleContextDir": "undertow-servlet",
+          "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+          "supports": "java:11,java",
+          "tags": "builder,java,openjdk,hidden",
+          "version": "11"
+        },
+        "creationTimestamp": "2023-07-26T18:56:48Z",
+        "labels": {
+          "samples.operator.openshift.io/managed": "true",
+          "xpaas": "1.4.17"
+        },
+        "name": "java:11",
+        "namespace": "openshift",
+        "resourceVersion": "14860",
+        "uid": "210e1300-206b-4f15-a169-edbeadca5d88"
+      },
+      "tag": {
+        "annotations": {
+          "description": "Build and run Java applications using Maven and OpenJDK 11.",
+          "iconClass": "icon-rh-openjdk",
+          "openshift.io/display-name": "Red Hat OpenJDK 11",
+          "sampleContextDir": "undertow-servlet",
+          "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+          "supports": "java:11,java",
+          "tags": "builder,java,openjdk,hidden",
+          "version": "11"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+        },
+        "generation": 2,
+        "importPolicy": {
+          "importMode": "Legacy"
+        },
+        "name": "11",
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    },
+    {
+      "apiVersion": "image.openshift.io/v1",
+      "generation": 2,
+      "image": {
+        "dockerImageLayers": [
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:d43c95783c3d99a3c275f4c278f8d68a1dfda166c399fd55aee8c1dce7d76611",
+            "size": 79767891
+          },
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:e53ac5fae1ac340de75c4c78c6eea9df409b45b2ffee95cd8085a8ed3b9cbf6c",
+            "size": 7515417
+          },
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:fa1531c978aeb28eb31c5ebc320c46907e5a56de6fc34d821ed2262d3d6c2864",
+            "size": 90352629
+          }
+        ],
+        "dockerImageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "dockerImageMetadata": {
+          "Architecture": "amd64",
+          "Author": "Red Hat, Inc.",
+          "Config": {
+            "Cmd": ["/bin/sh", "-c", "$STI_SCRIPTS_PATH/usage"],
+            "Entrypoint": ["container-entrypoint"],
+            "Env": [
+              "container=oci",
+              "STI_SCRIPTS_URL=image:///usr/libexec/s2i",
+              "STI_SCRIPTS_PATH=/usr/libexec/s2i",
+              "APP_ROOT=/opt/app-root",
+              "HOME=/opt/app-root/src",
+              "PLATFORM=el7",
+              "BASH_ENV=/opt/app-root/etc/scl_enable",
+              "ENV=/opt/app-root/etc/scl_enable",
+              "PROMPT_COMMAND=. /opt/app-root/etc/scl_enable",
+              "NODEJS_VERSION=14",
+              "NPM_RUN=start",
+              "NAME=nodejs",
+              "NPM_CONFIG_PREFIX=/opt/app-root/src/.npm-global",
+              "SUMMARY=Platform for building and running Node.js 14 applications",
+              "DESCRIPTION=Node.js 14 available as container is a base platform for building and running various Node.js 14 applications and frameworks. Node.js is a platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient, perfect for data-intensive real-time applications that run across distributed devices.",
+              "PATH=/opt/rh/rh-nodejs14/root/usr/bin:/opt/app-root/src/node_modules/.bin/:/opt/app-root/src/.npm-global/bin/:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+              "LD_LIBRARY_PATH=/opt/rh/rh-nodejs14/root/usr/lib64",
+              "X_SCLS=rh-nodejs14",
+              "MANPATH=/opt/rh/rh-nodejs14/root/usr/share/man"
+            ],
+            "ExposedPorts": {
+              "8080/tcp": {}
+            },
+            "Labels": {
+              "architecture": "x86_64",
+              "build-date": "2023-07-19T11:53:29",
+              "com.redhat.component": "rh-nodejs14-container",
+              "com.redhat.deployments-dir": "/opt/app-root/src",
+              "com.redhat.dev-mode": "DEV_MODE:false",
+              "com.redhat.dev-mode.port": "DEBUG_PORT:5858",
+              "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
+              "description": "Node.js 14 available as container is a base platform for building and running various Node.js 14 applications and frameworks. Node.js is a platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient, perfect for data-intensive real-time applications that run across distributed devices.",
+              "distribution-scope": "public",
+              "help": "For more information visit https://github.com/sclorg/s2i-nodejs-container",
+              "io.buildah.version": "1.29.0",
+              "io.k8s.description": "Node.js 14 available as container is a base platform for building and running various Node.js 14 applications and frameworks. Node.js is a platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient, perfect for data-intensive real-time applications that run across distributed devices.",
+              "io.k8s.display-name": "Node.js 14",
+              "io.openshift.expose-services": "8080:http",
+              "io.openshift.s2i.scripts-url": "image:///usr/libexec/s2i",
+              "io.openshift.tags": "builder,nodejs,nodejs14",
+              "io.s2i.scripts-url": "image:///usr/libexec/s2i",
+              "maintainer": "SoftwareCollections.org <sclorg@redhat.com>",
+              "name": "rhscl/nodejs-14-rhel7",
+              "release": "99",
+              "summary": "Platform for building and running Node.js 14 applications",
+              "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-14-rhel7/images/1-99",
+              "usage": "s2i build <SOURCE-REPOSITORY> rhscl/nodejs-14-rhel7:latest <APP-NAME>",
+              "vcs-ref": "8da2b9bd5665ecf7344eab52ac75ab35ee11194f",
+              "vcs-type": "git",
+              "vendor": "Red Hat, Inc.",
+              "version": "1"
+            },
+            "User": "1001",
+            "WorkingDir": "/opt/app-root/src"
+          },
+          "ContainerConfig": {},
+          "Created": "2023-07-19T11:57:00Z",
+          "Id": "sha256:8a2260b54d832ff4d44833e312c3e96de44651194c872b1851d8bcf8b1074d16",
+          "Size": 177656312,
+          "apiVersion": "image.openshift.io/1.0",
+          "kind": "DockerImage"
+        },
+        "dockerImageMetadataVersion": "1.0",
+        "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/nodejs@sha256:9a6eb662ac0c2f8f94d35b162553c3d8b81ea001cb7a9022e1d52e339da98b09",
+        "metadata": {
+          "annotations": {
+            "description": "Build and run Node.js 14 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+            "iconClass": "icon-nodejs",
+            "image.openshift.io/dockerLayersOrder": "ascending",
+            "openshift.io/display-name": "Node.js 14 (UBI 7)",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+            "tags": "builder,nodejs,hidden",
+            "version": "14"
+          },
+          "creationTimestamp": "2023-07-26T18:56:51Z",
+          "name": "sha256:9a6eb662ac0c2f8f94d35b162553c3d8b81ea001cb7a9022e1d52e339da98b09",
+          "resourceVersion": "14908",
+          "uid": "c6005c71-4d6a-493f-bd6a-a87761606bac"
+        }
+      },
+      "kind": "ImageStreamTag",
+      "lookupPolicy": {
+        "local": false
+      },
+      "metadata": {
+        "annotations": {
+          "description": "Build and run Node.js 14 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+          "iconClass": "icon-nodejs",
+          "openshift.io/display-name": "Node.js 14 (UBI 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+          "tags": "builder,nodejs,hidden",
+          "version": "14"
+        },
+        "creationTimestamp": "2023-07-26T18:56:51Z",
+        "labels": {
+          "samples.operator.openshift.io/managed": "true"
+        },
+        "name": "nodejs:14-ubi7",
+        "namespace": "openshift",
+        "resourceVersion": "14915",
+        "uid": "9f67482c-1e83-42d5-a8eb-04099005ea27"
+      },
+      "tag": {
+        "annotations": {
+          "description": "Build and run Node.js 14 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+          "iconClass": "icon-nodejs",
+          "openshift.io/display-name": "Node.js 14 (UBI 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+          "tags": "builder,nodejs,hidden",
+          "version": "14"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi7/nodejs-14:latest"
+        },
+        "generation": 2,
+        "importPolicy": {
+          "importMode": "Legacy"
+        },
+        "name": "14-ubi7",
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    },
+    {
+      "apiVersion": "image.openshift.io/v1",
+      "generation": 2,
+      "image": {
+        "dockerImageLayers": [
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:6c53be4efe39270422e3e2f7ee1c15887955e3d5e378ea6577c622f358f87691",
+            "size": 79290957
+          },
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:d96c2f4a5465b79c577fdecc27cd49a2c0f103fd2cfd372e667512be069e0143",
+            "size": 18415088
+          },
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:1a3c9e41511310aa895b5bc5b140efe6b6d9e9583f3ce9d70205d1f415d2d25f",
+            "size": 151139355
+          },
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "name": "sha256:0e05217c3e5798923dce4c10d4991ac94a7811ca5b864ed1c2a18beaeb60b9de",
+            "size": 74183818
+          }
+        ],
+        "dockerImageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "dockerImageMetadata": {
+          "Architecture": "amd64",
+          "Config": {
+            "Cmd": ["/bin/sh", "-c", "$STI_SCRIPTS_PATH/usage"],
+            "Entrypoint": ["container-entrypoint"],
+            "Env": [
+              "container=oci",
+              "STI_SCRIPTS_URL=image:///usr/libexec/s2i",
+              "STI_SCRIPTS_PATH=/usr/libexec/s2i",
+              "APP_ROOT=/opt/app-root",
+              "HOME=/opt/app-root/src",
+              "PLATFORM=el8",
+              "NODEJS_VER=14",
+              "PYTHON_VERSION=2.7",
+              "PATH=/opt/app-root/src/.local/bin/:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+              "PYTHONUNBUFFERED=1",
+              "PYTHONIOENCODING=UTF-8",
+              "LC_ALL=en_US.UTF-8",
+              "LANG=en_US.UTF-8",
+              "CNB_STACK_ID=com.redhat.stacks.ubi8-python-27",
+              "CNB_USER_ID=1001",
+              "CNB_GROUP_ID=0",
+              "PIP_NO_CACHE_DIR=off",
+              "SUMMARY=Platform for building and running Python 2.7 applications",
+              "DESCRIPTION=Python 2.7 available as container is a base platform for building and running various Python 2.7 applications and frameworks. Python is an easy to learn, powerful programming language. It has efficient high-level data structures and a simple but effective approach to object-oriented programming. Python's elegant syntax and dynamic typing, together with its interpreted nature, make it an ideal language for scripting and rapid application development in many areas on most platforms.",
+              "BASH_ENV=/opt/app-root/bin/activate",
+              "ENV=/opt/app-root/bin/activate",
+              "PROMPT_COMMAND=. /opt/app-root/bin/activate"
+            ],
+            "ExposedPorts": {
+              "8080/tcp": {}
+            },
+            "Labels": {
+              "architecture": "x86_64",
+              "build-date": "2023-06-23T09:49:56",
+              "com.redhat.component": "python-27-container",
+              "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
+              "description": "Python 2.7 available as container is a base platform for building and running various Python 2.7 applications and frameworks. Python is an easy to learn, powerful programming language. It has efficient high-level data structures and a simple but effective approach to object-oriented programming. Python's elegant syntax and dynamic typing, together with its interpreted nature, make it an ideal language for scripting and rapid application development in many areas on most platforms.",
+              "distribution-scope": "public",
+              "io.buildah.version": "1.29.0",
+              "io.buildpacks.stack.id": "com.redhat.stacks.ubi8-python-27",
+              "io.k8s.description": "Python 2.7 available as container is a base platform for building and running various Python 2.7 applications and frameworks. Python is an easy to learn, powerful programming language. It has efficient high-level data structures and a simple but effective approach to object-oriented programming. Python's elegant syntax and dynamic typing, together with its interpreted nature, make it an ideal language for scripting and rapid application development in many areas on most platforms.",
+              "io.k8s.display-name": "Python 2.7",
+              "io.openshift.expose-services": "8080:http",
+              "io.openshift.s2i.scripts-url": "image:///usr/libexec/s2i",
+              "io.openshift.tags": "builder,python,python27,python-27,rh-python27",
+              "io.s2i.scripts-url": "image:///usr/libexec/s2i",
+              "maintainer": "SoftwareCollections.org <sclorg@redhat.com>",
+              "name": "ubi8/python-27",
+              "release": "216",
+              "summary": "Platform for building and running Python 2.7 applications",
+              "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/python-27/images/2.7-216",
+              "usage": "s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=2.7/test/setup-test-app/ ubi8/python-27 python-sample-app",
+              "vcs-ref": "b9428036ceb2aef42c4f5d4181ff3acd52ef810a",
+              "vcs-type": "git",
+              "vendor": "Red Hat, Inc.",
+              "version": "2.7"
+            },
+            "User": "1001",
+            "WorkingDir": "/opt/app-root/src"
+          },
+          "ContainerConfig": {},
+          "Created": "2023-06-23T09:53:13Z",
+          "Id": "sha256:e73ddbbc6ecebcb472f62618fb02fb654af3802f69f45e8d3cfcfddc8c5bfd6d",
+          "Size": 323053263,
+          "apiVersion": "image.openshift.io/1.0",
+          "kind": "DockerImage"
+        },
+        "dockerImageMetadataVersion": "1.0",
+        "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/python@sha256:190ea81f2f64ccf7f7c8cb9dc4612eda59eb9e3d2e17f71727a270f078f5114a",
+        "metadata": {
+          "annotations": {
+            "description": "Build and run Python 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
+            "iconClass": "icon-python",
+            "image.openshift.io/dockerLayersOrder": "ascending",
+            "openshift.io/display-name": "Python 2.7 (UBI 8)",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "sampleRepo": "https://github.com/sclorg/django-ex.git",
+            "supports": "python:2.7,python",
+            "tags": "builder,python",
+            "version": "2.7"
+          },
+          "creationTimestamp": "2023-07-26T18:56:50Z",
+          "name": "sha256:190ea81f2f64ccf7f7c8cb9dc4612eda59eb9e3d2e17f71727a270f078f5114a",
+          "resourceVersion": "14901",
+          "uid": "c4fb3d1a-acbc-4ad8-8c69-0ca441c6e448"
+        }
+      },
+      "kind": "ImageStreamTag",
+      "lookupPolicy": {
+        "local": false
+      },
+      "metadata": {
+        "annotations": {
+          "description": "Build and run Python 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
+          "iconClass": "icon-python",
+          "openshift.io/display-name": "Python 2.7 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/django-ex.git",
+          "supports": "python:2.7,python",
+          "tags": "builder,python",
+          "version": "2.7"
+        },
+        "creationTimestamp": "2023-07-26T18:56:50Z",
+        "labels": {
+          "samples.operator.openshift.io/managed": "true"
+        },
+        "name": "python:2.7-ubi8",
+        "namespace": "openshift",
+        "resourceVersion": "14907",
+        "uid": "ef07a854-3ba3-4325-9c09-d40cafa55d87"
+      },
+      "tag": {
+        "annotations": {
+          "description": "Build and run Python 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
+          "iconClass": "icon-python",
+          "openshift.io/display-name": "Python 2.7 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/django-ex.git",
+          "supports": "python:2.7,python",
+          "tags": "builder,python",
+          "version": "2.7"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/python-27:latest"
+        },
+        "generation": 2,
+        "importPolicy": {
+          "importMode": "Legacy"
+        },
+        "name": "2.7-ubi8",
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": ""
+  }
+}

--- a/plugins/openshift-image-registry/src/api/index.ts
+++ b/plugins/openshift-image-registry/src/api/index.ts
@@ -45,7 +45,7 @@ export class OpenshiftImageRegistryApiClient
 
   private async getBaseUrl() {
     const proxyPath =
-      this.configApi.getOptionalString('openshiftImageRegistry.proxyPath') ||
+      this.configApi.getOptionalString('openshiftImageRegistry.proxyPath') ??
       DEFAULT_PROXY_PATH;
     return `${await this.discoveryApi.getBaseUrl('proxy')}${proxyPath}`;
   }

--- a/plugins/openshift-image-registry/src/components/OcirImages/OcirImageSidebar.tsx
+++ b/plugins/openshift-image-registry/src/components/OcirImages/OcirImageSidebar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { CopyTextButton, MarkdownContent } from '@backstage/core-components';
-import { BackstageTheme } from '@backstage/theme';
 
 import {
   Box,
@@ -11,13 +10,14 @@ import {
   IconButton,
   Input,
   makeStyles,
+  Theme,
   Typography,
 } from '@material-ui/core';
 import Close from '@material-ui/icons/Close';
 
 import { ImageStreamMetadata } from '../../types';
 
-const useDrawerStyles = makeStyles<BackstageTheme>(theme =>
+const useDrawerStyles = makeStyles<Theme>(theme =>
   createStyles({
     paper: {
       width: '40%',
@@ -27,7 +27,7 @@ const useDrawerStyles = makeStyles<BackstageTheme>(theme =>
   }),
 );
 
-const useDrawerContentStyles = makeStyles<BackstageTheme>(theme =>
+const useDrawerContentStyles = makeStyles<Theme>(theme =>
   createStyles({
     header: {
       display: 'flex',
@@ -56,14 +56,14 @@ const useDrawerContentStyles = makeStyles<BackstageTheme>(theme =>
 );
 
 type OcirImageSidebarProps = {
-  isOpen: boolean;
-  toggleDrawer: React.Dispatch<React.SetStateAction<boolean>>;
+  open: boolean;
+  onClose: () => void;
   imageStream: ImageStreamMetadata;
 };
 
 export const OcirImageSidebar = ({
-  isOpen,
-  toggleDrawer,
+  open,
+  onClose,
   imageStream,
 }: OcirImageSidebarProps) => {
   const classes = useDrawerStyles();
@@ -71,8 +71,8 @@ export const OcirImageSidebar = ({
   return (
     <Drawer
       anchor="right"
-      open={isOpen}
-      onClose={() => toggleDrawer(false)}
+      open={open}
+      onClose={onClose}
       classes={{
         paper: classes.paper,
       }}
@@ -83,7 +83,7 @@ export const OcirImageSidebar = ({
           <IconButton
             key="dismiss"
             title="Close the drawer"
-            onClick={() => toggleDrawer(false)}
+            onClick={onClose}
             color="inherit"
           >
             <Close className={contentClasses.icon} />
@@ -95,7 +95,7 @@ export const OcirImageSidebar = ({
               Description
             </Typography>
             <MarkdownContent
-              content={imageStream.description || 'N/A'}
+              content={imageStream.description ?? 'N/A'}
               className={contentClasses.description}
             />
           </Box>
@@ -112,7 +112,7 @@ export const OcirImageSidebar = ({
               Version
             </Typography>
             <span className={contentClasses.description}>
-              {imageStream.version || 'N/A'}
+              {imageStream.version ?? 'N/A'}
             </span>
           </Box>
           <Box>
@@ -120,7 +120,7 @@ export const OcirImageSidebar = ({
               Size
             </Typography>
             <span className={contentClasses.description}>
-              {imageStream.size || 'N/A'}
+              {imageStream.size ?? 'N/A'}
             </span>
           </Box>
           <Box>
@@ -132,8 +132,8 @@ export const OcirImageSidebar = ({
               Tags
             </Typography>
             {imageStream.tags?.length
-              ? imageStream.tags.map((tag: string, i: number) => (
-                  <Chip size="small" label={tag} key={i} />
+              ? imageStream.tags.map((tag: string) => (
+                  <Chip key={tag} size="small" label={tag} />
                 ))
               : 'N/A'}
           </Box>

--- a/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCard.tsx
+++ b/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCard.tsx
@@ -5,7 +5,6 @@ import {
   LinkButton,
   MarkdownContent,
 } from '@backstage/core-components';
-import { BackstageTheme } from '@backstage/theme';
 
 import {
   Box,
@@ -15,12 +14,13 @@ import {
   CardMedia,
   Chip,
   makeStyles,
+  Theme,
   Typography,
 } from '@material-ui/core';
 
 import { ImageStreamMetadata } from '../../types';
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
+const useStyles = makeStyles<Theme>(theme => ({
   label: {
     color: theme.palette.text.secondary,
     textTransform: 'uppercase',
@@ -39,12 +39,12 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 
 type OcirImagesCardProps = {
   imageStream: ImageStreamMetadata;
-  openSidebar: (imageStream: ImageStreamMetadata) => void;
+  onImageStreamSelected: (imageStream: ImageStreamMetadata) => void;
 };
 
 export const OcirImagesCard = ({
   imageStream,
-  openSidebar,
+  onImageStreamSelected,
 }: OcirImagesCardProps) => {
   const classes = useStyles();
 
@@ -65,7 +65,7 @@ export const OcirImagesCard = ({
             Description
           </Typography>
           <MarkdownContent
-            content={imageStream.description || 'N/A'}
+            content={imageStream.description ?? 'N/A'}
             className={classes.description}
           />
         </Box>
@@ -86,8 +86,8 @@ export const OcirImagesCard = ({
             Tags
           </Typography>
           {imageStream.tags?.length
-            ? imageStream.tags.map((tag: string, i: number) => (
-                <Chip size="small" label={tag} key={i} />
+            ? imageStream.tags.map((tag: string) => (
+                <Chip key={tag} size="small" label={tag} />
               ))
             : 'N/A'}
         </Box>
@@ -96,7 +96,7 @@ export const OcirImagesCard = ({
         <LinkButton
           color="primary"
           to=""
-          onClick={() => openSidebar(imageStream)}
+          onClick={() => onImageStreamSelected(imageStream)}
         >
           Open
         </LinkButton>

--- a/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCards.tsx
+++ b/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCards.tsx
@@ -12,19 +12,20 @@ type OcirImagesCardsProps = {
 };
 
 export const OcirImagesCards = ({ imageStreams }: OcirImagesCardsProps) => {
-  const [isOpen, toggleDrawer] = React.useState<boolean>(false);
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const [activeImageStream, setActiveImageStream] =
     React.useState<ImageStreamMetadata>();
   const [filteredImageStreams, setFilteredImageStreams] = React.useState<
     ImageStreamMetadata[] | undefined
   >();
 
-  const imageStreamsList = filteredImageStreams || imageStreams;
+  const imageStreamsList = filteredImageStreams ?? imageStreams;
 
-  const handleOpen = React.useCallback(imageStream => {
+  const handleImageStreamSelected = React.useCallback(imageStream => {
     setActiveImageStream(imageStream);
-    toggleDrawer(true);
+    setIsOpen(true);
   }, []);
+  const handleClose = React.useCallback(() => setIsOpen(false), [setIsOpen]);
 
   return (
     <>
@@ -39,14 +40,14 @@ export const OcirImagesCards = ({ imageStreams }: OcirImagesCardsProps) => {
               <OcirImagesCard
                 key={imageStream.uid}
                 imageStream={imageStream}
-                openSidebar={handleOpen}
+                onImageStreamSelected={handleImageStreamSelected}
               />
             ))}
           </ItemCardGrid>
           {activeImageStream && (
             <OcirImageSidebar
-              isOpen={isOpen}
-              toggleDrawer={toggleDrawer}
+              open={isOpen}
+              onClose={handleClose}
               imageStream={activeImageStream}
             />
           )}


### PR DESCRIPTION
Fix #596: Cleanup [3 small code smells](https://sonarcloud.io/code?id=janus-idp_backstage-plugins&selected=janus-idp_backstage-plugins%3Aplugins%2Fopenshift-image-registry) reported by sonarcloud:

* https://sonarcloud.io/code?id=janus-idp_backstage-plugins&selected=janus-idp_backstage-plugins%3Aplugins%2Fopenshift-image-registry%2Fsrc%2Fcomponents%2FOcirImages%2FOcirImagesCard.tsx
  * Used the tag as key since duplicates should happen because each tag refers to a resource name
* https://sonarcloud.io/code?id=janus-idp_backstage-plugins&selected=janus-idp_backstage-plugins%3Aplugins%2Fopenshift-image-registry%2Fsrc%2Fcomponents%2FOcirImages%2FOcirImagesCards.tsx
  * Cleanuped the usage of `toggleDrawer` by using more explicit props to close the drawer.
* https://sonarcloud.io/code?id=janus-idp_backstage-plugins&selected=janus-idp_backstage-plugins%3Aplugins%2Fopenshift-image-registry%2Fsrc%2Fcomponents%2FOcirImages%2FOcirImageSidebar.tsx
  * Used the tag as key since duplicates should happen because each tag refers to a resource name

I also added some mock data so that the UI test page can be used to confirm that the plugin still works:

![image](https://github.com/janus-idp/backstage-plugins/assets/139310/b40f2f5d-db6b-4559-ab82-a5211a0e4620)

I've also tested it on backstage app with a real cluster:

https://github.com/janus-idp/backstage-plugins/assets/139310/acc7f0cf-0af4-4569-b6ed-8a0788b7298b
