### PR TITLE
feat(plugins): ui for dynamic-plugins-info-backend

### DIFF
--- a/plugins/dynamic-plugins-info/.eslintrc.js
+++ b/plugins/dynamic-plugins-info/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/dynamic-plugins-info/CONTRIBUTING.md
+++ b/plugins/dynamic-plugins-info/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Setting up the development environment for Dynamic Plugins Info plugin
+
+In [Backstage plugin terminology](https://backstage.io/docs/local-dev/cli-build-system#package-roles), the Dynamic Plugins Info plugin is a front-end plugin. You can start a live development session from the repository root using the following command:
+
+```console
+yarn workspace @janus-idp/backstage-plugin-dynamic-plugins-info run start
+```

--- a/plugins/dynamic-plugins-info/README.md
+++ b/plugins/dynamic-plugins-info/README.md
@@ -1,0 +1,45 @@
+# Dynamic Plugins Info plugin for Backstage
+
+The dynamic-plugins-info plugin is a frontend component for the [dynamic-plugins-info-backend](https://github.com/janus-idp/backstage-showcase/tree/main/plugins/dynamic-plugins-info-backend) plugin. It offers a simple table UI that supports client-side sorting, filtering and pagination.
+
+The plugin is designed to be installed dynamically in the [backstage-showcase](https://github.com/janus-idp/backstage-showcase/tree/main) app.
+
+To build this plugin and the dynamic entrypoint:
+
+`yarn install`
+
+`yarn tsc`
+
+`yarn build`
+
+`yarn export-dynamic`
+
+To install the dynamic plugin from a local build:
+
+```bash
+cd dist-scalprum
+npm pack .
+archive=$(npm pack $pkg)
+tar -xzf "$archive" && rm "$archive"
+mv package $(echo $archive | sed -e 's:\.tgz$::')
+```
+
+Move the resulting directory (`janus-idp-backstage-plugin-dynamic-plugins-info-0.1.0`) into the `dynamic-plugins-root` folder of your [backstage-showcase](https://github.com/janus-idp/backstage-showcase/tree/main) clone.
+
+This configuration will enable the plugin to be visible in the UI:
+
+```yaml
+dynamicPlugins:
+  frontend:
+    janus-idp.backstage-plugin-dynamic-plugins-info:
+      dynamicRoutes:
+        - path: /admin/plugins
+          importName: DynamicPluginsInfo
+      mountPoints:
+        - mountPoint: admin.page.plugins/cards
+          importName: DynamicPluginsInfo
+          config:
+            layout:
+              gridColumn: '1 / -1'
+              width: 100vw
+```

--- a/plugins/dynamic-plugins-info/app-config.janus-idp.yaml
+++ b/plugins/dynamic-plugins-info/app-config.janus-idp.yaml
@@ -1,0 +1,13 @@
+dynamicPlugins:
+  frontend:
+    janus-idp.backstage-plugin-dynamic-plugins-info:
+      dynamicRoutes:
+        - path: /admin/plugins
+          importName: DynamicPluginsInfo
+      mountPoints:
+        - mountPoint: admin.page.plugins/cards
+          importName: DynamicPluginsInfo
+          config:
+            layout:
+              gridColumn: '1 / -1'
+              width: 100vw

--- a/plugins/dynamic-plugins-info/dev/index.tsx
+++ b/plugins/dynamic-plugins-info/dev/index.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import { Content, Header, HeaderTabs, Page } from '@backstage/core-components';
+import { createDevApp } from '@backstage/dev-utils';
+import { TestApiProvider } from '@backstage/test-utils';
+
+import { dynamicPluginsInfoApiRef } from '../src/api/types';
+import { DynamicPluginsInfoContent } from '../src/components/DynamicPluginsInfoContent/DynamicPluginsInfoContent';
+import { dynamicPluginsInfoPlugin } from '../src/plugin';
+
+export const listLoadedPluginsResult = [
+  {
+    name: 'some-plugin-one',
+    version: '0.1.0',
+    role: 'frontend-plugin',
+    platform: 'web',
+  },
+  {
+    name: 'some-plugin-two',
+    version: '1.1.0',
+    role: 'backend-plugin-module',
+    platform: 'node',
+  },
+  {
+    name: 'some-plugin-three',
+    version: '0.1.2',
+    role: 'backend-plugin',
+    platform: 'node',
+  },
+  {
+    name: 'some-plugin-four',
+    version: '1.1.0',
+    role: 'frontend-plugin',
+    platform: 'web',
+  },
+  {
+    name: 'some-plugin-five',
+    version: '1.2.0',
+    role: 'frontend-plugin',
+    platform: 'web',
+  },
+  {
+    name: 'some-plugin-six',
+    version: '0.6.3',
+    role: 'backend-plugin',
+    platform: 'node',
+  },
+];
+
+const mockedApi = {
+  listLoadedPlugins: async () => {
+    return listLoadedPluginsResult;
+  },
+};
+
+createDevApp()
+  .registerPlugin(dynamicPluginsInfoPlugin)
+  .addPage({
+    element: (
+      <TestApiProvider apis={[[dynamicPluginsInfoApiRef, mockedApi]]}>
+        <Page themeId="theme">
+          <Header title="Administration" />
+          <HeaderTabs
+            selectedIndex={1}
+            tabs={[
+              {
+                id: 'rbac',
+                label: 'RBAC',
+              },
+              {
+                id: 'plugins',
+                label: 'Plugins',
+              },
+            ]}
+          />
+          <Content>
+            <DynamicPluginsInfoContent />
+          </Content>
+        </Page>
+      </TestApiProvider>
+    ),
+    title: 'Root Page',
+    path: '/dynamic-plugins-info',
+  })
+  .render();

--- a/plugins/dynamic-plugins-info/package.json
+++ b/plugins/dynamic-plugins-info/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@janus-idp/backstage-plugin-dynamic-plugins-info",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin",
+    "lint": "backstage-cli package lint",
+    "postpack": "backstage-cli package postpack",
+    "postversion": "yarn run export-dynamic",
+    "prepack": "backstage-cli package prepack",
+    "start": "backstage-cli package start",
+    "test": "backstage-cli package test --passWithNoTests --coverage",
+    "tsc": "tsc"
+  },
+  "dependencies": {
+    "@backstage/core-components": "^0.13.6",
+    "@backstage/core-plugin-api": "^1.7.0",
+    "@backstage/theme": "^0.4.3",
+    "@material-table/core": "^3.1.0",
+    "react-use": "^17.4.0"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-router-dom": "^6.20.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.0",
+    "@backstage/core-app-api": "1.11.0",
+    "@backstage/dev-utils": "1.0.22",
+    "@backstage/test-utils": "1.4.4",
+    "@testing-library/jest-dom": "5.17.0",
+    "@testing-library/react": "12.1.5",
+    "@testing-library/user-event": "14.5.1",
+    "msw": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "janus-idp.backstage-plugin-dynamic-plugins-info",
+    "exposedModules": {
+      "PluginRoot": "./src/index.ts"
+    }
+  },
+  "repository": "github:janus-idp/backstage-plugins",
+  "keywords": [
+    "backstage",
+    "plugin"
+  ],
+  "homepage": "https://janus-idp.io/",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
+}

--- a/plugins/dynamic-plugins-info/src/api/DynamicPluginsInfoClient.ts
+++ b/plugins/dynamic-plugins-info/src/api/DynamicPluginsInfoClient.ts
@@ -1,0 +1,30 @@
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+
+import { DynamicPluginInfo, DynamicPluginsInfoApi } from './types';
+
+export interface DynamicPluginsInfoClientOptions {
+  discoveryApi: DiscoveryApi;
+  fetchApi: FetchApi;
+}
+
+const loadedPluginsEndpoint = '/loaded-plugins';
+
+export class DynamicPluginsInfoClient implements DynamicPluginsInfoApi {
+  private readonly discoveryApi: DiscoveryApi;
+  private readonly fetchApi: FetchApi;
+
+  constructor(options: DynamicPluginsInfoClientOptions) {
+    this.discoveryApi = options.discoveryApi;
+    this.fetchApi = options.fetchApi;
+  }
+  async listLoadedPlugins(): Promise<DynamicPluginInfo[]> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('dynamic-plugins-info');
+    const targetUrl = `${baseUrl}${loadedPluginsEndpoint}`;
+    const response = await this.fetchApi.fetch(targetUrl);
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(`${data.message}`);
+    }
+    return data;
+  }
+}

--- a/plugins/dynamic-plugins-info/src/api/types.ts
+++ b/plugins/dynamic-plugins-info/src/api/types.ts
@@ -1,0 +1,16 @@
+import { createApiRef } from '@backstage/core-plugin-api';
+
+export type DynamicPluginInfo = {
+  name: string;
+  version: string;
+  role: string;
+  platform: string;
+};
+
+export interface DynamicPluginsInfoApi {
+  listLoadedPlugins(): Promise<DynamicPluginInfo[]>;
+}
+
+export const dynamicPluginsInfoApiRef = createApiRef<DynamicPluginsInfoApi>({
+  id: 'plugin.dynamic-plugins-info',
+});

--- a/plugins/dynamic-plugins-info/src/components/DynamicPluginsInfoContent/DynamicPluginsInfoContent.tsx
+++ b/plugins/dynamic-plugins-info/src/components/DynamicPluginsInfoContent/DynamicPluginsInfoContent.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { ContentHeader, SupportButton } from '@backstage/core-components';
+
+import { DynamicPluginsTable } from '../DynamicPluginsTable/DynamicPluginsTable';
+
+export const DynamicPluginsInfoContent = () => (
+  <>
+    <ContentHeader title="">
+      <SupportButton title="Support">Some placeholder text</SupportButton>
+    </ContentHeader>
+    <DynamicPluginsTable />
+  </>
+);

--- a/plugins/dynamic-plugins-info/src/components/DynamicPluginsTable/DynamicPluginsTable.tsx
+++ b/plugins/dynamic-plugins-info/src/components/DynamicPluginsTable/DynamicPluginsTable.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+
+import {
+  ResponseErrorPanel,
+  Table,
+  TableColumn,
+} from '@backstage/core-components';
+import { useApi } from '@backstage/core-plugin-api';
+
+import { Query, QueryResult } from '@material-table/core';
+
+import { DynamicPluginInfo, dynamicPluginsInfoApiRef } from '../../api/types';
+
+export const DynamicPluginsTable = () => {
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [count, setCount] = useState<number>(0);
+  const dynamicPluginInfo = useApi(dynamicPluginsInfoApiRef);
+  const columns: TableColumn<DynamicPluginInfo>[] = [
+    {
+      title: 'Name',
+      field: 'name',
+      defaultSort: 'asc',
+    },
+    {
+      title: 'Version',
+      field: 'version',
+      width: '30%',
+    },
+    {
+      title: 'Role',
+      render: ({ platform, role }) => <>{`${role} (${platform})`}</>,
+      sorting: false,
+    },
+  ];
+  const fetchData = async (
+    query: Query<DynamicPluginInfo>,
+  ): Promise<QueryResult<DynamicPluginInfo>> => {
+    const {
+      orderBy = { field: 'name' },
+      orderDirection = 'asc',
+      page = 0,
+      pageSize = 5,
+      search = '',
+    } = query || {};
+    try {
+      // for now sorting/searching/pagination is handled client-side
+      const data = (await dynamicPluginInfo.listLoadedPlugins())
+        .sort((a: Record<string, string>, b: Record<string, string>) => {
+          const field = orderBy.field!;
+          if (!a[field] || !b[field]) {
+            return 0;
+          }
+          return (
+            a[field].localeCompare(b[field]) *
+            (orderDirection === 'desc' ? -1 : 1)
+          );
+        })
+        .filter(
+          value =>
+            search.trim() === '' ||
+            JSON.stringify(value).indexOf(search.trim()) > 0,
+        );
+      const totalCount = data.length;
+      let start = 0;
+      let end = totalCount;
+      if (totalCount > pageSize) {
+        start = page * pageSize;
+        end = start + pageSize;
+      }
+      setCount(totalCount);
+      return { data: data.slice(start, end), page, totalCount };
+    } catch (loadingError) {
+      setError(loadingError as Error);
+      return { data: [], totalCount: 0, page: 0 };
+    }
+  };
+  if (error) {
+    return <ResponseErrorPanel error={error} />;
+  }
+  return (
+    <Table
+      title={`Installed Plugins (${count})`}
+      options={{
+        draggable: false,
+        filtering: false,
+        sorting: true,
+        paging: true,
+        thirdSortClick: false,
+        debounceInterval: 500,
+      }}
+      columns={columns}
+      data={fetchData}
+    />
+  );
+};

--- a/plugins/dynamic-plugins-info/src/index.ts
+++ b/plugins/dynamic-plugins-info/src/index.ts
@@ -1,0 +1,1 @@
+export { dynamicPluginsInfoPlugin, DynamicPluginsInfo } from './plugin';

--- a/plugins/dynamic-plugins-info/src/plugin.test.ts
+++ b/plugins/dynamic-plugins-info/src/plugin.test.ts
@@ -1,0 +1,7 @@
+import { dynamicPluginsInfoPlugin } from './plugin';
+
+describe('dynamic-plugins-info', () => {
+  it('should export plugin', () => {
+    expect(dynamicPluginsInfoPlugin).toBeDefined();
+  });
+});

--- a/plugins/dynamic-plugins-info/src/plugin.ts
+++ b/plugins/dynamic-plugins-info/src/plugin.ts
@@ -1,0 +1,40 @@
+import {
+  createApiFactory,
+  createPlugin,
+  createRoutableExtension,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
+
+import { DynamicPluginsInfoClient } from './api/DynamicPluginsInfoClient';
+import { dynamicPluginsInfoApiRef } from './api/types';
+import { dynamicPluginsInfoRouteRef } from './routes';
+
+export const dynamicPluginsInfoPlugin = createPlugin({
+  id: 'dynamic-plugins-info',
+  routes: {
+    root: dynamicPluginsInfoRouteRef,
+  },
+  apis: [
+    createApiFactory({
+      api: dynamicPluginsInfoApiRef,
+      deps: {
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, fetchApi }) =>
+        new DynamicPluginsInfoClient({ discoveryApi, fetchApi }),
+    }),
+  ],
+});
+
+export const DynamicPluginsInfo = dynamicPluginsInfoPlugin.provide(
+  createRoutableExtension({
+    name: 'DynamicPluginsInfo',
+    component: () =>
+      import(
+        './components/DynamicPluginsInfoContent/DynamicPluginsInfoContent'
+      ).then(m => m.DynamicPluginsInfoContent),
+    mountPoint: dynamicPluginsInfoRouteRef,
+  }),
+);

--- a/plugins/dynamic-plugins-info/src/routes.ts
+++ b/plugins/dynamic-plugins-info/src/routes.ts
@@ -1,0 +1,5 @@
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+export const dynamicPluginsInfoRouteRef = createRouteRef({
+  id: 'dynamic-plugins-info',
+});

--- a/plugins/dynamic-plugins-info/src/setupTests.ts
+++ b/plugins/dynamic-plugins-info/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/plugins/dynamic-plugins-info/tsconfig.json
+++ b/plugins/dynamic-plugins-info/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "include": ["src", "dev", "migrations"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "../../dist-types/plugins/dynamic-plugins-info",
+    "rootDir": "."
+  }
+}

--- a/plugins/dynamic-plugins-info/turbo.json
+++ b/plugins/dynamic-plugins-info/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "tsc": {
+      "outputs": ["../../dist-types/plugins/dynamic-plugins-info/**"],
+      "dependsOn": ["^tsc"]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,15 +249,6 @@
     "@aws-sdk/types" "^3.222.0"
     tslib "^1.11.1"
 
-"@aws-crypto/sha256-js@^5.0.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz#c4fdb773fdbed9a664fc1a95724e206cf3860042"
-  integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
-  dependencies:
-    "@aws-crypto/util" "^5.2.0"
-    "@aws-sdk/types" "^3.222.0"
-    tslib "^2.6.2"
-
 "@aws-crypto/supports-web-crypto@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz#5d1bf825afa8072af2717c3e455f35cda0103ec2"
@@ -273,15 +264,6 @@
     "@aws-sdk/types" "^3.222.0"
     "@aws-sdk/util-utf8-browser" "^3.0.0"
     tslib "^1.11.1"
-
-"@aws-crypto/util@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-5.2.0.tgz#71284c9cffe7927ddadac793c14f14886d3876da"
-  integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
-  dependencies:
-    "@aws-sdk/types" "^3.222.0"
-    "@smithy/util-utf8" "^2.0.0"
-    tslib "^2.6.2"
 
 "@aws-sdk/abort-controller@^3.347.0":
   version "3.374.0"
@@ -773,14 +755,6 @@
     "@smithy/protocol-http" "^3.0.7"
     "@smithy/signature-v4" "^2.0.0"
     "@smithy/types" "^2.3.5"
-    tslib "^2.5.0"
-
-"@aws-sdk/signature-v4@^3.347.0":
-  version "3.374.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-3.374.0.tgz#bd727f4c392acb81bc667aa4cfceeba608250771"
-  integrity sha512-2xLJvSdzcZZAg0lsDLUAuSQuihzK0dcxIK7WmfuJeF7DGKJFmp9czQmz5f3qiDz6IDQzvgK1M9vtJSVCslJbyQ==
-  dependencies:
-    "@smithy/signature-v4" "^1.0.1"
     tslib "^2.5.0"
 
 "@aws-sdk/token-providers@3.430.0":
@@ -4934,6 +4908,10 @@
   version "1.0.18"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-common/-/plugin-catalog-common-1.0.18.tgz#c60bc17ac6cf7c112713c9adc2a9eca6c08e0a09"
   integrity sha512-k8EQHv7x6ZmJlkyrC3cQByyiUh/mBxM83LbZcGDVR0WZw2+yP23rV3+NGMYuFW6P9c8jL47YuRFoqQ8FkmDs0Q==
+  dependencies:
+    "@backstage/catalog-model" "^1.4.3"
+    "@backstage/plugin-permission-common" "^0.7.10"
+    "@backstage/plugin-search-common" "^1.2.8"
 
 "@backstage/plugin-catalog-common@^1.0.20":
   version "1.0.20"
@@ -5003,20 +4981,6 @@
     "@backstage/catalog-model" "^1.4.3"
     "@backstage/errors" "^1.2.3"
     "@backstage/plugin-catalog-common" "^1.0.17"
-    "@backstage/types" "^1.1.1"
-
-"@backstage/plugin-catalog-node@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-node/-/plugin-catalog-node-1.6.1.tgz#9a872dfdc562f79cb1e3a5873028abaf5ae0b4f9"
-  integrity sha512-mYNzcCUy9s28/SymS0p1mPmjtRQBfICAS2lFUKfKFT6pXQ7sqnC0Cxcn9ln1XjS3+ikxFC7jfYs4EOrv2DVm7w==
-  dependencies:
-    "@backstage/backend-plugin-api" "^0.6.9"
-    "@backstage/catalog-client" "^1.5.2"
-    "@backstage/catalog-model" "^1.4.3"
-    "@backstage/errors" "^1.2.3"
-    "@backstage/plugin-catalog-common" "^1.0.20"
-    "@backstage/plugin-permission-common" "^0.7.12"
-    "@backstage/plugin-permission-node" "^0.7.20"
     "@backstage/types" "^1.1.1"
 
 "@backstage/plugin-catalog-react@^1.8.5":
@@ -5293,50 +5257,6 @@
     react-use "^17.2.4"
     zod "^3.21.4"
 
-"@backstage/plugin-kubernetes-backend@^0.14.0":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-kubernetes-backend/-/plugin-kubernetes-backend-0.14.1.tgz#452a55589a9026ed3a1b93274fbf671b68011c51"
-  integrity sha512-iZqUP0/516SS1HvyJsP/Frf0fR8Q9VN26RQDWB6uz09AS2EUJaUa53xdU8k8JqjdGhgi9V9uzqUbl93TT20DgQ==
-  dependencies:
-    "@aws-crypto/sha256-js" "^5.0.0"
-    "@aws-sdk/credential-providers" "^3.350.0"
-    "@aws-sdk/signature-v4" "^3.347.0"
-    "@azure/identity" "^4.0.0"
-    "@backstage/backend-common" "^0.20.1"
-    "@backstage/backend-plugin-api" "^0.6.9"
-    "@backstage/catalog-client" "^1.5.2"
-    "@backstage/catalog-model" "^1.4.3"
-    "@backstage/config" "^1.1.1"
-    "@backstage/errors" "^1.2.3"
-    "@backstage/integration-aws-node" "^0.1.8"
-    "@backstage/plugin-auth-node" "^0.4.3"
-    "@backstage/plugin-catalog-node" "^1.6.1"
-    "@backstage/plugin-kubernetes-common" "^0.7.3"
-    "@backstage/plugin-kubernetes-node" "^0.1.3"
-    "@backstage/plugin-permission-common" "^0.7.12"
-    "@backstage/plugin-permission-node" "^0.7.20"
-    "@backstage/types" "^1.1.1"
-    "@google-cloud/container" "^5.0.0"
-    "@jest-mock/express" "^2.0.1"
-    "@kubernetes/client-node" "0.20.0"
-    "@types/express" "^4.17.6"
-    "@types/http-proxy-middleware" "^0.19.3"
-    "@types/luxon" "^3.0.0"
-    compression "^1.7.4"
-    cors "^2.8.5"
-    express "^4.17.1"
-    express-promise-router "^4.1.0"
-    fs-extra "10.1.0"
-    helmet "^6.0.0"
-    http-proxy-middleware "^2.0.6"
-    lodash "^4.17.21"
-    luxon "^3.0.0"
-    morgan "^1.10.0"
-    node-fetch "^2.6.7"
-    stream-buffers "^3.0.2"
-    winston "^3.2.1"
-    yn "^4.0.0"
-
 "@backstage/plugin-kubernetes-common@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-kubernetes-common/-/plugin-kubernetes-common-0.7.0.tgz#9a76ca60f74d8bf76def9c22b8d0815b09b3b562"
@@ -5352,29 +5272,6 @@
     lodash "^4.17.21"
     luxon "^3.0.0"
 
-"@backstage/plugin-kubernetes-common@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-kubernetes-common/-/plugin-kubernetes-common-0.7.3.tgz#d9421387109e9bfc510b0e2de3857b78ba5181ef"
-  integrity sha512-5p9Tj8HjBs06cdofzkGZm4fncUGyhsKboodzK/RF47sHY8G+sAC4vUMoTlcOJczU16tC0tOeXOgkKjhVYIMWDQ==
-  dependencies:
-    "@backstage/catalog-model" "^1.4.3"
-    "@backstage/plugin-permission-common" "^0.7.12"
-    "@backstage/types" "^1.1.1"
-    "@kubernetes/client-node" "0.20.0"
-    kubernetes-models "^4.3.1"
-    lodash "^4.17.21"
-    luxon "^3.0.0"
-
-"@backstage/plugin-kubernetes-node@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-kubernetes-node/-/plugin-kubernetes-node-0.1.3.tgz#b3478b58fddd6a6931122cf377eeef2275f93d2b"
-  integrity sha512-MWnGmzv6swwg3kWtP8k0nIYlOCOsfDkMW/Rk8Vy5RVLy/TkDjJilSXl8nHR1h9z3XFTwXMMtR7X7UmhwK6wxxQ==
-  dependencies:
-    "@backstage/backend-plugin-api" "^0.6.9"
-    "@backstage/catalog-model" "^1.4.3"
-    "@backstage/plugin-kubernetes-common" "^0.7.3"
-    "@backstage/types" "^1.1.1"
-
 "@backstage/plugin-kubernetes-react@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-kubernetes-react/-/plugin-kubernetes-react-0.1.0.tgz#2e7f185e8fb14e9e6afa792fe17630705e01d240"
@@ -5389,34 +5286,6 @@
     "@kubernetes-models/apimachinery" "^1.1.0"
     "@kubernetes-models/base" "^4.0.1"
     "@kubernetes/client-node" "^0.19.0"
-    "@material-ui/core" "^4.9.13"
-    "@material-ui/icons" "^4.11.3"
-    "@material-ui/lab" "^4.0.0-alpha.61"
-    "@types/react" "^16.13.1 || ^17.0.0"
-    cronstrue "^2.32.0"
-    js-yaml "^4.1.0"
-    kubernetes-models "^4.3.1"
-    lodash "^4.17.21"
-    luxon "^3.0.0"
-    react-use "^17.4.0"
-    xterm "^5.3.0"
-    xterm-addon-attach "^0.9.0"
-    xterm-addon-fit "^0.8.0"
-
-"@backstage/plugin-kubernetes-react@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-kubernetes-react/-/plugin-kubernetes-react-0.2.1.tgz#cd62a15639f36b0e1ac3bc03cb34d901a885bb14"
-  integrity sha512-f5tNbBzfn5/DHavPW3pj/zuqsnIyDFGjZhxf9sCvakPiq18eh9P6FH8CMlsr9I5WzHeE+sbtPjLuHySFZbnVVg==
-  dependencies:
-    "@backstage/catalog-model" "^1.4.3"
-    "@backstage/core-components" "^0.13.10"
-    "@backstage/core-plugin-api" "^1.8.2"
-    "@backstage/errors" "^1.2.3"
-    "@backstage/plugin-kubernetes-common" "^0.7.3"
-    "@backstage/types" "^1.1.1"
-    "@kubernetes-models/apimachinery" "^1.1.0"
-    "@kubernetes-models/base" "^4.0.1"
-    "@kubernetes/client-node" "^0.20.0"
     "@material-ui/core" "^4.9.13"
     "@material-ui/icons" "^4.11.3"
     "@material-ui/lab" "^4.0.0-alpha.61"
@@ -5459,31 +5328,6 @@
     lodash "^4.17.21"
     luxon "^3.0.0"
     react-use "^17.2.4"
-    xterm "^5.2.1"
-    xterm-addon-attach "^0.9.0"
-    xterm-addon-fit "^0.8.0"
-
-"@backstage/plugin-kubernetes@^0.11.2":
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-kubernetes/-/plugin-kubernetes-0.11.4.tgz#7c8fca7219df57b35b1cfc94d0c1bc16d24c275f"
-  integrity sha512-I/86dpa1sVH472huUt+PpJXEMRtTEqKZLJj+vYFs2a+aXOU9hWBF0fqBC+CoIaX1GLw8dCsy83jpIIzUa0PEww==
-  dependencies:
-    "@backstage/catalog-model" "^1.4.3"
-    "@backstage/core-components" "^0.13.10"
-    "@backstage/core-plugin-api" "^1.8.2"
-    "@backstage/plugin-catalog-react" "^1.9.3"
-    "@backstage/plugin-kubernetes-common" "^0.7.3"
-    "@backstage/plugin-kubernetes-react" "^0.2.1"
-    "@kubernetes-models/apimachinery" "^1.1.0"
-    "@kubernetes-models/base" "^4.0.1"
-    "@kubernetes/client-node" "0.20.0"
-    "@material-ui/core" "^4.12.2"
-    "@types/react" "^16.13.1 || ^17.0.0"
-    cronstrue "^2.2.0"
-    js-yaml "^4.0.0"
-    kubernetes-models "^4.1.0"
-    lodash "^4.17.21"
-    luxon "^3.0.0"
     xterm "^5.2.1"
     xterm-addon-attach "^0.9.0"
     xterm-addon-fit "^0.8.0"
@@ -7183,13 +7027,6 @@
     qs "^6.10.1"
     xcase "^2.0.1"
 
-"@google-cloud/container@^5.0.0":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@google-cloud/container/-/container-5.4.1.tgz#1e2010c98c68d54d3f5faf1b07663bdeb330c328"
-  integrity sha512-O5g6YHqN4gQHdNwORiqodAIJRuBCHiXPBVJ4bYfPnyRwGcStxEIF4YCdTawbvOhoqlzqHWoLMDTPFE+ytSE91A==
-  dependencies:
-    google-gax "^4.0.3"
-
 "@google-cloud/firestore@^6.0.0":
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/firestore/-/firestore-6.8.0.tgz#d8c852844c381afaf62592796606c10e178400b5"
@@ -7313,15 +7150,7 @@
     "@grpc/proto-loader" "^0.7.0"
     "@types/node" ">=12.12.47"
 
-"@grpc/grpc-js@~1.9.6":
-  version "1.9.14"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.14.tgz#236378822876cbf7903f9d61a0330410e8dcc5a1"
-  integrity sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==
-  dependencies:
-    "@grpc/proto-loader" "^0.7.8"
-    "@types/node" ">=12.12.47"
-
-"@grpc/proto-loader@^0.7.0", "@grpc/proto-loader@^0.7.8":
+"@grpc/proto-loader@^0.7.0":
   version "0.7.10"
   resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.10.tgz#6bf26742b1b54d0a473067743da5d3189d06d720"
   integrity sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==
@@ -7416,76 +7245,6 @@
   dependencies:
     "@backstage/config" "^1.1.1"
     deep-freeze "^0.0.1"
-
-"@janus-idp/cli@1.4.7":
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/@janus-idp/cli/-/cli-1.4.7.tgz#2f013d68f768bc3d5b930c9527e032a1dd90c379"
-  integrity sha512-7lnmkTvcxT/iFXE3or5exgQ3CXd+VR9gJtCAXzjcFfpf8LfTQ4SgS7xRiijaQSZJacg/JSpRoIxuIH0sOHAvvw==
-  dependencies:
-    "@backstage/cli-common" "^0.1.13"
-    "@backstage/cli-node" "^0.1.5"
-    "@backstage/config" "^1.1.1"
-    "@backstage/config-loader" "^1.5.1"
-    "@backstage/errors" "^1.2.3"
-    "@backstage/eslint-plugin" "^0.1.3"
-    "@backstage/types" "^1.1.1"
-    "@manypkg/get-packages" "^1.1.3"
-    "@openshift/dynamic-plugin-sdk-webpack" "^3.0.0"
-    "@pmmmwh/react-refresh-webpack-plugin" "^0.5.7"
-    "@rollup/plugin-commonjs" "^25.0.4"
-    "@rollup/plugin-json" "^6.0.0"
-    "@rollup/plugin-node-resolve" "^15.2.1"
-    "@rollup/plugin-yaml" "^4.0.0"
-    "@svgr/rollup" "^8.1.0"
-    "@svgr/webpack" "^6.5.1"
-    "@yarnpkg/lockfile" "^1.1.0"
-    "@yarnpkg/parsers" "^3.0.0-rc.4"
-    bfj "^7.0.2"
-    chalk "^4.0.0"
-    chokidar "^3.3.1"
-    commander "^9.1.0"
-    css-loader "^6.5.1"
-    esbuild "^0.19.0"
-    esbuild-loader "^2.18.0"
-    eslint "^8.49.0"
-    eslint-config-prettier "^8.10.0"
-    eslint-webpack-plugin "^3.2.0"
-    express "^4.18.2"
-    fork-ts-checker-webpack-plugin "^7.0.0-alpha.8"
-    fs-extra "^10.1.0"
-    handlebars "^4.7.7"
-    html-webpack-plugin "^5.3.1"
-    inquirer "^8.2.0"
-    lodash "^4.17.21"
-    mini-css-extract-plugin "^2.4.2"
-    node-libs-browser "^2.2.1"
-    npm-packlist "^5.0.0"
-    ora "^5.3.0"
-    postcss "^8.2.13"
-    process "^0.11.10"
-    react-dev-utils "^12.0.0-next.60"
-    react-refresh "^0.14.0"
-    recursive-readdir "^2.2.2"
-    rollup "^2.78.0"
-    rollup-plugin-dts "^4.0.1"
-    rollup-plugin-esbuild "^4.7.2"
-    rollup-plugin-postcss "^4.0.0"
-    rollup-pluginutils "^2.8.2"
-    semver "^7.5.4"
-    style-loader "^3.3.1"
-    swc-loader "^0.2.3"
-    typescript-json-schema "^0.62.0"
-    webpack "^5.89.0"
-    webpack-dev-server "^4.15.1"
-    yml-loader "^2.1.0"
-    yn "^4.0.0"
-
-"@jest-mock/express@^2.0.1":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@jest-mock/express/-/express-2.0.2.tgz#e4f61c30b45e517c14b35ea5d67d89a7e52908f7"
-  integrity sha512-B1mjh5Tgm/HDd3BLC9s2jZNqRIxiJJD5rMWm48gEeK0K2hfUE66QZ+AxHxHlb/uaqL9H+PFJzCSjJPl46oNzDg==
-  dependencies:
-    "@types/express" "^4.17.17"
 
 "@jest/console@^29.7.0":
   version "29.7.0"
@@ -8156,7 +7915,7 @@
   optionalDependencies:
     openid-client "^5.3.0"
 
-"@kubernetes/client-node@0.20.0", "@kubernetes/client-node@^0.20.0":
+"@kubernetes/client-node@0.20.0":
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-0.20.0.tgz#4447ae27fd6eef3d4830a5a039f3b84ffd5c5913"
   integrity sha512-xxlv5GLX4FVR/dDKEsmi4SPeuB49aRc35stndyxcC73XnUEEwF39vXbROpHOirmDse8WE9vxOjABnSVS+jb7EA==
@@ -10840,16 +10599,6 @@
     "@smithy/url-parser" "^2.0.11"
     tslib "^2.5.0"
 
-"@smithy/eventstream-codec@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-1.1.0.tgz#bfe1308ba84ff3db3e79dc1ced8231c52ac0fc36"
-  integrity sha512-3tEbUb8t8an226jKB6V/Q2XU/J53lCwCzULuBPEaF4JjSh+FlCMp7TmogE/Aij5J9DwlsZ4VAD/IRDuQ/0ZtMw==
-  dependencies:
-    "@aws-crypto/crc32" "3.0.0"
-    "@smithy/types" "^1.2.0"
-    "@smithy/util-hex-encoding" "^1.1.0"
-    tslib "^2.5.0"
-
 "@smithy/eventstream-codec@^2.0.11":
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-2.0.11.tgz#1ba090ea5dbf956e32d3d0d0986ffb0d0af8c57d"
@@ -10941,13 +10690,6 @@
   integrity sha512-zazq99ujxYv/NOf9zh7xXbNgzoVLsqE0wle8P/1zU/XdhPi/0zohTPKWUzIxjGdqb5hkkwfBkNkl5H+LE0mvgw==
   dependencies:
     "@smithy/types" "^2.3.5"
-    tslib "^2.5.0"
-
-"@smithy/is-array-buffer@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz#29948072da2b57575aa9898cda863932e842ab11"
-  integrity sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==
-  dependencies:
     tslib "^2.5.0"
 
 "@smithy/is-array-buffer@^2.0.0":
@@ -11115,20 +10857,6 @@
     "@smithy/types" "^2.3.5"
     tslib "^2.5.0"
 
-"@smithy/signature-v4@^1.0.1":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-1.1.0.tgz#e85309995c2475d39598a4f56e68b7ed856bdfa6"
-  integrity sha512-fDo3m7YqXBs7neciOePPd/X9LPm5QLlDMdIC4m1H6dgNLnXfLMFNIxEfPyohGA8VW9Wn4X8lygnPSGxDZSmp0Q==
-  dependencies:
-    "@smithy/eventstream-codec" "^1.1.0"
-    "@smithy/is-array-buffer" "^1.1.0"
-    "@smithy/types" "^1.2.0"
-    "@smithy/util-hex-encoding" "^1.1.0"
-    "@smithy/util-middleware" "^1.1.0"
-    "@smithy/util-uri-escape" "^1.1.0"
-    "@smithy/util-utf8" "^1.1.0"
-    tslib "^2.5.0"
-
 "@smithy/signature-v4@^2.0.0":
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-2.0.11.tgz#e6d9065c7a73fc6f518f0cbc94039aed49307a1c"
@@ -11198,14 +10926,6 @@
   dependencies:
     tslib "^2.5.0"
 
-"@smithy/util-buffer-from@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz#a000bd9f95c0e8d5b0edb0112f2a586daa5bed49"
-  integrity sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==
-  dependencies:
-    "@smithy/is-array-buffer" "^1.1.0"
-    tslib "^2.5.0"
-
 "@smithy/util-buffer-from@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz#7eb75d72288b6b3001bc5f75b48b711513091deb"
@@ -11245,24 +10965,10 @@
     "@smithy/types" "^2.3.5"
     tslib "^2.5.0"
 
-"@smithy/util-hex-encoding@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-1.1.0.tgz#b5ba919aa076a3fd5e93e368e34ae2b732fa2090"
-  integrity sha512-7UtIE9eH0u41zpB60Jzr0oNCQ3hMJUabMcKRUVjmyHTXiWDE4vjSqN6qlih7rCNeKGbioS7f/y2Jgym4QZcKFg==
-  dependencies:
-    tslib "^2.5.0"
-
 "@smithy/util-hex-encoding@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz#0aa3515acd2b005c6d55675e377080a7c513b59e"
   integrity sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==
-  dependencies:
-    tslib "^2.5.0"
-
-"@smithy/util-middleware@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-1.1.0.tgz#9f186489437ca2ef753c5e1de2930f76fd1edc14"
-  integrity sha512-6hhckcBqVgjWAqLy2vqlPZ3rfxLDhFWEmM7oLh2POGvsi7j0tHkbN7w4DFhuBExVJAbJ/qqxqZdRY6Fu7/OezQ==
   dependencies:
     tslib "^2.5.0"
 
@@ -11309,14 +11015,6 @@
   resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz#19955b1a0f517a87ae77ac729e0e411963dfda95"
   integrity sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==
   dependencies:
-    tslib "^2.5.0"
-
-"@smithy/util-utf8@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-1.1.0.tgz#b791ab1e3f694374edfe22811e39dd8424a1be69"
-  integrity sha512-p/MYV+JmqmPyjdgyN2UxAeYDj9cBqCjp0C/NsTWnnjoZUVqoeZ6IrW915L9CAKWVECgv9lVQGc4u/yz26/bI1A==
-  dependencies:
-    "@smithy/util-buffer-from" "^1.1.0"
     tslib "^2.5.0"
 
 "@smithy/util-utf8@^2.0.0":
@@ -14316,7 +14014,7 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/express@^4.17.17", "@types/express@^4.7.0":
+"@types/express@^4.7.0":
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
   integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
@@ -14418,22 +14116,6 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.3.tgz#c54e61f79b3947d040f150abd58f71efb422ff62"
   integrity sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA==
-
-"@types/http-proxy-middleware@^0.19.3":
-  version "0.19.3"
-  resolved "https://registry.yarnpkg.com/@types/http-proxy-middleware/-/http-proxy-middleware-0.19.3.tgz#b2eb96fbc0f9ac7250b5d9c4c53aade049497d03"
-  integrity sha512-lnBTx6HCOUeIJMLbI/LaL5EmdKLhczJY5oeXZpX/cXE4rRqb3RmV7VcMpiEfYkmTjipv3h7IAyIINe4plEv7cA==
-  dependencies:
-    "@types/connect" "*"
-    "@types/http-proxy" "*"
-    "@types/node" "*"
-
-"@types/http-proxy@*":
-  version "1.17.14"
-  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.14.tgz#57f8ccaa1c1c3780644f8a94f9c6b5000b5e2eec"
-  integrity sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==
-  dependencies:
-    "@types/node" "*"
 
 "@types/http-proxy@^1.17.8":
   version "1.17.13"
@@ -22296,24 +21978,6 @@ google-gax@^3.5.7:
     protobufjs "7.2.4"
     protobufjs-cli "1.1.1"
     retry-request "^5.0.0"
-
-google-gax@^4.0.3:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-4.2.1.tgz#4b3a269b543655ef25f04537b5494a4bb5656934"
-  integrity sha512-Yal4oh2GMHBsFX8zunxwaRuD2bP7rrA7Oz/ooXK8uOMGnP71jNVRl6fUv8chYLkPTqEzBSij9TZw49B86SDVTg==
-  dependencies:
-    "@grpc/grpc-js" "~1.9.6"
-    "@grpc/proto-loader" "^0.7.0"
-    "@types/long" "^4.0.0"
-    abort-controller "^3.0.0"
-    duplexify "^4.0.0"
-    google-auth-library "^9.0.0"
-    node-fetch "^2.6.1"
-    object-hash "^3.0.0"
-    proto3-json-serializer "^2.0.0"
-    protobufjs "7.2.6"
-    retry-request "^7.0.0"
-    uuid "^9.0.1"
 
 google-p12-pem@^4.0.0:
   version "4.0.1"
@@ -30256,13 +29920,6 @@ proto3-json-serializer@^1.0.0:
   dependencies:
     protobufjs "^7.0.0"
 
-proto3-json-serializer@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/proto3-json-serializer/-/proto3-json-serializer-2.0.1.tgz#da0b510f6d6e584b1b5c271f045c26728abe71e0"
-  integrity sha512-8awBvjO+FwkMd6gNoGFZyqkHZXCFd54CIYTb6De7dPaufGJ2XNW+QUNqbMr8MaAocMdb+KpsD4rxEOaTBDCffA==
-  dependencies:
-    protobufjs "^7.2.5"
-
 protobufjs-cli@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz#f531201b1c8c7772066aa822bf9a08318b24a704"
@@ -30283,24 +29940,6 @@ protobufjs@7.2.4:
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
   integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/node" ">=13.7.0"
-    long "^5.0.0"
-
-protobufjs@7.2.6:
-  version "7.2.6"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.6.tgz#4a0ccd79eb292717aacf07530a07e0ed20278215"
-  integrity sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -30967,6 +30606,11 @@ react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
+react-relative-time@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/react-relative-time/-/react-relative-time-0.0.9.tgz#2fcbd7e9a74ee82ff0eac24bfbd26a7dc2998ccc"
+  integrity sha512-Vf59erCwSaJaYp/IhoEtq7dtt1y4YNDqNegmOY8sK2P6oHHe3sLOXjz9VTCr0yvL2Y7W6uwufrxU4jOX8fS/dA==
 
 react-remove-scroll-bar@^2.3.3:
   version "2.3.4"


### PR DESCRIPTION
This change adds a dynamic-plugins-info plugin which is a frontend for the [dynamic-plugins-info-backend](https://github.com/janus-idp/backstage-showcase/tree/main/plugins/dynamic-plugins-info-backend) plugin that is part of the Janus IDP [backstage-showcase](https://github.com/janus-idp/backstage-showcase) instance.  The plugin implements a table view of the plugin data and includes client-side filtering, sorting and pagination. A dev mode is available with some test data to populate the table. This initial implementation only covers installing the plugin dynamically.

Part pf [RHIDP-980](https://issues.redhat.com/browse/RHIDP-980)

Here's an example of the plugin running in dev mode:

![Screenshot from 2024-01-29 09-14-05](https://github.com/janus-idp/backstage-plugins/assets/351660/e2fcef5d-837e-4138-a236-bc52a04ca378)

And here's an example of the plugin running in backstage-showcase with [this PR in place](https://github.com/janus-idp/backstage-showcase/pull/932) using [this plugin](https://github.com/gashcrumb/simple-test-components) as a placeholder for the RBAC tab:

![Screenshot from 2024-01-29 09-55-49](https://github.com/janus-idp/backstage-plugins/assets/351660/65803f61-6376-4fbf-8351-8465a5916b3c)

There's a number of follow on improvements to be made such as replacing the placeholder for the support button.