### PR TITLE
fix(servicenow): make sure that the correct openapi generator is executed

### DIFF
--- a/plugins/servicenow-actions/package.json
+++ b/plugins/servicenow-actions/package.json
@@ -24,7 +24,8 @@
     "prepack": "backstage-cli package prepack",
     "start": "backstage-cli package start",
     "test": "backstage-cli package test --passWithNoTests --coverage",
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "openapi": "npx openapi-typescript-codegen"
   },
   "dependencies": {
     "@backstage/plugin-scaffolder-node": "^0.2.6",


### PR DESCRIPTION
Tests for servicenow-actions were failing due to `Error: command --input not found`.
This was due to the wrong open API generator being executed. Instead of https://github.com/ferdikoomen/openapi-typescript-codegen the https://github.com/openapistack/openapicmd was started.