### PR TITLE
fix(orchestrator): workflow runs table should be sorted by started date in descending order

### DIFF
--- a/plugins/orchestrator/package.json
+++ b/plugins/orchestrator/package.json
@@ -80,7 +80,8 @@
     "react-use": "^17.4.0",
     "swr": "^2.0.0",
     "uuid": "^9.0.1",
-    "vscode-languageserver-types": "^3.16.0"
+    "vscode-languageserver-types": "^3.16.0",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/plugins/orchestrator/src/components/WorkflowRunsTabContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowRunsTabContent.tsx
@@ -11,7 +11,7 @@ import {
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 
 import { Grid } from '@material-ui/core';
-import _ from 'lodash';
+import { sortBy } from 'lodash';
 
 import {
   ProcessInstanceState,
@@ -94,7 +94,7 @@ export const WorkflowRunsTabContent = () => {
 
   const filteredData = React.useMemo(
     () =>
-      _.sortBy(
+      sortBy(
         (value || []).filter(
           (row: WorkflowRunDetail) =>
             statusSelectorValue === Selector.AllItems ||

--- a/plugins/orchestrator/src/components/WorkflowRunsTabContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowRunsTabContent.tsx
@@ -11,6 +11,7 @@ import {
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 
 import { Grid } from '@material-ui/core';
+import _ from 'lodash';
 
 import {
   ProcessInstanceState,
@@ -93,11 +94,14 @@ export const WorkflowRunsTabContent = () => {
 
   const filteredData = React.useMemo(
     () =>
-      (value || []).filter(
-        (row: WorkflowRunDetail) =>
-          statusSelectorValue === Selector.AllItems ||
-          row.status === statusSelectorValue,
-      ),
+      _.sortBy(
+        (value || []).filter(
+          (row: WorkflowRunDetail) =>
+            statusSelectorValue === Selector.AllItems ||
+            row.status === statusSelectorValue,
+        ),
+        'started',
+      ).reverse(),
     [statusSelectorValue, value],
   );
 


### PR DESCRIPTION
Jira: [https://issues.redhat.com/browse/FLPATH-888](https://issues.redhat.com/browse/FLPATH-888)

In the workflow run table, the newest run workflow is always on the top of the list, and list is sorted by 'started' in descending order.
