### PR TITLE
fix(app-config): invalid app-config.yaml

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -78,6 +78,7 @@ auth:
   providers: {}
 
 scaffolder:
+  {}
   # see https://backstage.io/docs/features/software-templates/configuration for software template options
 
 catalog:


### PR DESCRIPTION
The `app-config.yaml` file was found to be invalid.
To address this issue and ensure consistency with [backstage-showcase](https://github.com/janus-idp/backstage-showcase/blob/main/app-config.yaml#L139), the `scaffolder` property has been set to an empty object.