### PR TITLE
chore: add initial OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+ - AndrienkoAleksandr
+ - davidfestal
+ - debsmita1
+ - divyanshiGupta
+ - invincibleJai
+ - kadel
+ - nickboldt
+ - schultzp2020
+ - tumido
+
+reviewers:


### PR DESCRIPTION
Initial OWNERS file for Prow integrations.
This matches the list of the people with write access to this repo.