### PR TITLE
feat(rbac): add vscode debug configuration for opened jest test files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0.0",
+    "configurations": [
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Current selected test",
+        "program": "${workspaceRoot}/node_modules/.bin/backstage-cli",
+        "args": ["package", "test", "${relativeFile}"],
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+      }
+    ]
+  }


### PR DESCRIPTION
# What does this pull request do:

Add ability to debug opened and selected test files for rbac-backend plugin  and another plugins in the vscode.