### PR TITLE
fix(kiali): update login url

### DIFF
--- a/plugins/kiali-backend/src/clients/fetch.ts
+++ b/plugins/kiali-backend/src/clients/fetch.ts
@@ -147,7 +147,7 @@ export class KialiFetcher {
       };
     }
 
-    const loginUrl = `${this.KialiDetails.url}/${endpoint}`;
+    const loginUrl = `${this.KialiDetails.url}/${endpoint.replace(/^\//g, '')}`;
     requestInit.url = new URL(loginUrl).href;
 
     if (this.KialiDetails.skipTLSVerify) {


### PR DESCRIPTION
Fix for Kiali plugin to use a url with a path as the Kiali backend url. 

Tested with: 

- `http://localhost:3001`
- `http://localhost:20001/kiali`

Fixes https://github.com/janus-idp/backstage-plugins/issues/1093

