### PR TITLE
feat(quay): fix sorting in quay table and tag details

### DIFF
--- a/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
+++ b/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
@@ -38,7 +38,7 @@ export function QuayRepository(_props: QuayRepositoryProps) {
     <div data-testid="quay-repo-table" style={{ border: '1px solid #ddd' }}>
       <Table
         title={title}
-        options={{ paging: true, padding: 'dense' }}
+        options={{ sorting: true, paging: true, padding: 'dense' }}
         data={data}
         columns={columns}
         emptyContent={

--- a/plugins/quay/src/components/QuayRepository/tableHeading.tsx
+++ b/plugins/quay/src/components/QuayRepository/tableHeading.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from '@material-ui/core';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 
 import { vulnerabilitySummary } from '../../lib/utils';
-import type { Layer } from '../../types';
+import type { QuayTagData } from '../../types';
 
 export const columns: TableColumn[] = [
   {
@@ -24,7 +24,8 @@ export const columns: TableColumn[] = [
     title: 'Security Scan',
     field: 'securityScan',
     render: (rowData: any): React.ReactNode => {
-      if (!rowData.securityStatus && !rowData.securityDetails) {
+      const quayRowData = rowData as QuayTagData;
+      if (!quayRowData.securityStatus && !quayRowData.securityDetails) {
         return (
           <span data-testid="quay-repo-security-scan-progress">
             <Progress />
@@ -32,7 +33,7 @@ export const columns: TableColumn[] = [
         );
       }
 
-      if (rowData.securityStatus === 'unsupported') {
+      if (quayRowData.securityStatus === 'unsupported') {
         return (
           <Tooltip title="The manifest for this tag has an operating system or package manager unsupported by Quay Security Scanner">
             <span data-testid="quay-repo-security-scan-unsupported">
@@ -42,8 +43,8 @@ export const columns: TableColumn[] = [
         );
       }
 
-      const tagManifest = rowData.manifest_digest_raw;
-      const retStr = vulnerabilitySummary(rowData.securityDetails as Layer);
+      const tagManifest = quayRowData.manifest_digest_raw;
+      const retStr = vulnerabilitySummary(quayRowData.securityDetails);
       return <Link to={`tag/${tagManifest}`}>{retStr}</Link>;
     },
     id: 'securityScan',
@@ -54,8 +55,8 @@ export const columns: TableColumn[] = [
     field: 'size',
     type: 'numeric',
     customSort: (a, b) => {
-      const A = a as any;
-      const B = b as any;
+      const A = a as QuayTagData;
+      const B = b as QuayTagData;
 
       return A.rawSize - B.rawSize;
     },
@@ -71,8 +72,8 @@ export const columns: TableColumn[] = [
     field: 'manifest_digest',
     type: 'string',
     customSort: (a, b) => {
-      const A = a as any;
-      const B = b as any;
+      const A = a as QuayTagData;
+      const B = b as QuayTagData;
 
       return A.manifest_digest_raw.localeCompare(B.manifest_digest_raw);
     },

--- a/plugins/quay/src/components/QuayRepository/tableHeading.tsx
+++ b/plugins/quay/src/components/QuayRepository/tableHeading.tsx
@@ -8,7 +8,7 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 import { vulnerabilitySummary } from '../../lib/utils';
 import type { QuayTagData } from '../../types';
 
-export const columns: TableColumn[] = [
+export const columns: TableColumn<QuayTagData>[] = [
   {
     title: 'Tag',
     field: 'name',
@@ -23,9 +23,8 @@ export const columns: TableColumn[] = [
   {
     title: 'Security Scan',
     field: 'securityScan',
-    render: (rowData: any): React.ReactNode => {
-      const quayRowData = rowData as QuayTagData;
-      if (!quayRowData.securityStatus && !quayRowData.securityDetails) {
+    render: (rowData: QuayTagData): React.ReactNode => {
+      if (!rowData.securityStatus && !rowData.securityDetails) {
         return (
           <span data-testid="quay-repo-security-scan-progress">
             <Progress />
@@ -33,7 +32,7 @@ export const columns: TableColumn[] = [
         );
       }
 
-      if (quayRowData.securityStatus === 'unsupported') {
+      if (rowData.securityStatus === 'unsupported') {
         return (
           <Tooltip title="The manifest for this tag has an operating system or package manager unsupported by Quay Security Scanner">
             <span data-testid="quay-repo-security-scan-unsupported">
@@ -43,8 +42,8 @@ export const columns: TableColumn[] = [
         );
       }
 
-      const tagManifest = quayRowData.manifest_digest_raw;
-      const retStr = vulnerabilitySummary(quayRowData.securityDetails);
+      const tagManifest = rowData.manifest_digest_raw;
+      const retStr = vulnerabilitySummary(rowData.securityDetails);
       return <Link to={`tag/${tagManifest}`}>{retStr}</Link>;
     },
     id: 'securityScan',
@@ -54,12 +53,7 @@ export const columns: TableColumn[] = [
     title: 'Size',
     field: 'size',
     type: 'numeric',
-    customSort: (a, b) => {
-      const A = a as QuayTagData;
-      const B = b as QuayTagData;
-
-      return A.rawSize - B.rawSize;
-    },
+    customSort: (a: QuayTagData, b: QuayTagData) => a.rawSize - b.rawSize,
   },
   {
     title: 'Expires',
@@ -71,12 +65,8 @@ export const columns: TableColumn[] = [
     title: 'Manifest',
     field: 'manifest_digest',
     type: 'string',
-    customSort: (a, b) => {
-      const A = a as QuayTagData;
-      const B = b as QuayTagData;
-
-      return A.manifest_digest_raw.localeCompare(B.manifest_digest_raw);
-    },
+    customSort: (a: QuayTagData, b: QuayTagData) =>
+      a.manifest_digest_raw.localeCompare(b.manifest_digest_raw),
   },
 ];
 

--- a/plugins/quay/src/components/QuayRepository/tableHeading.tsx
+++ b/plugins/quay/src/components/QuayRepository/tableHeading.tsx
@@ -47,11 +47,18 @@ export const columns: TableColumn[] = [
       return <Link to={`tag/${tagManifest}`}>{retStr}</Link>;
     },
     id: 'securityScan',
+    sorting: false,
   },
   {
     title: 'Size',
     field: 'size',
     type: 'numeric',
+    customSort: (a, b) => {
+      const A = a as any;
+      const B = b as any;
+
+      return A.rawSize - B.rawSize;
+    },
   },
   {
     title: 'Expires',
@@ -63,6 +70,12 @@ export const columns: TableColumn[] = [
     title: 'Manifest',
     field: 'manifest_digest',
     type: 'string',
+    customSort: (a, b) => {
+      const A = a as any;
+      const B = b as any;
+
+      return A.manifest_digest_raw.localeCompare(B.manifest_digest_raw);
+    },
   },
 ];
 

--- a/plugins/quay/src/components/QuayTagDetails/component.tsx
+++ b/plugins/quay/src/components/QuayTagDetails/component.tsx
@@ -25,52 +25,44 @@ type QuayTagDetailsProps = {
 // from: https://github.com/quay/quay/blob/f1d85588157eababc3cbf789002c5db521dbd616/web/src/routes/TagDetails/SecurityReport/SecurityReportTable.tsx#L43
 const getVulnerabilityLink = (link: string) => link.split(' ')[0];
 
-const columns: TableColumn[] = [
+const columns: TableColumn<VulnerabilityListItem>[] = [
   {
     title: 'Advisory',
     field: 'name',
-    render: (rowData: any): React.ReactNode => {
-      const row = rowData as VulnerabilityListItem;
+    render: (rowData: VulnerabilityListItem): React.ReactNode => {
       return (
         <div style={{ display: 'flex', alignItems: 'center' }}>
-          {row.Name}
-          {row.Link.trim().length > 0 ? (
-            <Link to={getVulnerabilityLink(row.Link)}>
+          {rowData.Name}
+          {rowData.Link.trim().length > 0 ? (
+            <Link to={getVulnerabilityLink(rowData.Link)}>
               <LinkIcon style={{ marginLeft: '0.5rem' }} />
             </Link>
           ) : null}
         </div>
       );
     },
-    customSort: (a, b) => {
-      const rowA = a as VulnerabilityListItem;
-      const rowB = b as VulnerabilityListItem;
-
-      return rowA.Name.localeCompare(rowB.Name, 'en');
-    },
+    customSort: (a: VulnerabilityListItem, b: VulnerabilityListItem) =>
+      a.Name.localeCompare(b.Name, 'en'),
   },
   {
     title: 'Severity',
     field: 'Severity',
-    customSort: (a, b) => {
-      const rowA = a as VulnerabilityListItem;
-      const rowB = b as VulnerabilityListItem;
-      const severityA = VulnerabilityOrder[rowA.Severity];
-      const severityB = VulnerabilityOrder[rowB.Severity];
+    customSort: (a: VulnerabilityListItem, b: VulnerabilityListItem) => {
+      const severityA = VulnerabilityOrder[a.Severity];
+      const severityB = VulnerabilityOrder[b.Severity];
 
       return severityA - severityB;
     },
-    render: (rowData: any): React.ReactNode => {
-      const row = rowData as VulnerabilityListItem;
+    render: (rowData: VulnerabilityListItem): React.ReactNode => {
       return (
         <div style={{ display: 'flex', alignItems: 'center' }}>
           <WarningIcon
-            htmlColor={SEVERITY_COLORS[row.Severity]}
+            htmlColor={SEVERITY_COLORS[rowData.Severity]}
             style={{
               marginRight: '0.5rem',
             }}
           />
-          <span>{row.Severity}</span>
+          <span>{rowData.Severity}</span>
         </div>
       );
     },
@@ -88,10 +80,15 @@ const columns: TableColumn[] = [
   {
     title: 'Fixed By',
     field: 'FixedBy',
-    render: (rowData: any): React.ReactNode => {
-      const row = rowData as VulnerabilityListItem;
+    render: (rowData: VulnerabilityListItem): React.ReactNode => {
       return (
-        <>{row.FixedBy.length > 0 ? <span>{row.FixedBy}</span> : '(None)'}</>
+        <>
+          {rowData.FixedBy.length > 0 ? (
+            <span>{rowData.FixedBy}</span>
+          ) : (
+            '(None)'
+          )}
+        </>
       );
     },
   },

--- a/plugins/quay/src/components/QuayTagDetails/component.tsx
+++ b/plugins/quay/src/components/QuayTagDetails/component.tsx
@@ -42,10 +42,24 @@ const columns: TableColumn[] = [
         </div>
       );
     },
+    customSort: (a, b) => {
+      const rowA = a as Vulnerability;
+      const rowB = b as Vulnerability;
+
+      return rowA.Name.localeCompare(rowB.Name, 'en');
+    },
   },
   {
     title: 'Severity',
     field: 'Severity',
+    customSort: (a, b) => {
+      const rowA = a as VulnerabilityListItem;
+      const rowB = b as VulnerabilityListItem;
+      const severityA = VulnerabilityOrder[rowA.Severity];
+      const severityB = VulnerabilityOrder[rowB.Severity];
+
+      return severityA - severityB;
+    },
     render: (rowData: any): React.ReactNode => {
       const row = rowData as Vulnerability;
       return (
@@ -77,15 +91,7 @@ const columns: TableColumn[] = [
     render: (rowData: any): React.ReactNode => {
       const row = rowData as VulnerabilityListItem;
       return (
-        <>
-          {row.FixedBy.length > 0 ? (
-            <>
-              <span>{row.FixedBy}</span>
-            </>
-          ) : (
-            '(None)'
-          )}
-        </>
+        <>{row.FixedBy.length > 0 ? <span>{row.FixedBy}</span> : '(None)'}</>
       );
     },
   },

--- a/plugins/quay/src/components/QuayTagDetails/component.tsx
+++ b/plugins/quay/src/components/QuayTagDetails/component.tsx
@@ -30,7 +30,7 @@ const columns: TableColumn[] = [
     title: 'Advisory',
     field: 'name',
     render: (rowData: any): React.ReactNode => {
-      const row = rowData as Vulnerability;
+      const row = rowData as VulnerabilityListItem;
       return (
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {row.Name}
@@ -43,8 +43,8 @@ const columns: TableColumn[] = [
       );
     },
     customSort: (a, b) => {
-      const rowA = a as Vulnerability;
-      const rowB = b as Vulnerability;
+      const rowA = a as VulnerabilityListItem;
+      const rowB = b as VulnerabilityListItem;
 
       return rowA.Name.localeCompare(rowB.Name, 'en');
     },
@@ -61,7 +61,7 @@ const columns: TableColumn[] = [
       return severityA - severityB;
     },
     render: (rowData: any): React.ReactNode => {
-      const row = rowData as Vulnerability;
+      const row = rowData as VulnerabilityListItem;
       return (
         <div style={{ display: 'flex', alignItems: 'center' }}>
           <WarningIcon

--- a/plugins/quay/src/hooks/quay.tsx
+++ b/plugins/quay/src/hooks/quay.tsx
@@ -77,6 +77,7 @@ export const useTags = (organization: string, repository: string) => {
         name: tag.name,
         last_modified: formatDate(tag.last_modified),
         size: formatByteSize(tag.size),
+        rawSize: tag.size,
         manifest_digest: (
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Chip label={hashFunc} className={localClasses.chip} />

--- a/plugins/quay/src/hooks/quay.tsx
+++ b/plugins/quay/src/hooks/quay.tsx
@@ -10,7 +10,7 @@ import { Box, Chip, makeStyles } from '@material-ui/core';
 import { formatByteSize, formatDate } from '@janus-idp/shared-react';
 
 import { quayApiRef } from '../api';
-import { Layer, Tag } from '../types';
+import { Layer, QuayTagData, Tag } from '../types';
 
 const useLocalStyles = makeStyles({
   chip: {
@@ -68,7 +68,7 @@ export const useTags = (organization: string, repository: string) => {
     return tagsResponse;
   });
 
-  const data = useMemo(() => {
+  const data: QuayTagData[] = useMemo(() => {
     return Object.values(tags)?.map(tag => {
       const hashFunc = tag.manifest_digest.substring(0, 6);
       const shortHash = tag.manifest_digest.substring(7, 19);

--- a/plugins/quay/src/types.ts
+++ b/plugins/quay/src/types.ts
@@ -20,7 +20,18 @@ export interface Tag {
 export interface LabelsResponse {
   labels: Label[];
 }
-
+export interface QuayTagData {
+  id: string;
+  name: string;
+  last_modified: string;
+  size: string;
+  rawSize: number;
+  manifest_digest: React.JSX.Element;
+  expiration?: string;
+  securityDetails: Layer;
+  securityStatus: string;
+  manifest_digest_raw: string;
+}
 export interface Label {
   id: string;
   key: string;


### PR DESCRIPTION
### Description
Allows sorting for all columns in the quay table (with the exception of `SECURITY_SCAN`)
Fixes sorting for vulnerability `SEVERITY` column in the tag details page

### What issue(s) does this fix
Fixes #1034
Fixes #1043 