### PR TITLE
fix(regex-actions): fix #594: Cleanup some small code smells

### DIFF
--- a/plugins/regex-actions/README.md
+++ b/plugins/regex-actions/README.md
@@ -50,13 +50,13 @@ export default async function createPlugin(
 
 ### Action : regex:replace
 
-| Parameter Name             |  Type  | Required | Description                                                                     |
-| -------------------------- | :----: | :------: | ------------------------------------------------------------------------------- |
-| `regExps[].pattern`        | string |   Yes    | The regex pattern to match the value like in `String.prototype.replace()`       |
-| `regExps[].flags`          | string |    No    | The flags for the regex, possible values are: `g`, `m`, `i`, `y`, `u`, `s`, `d` |
-| `regExps[].replacement`    | string |   Yes    | The replacement value for the regex like in `String.prototype.replace()`        |
-| `regExps[].values[].key`   | string |   Yes    | The key to access the regex value                                               |
-| `regExps[].values[].value` | string |   Yes    | The input value of the regex                                                    |
+| Parameter Name             |   Type   | Required | Description                                                                     |
+| -------------------------- | :------: | :------: | ------------------------------------------------------------------------------- |
+| `regExps[].pattern`        |  string  |   Yes    | The regex pattern to match the value like in `String.prototype.replace()`       |
+| `regExps[].flags`          | string[] |    No    | The flags for the regex, possible values are: `g`, `m`, `i`, `y`, `u`, `s`, `d` |
+| `regExps[].replacement`    |  string  |   Yes    | The replacement value for the regex like in `String.prototype.replace()`        |
+| `regExps[].values[].key`   |  string  |   Yes    | The key to access the regex value                                               |
+| `regExps[].values[].value` |  string  |   Yes    | The input value of the regex                                                    |
 
 > **Warning**
 >

--- a/plugins/regex-actions/src/actions/regex/replace.test.ts
+++ b/plugins/regex-actions/src/actions/regex/replace.test.ts
@@ -18,17 +18,13 @@ import { createReplaceAction } from './replace';
 describe('regex:replace', () => {
   const action = createReplaceAction();
 
-  const logStream = {
-    write: jest.fn(),
-  } as jest.Mocked<Partial<Writable>> as jest.Mocked<Writable>;
-
   const mockTmpDir = os.tmpdir();
   const mockContext = {
     input: {},
     baseUrl: 'somebase',
     workspacePath: mockTmpDir,
     logger: getVoidLogger(),
-    logStream,
+    logStream: {} as Writable,
     output: jest.fn(),
     createTemporaryDirectory: jest.fn().mockResolvedValue(mockTmpDir),
   };
@@ -87,7 +83,7 @@ describe('regex:replace', () => {
         {
           pattern: 'Dog',
           replacement: 'ferret',
-          flags: ['i'] as any,
+          flags: ['i'] as 'i'[],
           values: [
             {
               key: 'eg2',
@@ -120,7 +116,7 @@ describe('regex:replace', () => {
         {
           pattern: 'dog',
           replacement: 'monkey',
-          flags: ['g'] as any,
+          flags: ['g'] as ('g' | 'i')[],
           values: [
             {
               key: 'eg1',
@@ -131,7 +127,7 @@ describe('regex:replace', () => {
         {
           pattern: 'Dog',
           replacement: 'ferret',
-          flags: ['g', 'i'] as any,
+          flags: ['g', 'i'] as ('g' | 'i')[],
           values: [
             {
               key: 'eg2',

--- a/plugins/regex-actions/src/actions/regex/replace.ts
+++ b/plugins/regex-actions/src/actions/regex/replace.ts
@@ -12,10 +12,7 @@ const schemaInput = z.object({
           // You should not parse a regex (regular language) with a regex (regular language),
           // you actually need a context free grammar to parse a regex (regular language).
           // Hence, we are using a string comparison here.
-          value =>
-            !(
-              value.charAt(0) === '/' && value.charAt(value.length - 1) === '/'
-            ),
+          value => !value.startsWith('/') && !value.endsWith('/'),
           {
             message:
               'The RegExp constructor cannot take a string pattern with a leading and trailing forward slash.',
@@ -26,7 +23,7 @@ const schemaInput = z.object({
         ),
       flags: z
         .array(
-          // FIXME: changed from z.set() because that breaks zod-to-json-schema parser in unknown way.
+          // Prefer array over set here because input values are normally defined in YAML which doesn't support Sets.
           z.enum(['g', 'm', 'i', 'y', 'u', 's', 'd'], {
             invalid_type_error:
               'Invalid flag, possible values are: g, m, i, y, u, s, d',
@@ -169,7 +166,7 @@ export const createReplaceAction = () => {
     async handler(ctx) {
       const input = ctx.input;
 
-      const values = {} as Record<string, string>;
+      const values: Record<string, string> = {};
 
       for (const {
         pattern,
@@ -177,7 +174,7 @@ export const createReplaceAction = () => {
         replacement,
         values: valuesInput,
       } of input.regExps) {
-        // FIXME: remove `new Set()` when the `z.set()` issue is fixed
+        // remove duplicates from the flags input array
         const flags = flagsInput
           ? Array.from(new Set(flagsInput)).join('')
           : '';


### PR DESCRIPTION
Fix #594: Cleanup [3 small code smells](https://sonarcloud.io/code?id=janus-idp_backstage-plugins&selected=janus-idp_backstage-plugins%3Aplugins%2Fregex-actions) reported by sonarcloud:

* https://sonarcloud.io/code?id=janus-idp_backstage-plugins&selected=janus-idp_backstage-plugins%3Aplugins%2Fregex-actions%2Fsrc%2Factions%2Fregex%2Freplace.ts
  * removed the FIXME: comments since the common input format is YAML which doesn't support Sets. So imho it might be incorrect to expect a Set here.
  * Updated the README with the right Type definition.
  * fixed another warning that recommended to prefer startsWith and endsWith.
* https://sonarcloud.io/code?id=janus-idp_backstage-plugins&selected=janus-idp_backstage-plugins%3Aplugins%2Fregex-actions%2Fsrc%2Factions%2Fregex%2Freplace.test.ts
  * fixed type casting to Writable