### PR TITLE
fix(rbac): disable edit when the user is unauthorized to read the catalog-entity

### DIFF
--- a/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
+++ b/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Table, WarningPanel } from '@backstage/core-components';
+import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
 import { usePermission } from '@backstage/plugin-permission-react';
 
 import { Card, CardContent, makeStyles } from '@material-ui/core';
@@ -43,9 +44,13 @@ const getEditIcon = (isAllowed: boolean, roleName: string) => {
 export const MembersCard = ({ roleName }: MembersCardProps) => {
   const { data, loading, retry, error } = useMembers(roleName);
   const [members, setMembers] = React.useState<MembersData[]>();
-  const permissionResult = usePermission({
+  const policyEntityPermissionResult = usePermission({
     permission: policyEntityUpdatePermission,
     resourceRef: policyEntityUpdatePermission.resourceType,
+  });
+  const catalogEntityPermissionResult = usePermission({
+    permission: catalogEntityReadPermission,
+    resourceRef: catalogEntityReadPermission.resourceType,
   });
 
   const classes = useStyles();
@@ -57,8 +62,17 @@ export const MembersCard = ({ roleName }: MembersCardProps) => {
       onClick: () => retry(),
     },
     {
-      icon: () => getEditIcon(permissionResult.allowed, roleName),
-      tooltip: !permissionResult.allowed ? 'Unauthorized to edit' : 'Edit',
+      icon: () =>
+        getEditIcon(
+          policyEntityPermissionResult.allowed &&
+            catalogEntityPermissionResult.allowed,
+          roleName,
+        ),
+      tooltip:
+        catalogEntityPermissionResult.allowed &&
+        policyEntityPermissionResult.allowed
+          ? 'Edit'
+          : 'Unauthorized to edit',
       isFreeAction: true,
       onClick: () => {},
     },

--- a/plugins/rbac/src/hooks/useRoles.ts
+++ b/plugins/rbac/src/hooks/useRoles.ts
@@ -81,13 +81,26 @@ export const useRoles = (
                 lastModified: '-',
                 actionsPermissionResults: {
                   delete: deletePermissionResult,
-                  edit: editPermissionResult,
+                  edit: {
+                    allowed:
+                      editPermissionResult.allowed &&
+                      catalogEntityReadPermissionResult.allowed,
+                    loading:
+                      editPermissionResult.loading &&
+                      catalogEntityReadPermissionResult.loading,
+                  },
                 },
               },
             ];
           }, [])
         : [],
-    [roles, policies, deletePermissionResult, editPermissionResult],
+    [
+      roles,
+      policies,
+      deletePermissionResult,
+      editPermissionResult,
+      catalogEntityReadPermissionResult,
+    ],
   );
   const loading = rolesLoading && policiesLoading;
   useInterval(


### PR DESCRIPTION
**Resolves:**
https://github.com/janus-idp/backstage-plugins/issues/1048

**Solution:**
Also checking for catalog entity read permission

**GIF:**
With no catalog-entity read permission
https://github.com/janus-idp/backstage-plugins/assets/22490998/7346598b-7ea0-475a-875d-875a05b018f2


With catalog-entity read permission
https://github.com/janus-idp/backstage-plugins/assets/22490998/4b943d00-d558-4105-b0ca-2c74f07d5f0f

