### PR TITLE
fix(tekton): fix #947: Reset pagination when changing any filter

### DIFF
--- a/plugins/shared-react/src/types/pipeline/computedStatus.ts
+++ b/plugins/shared-react/src/types/pipeline/computedStatus.ts
@@ -3,6 +3,7 @@ export enum TerminatedReasons {
 }
 
 export enum ComputedStatus {
+  All = 'All',
   Cancelling = 'Cancelling',
   Succeeded = 'Succeeded',
   Failed = 'Failed',
@@ -14,7 +15,7 @@ export enum ComputedStatus {
   Cancelled = 'Cancelled',
   Pending = 'Pending',
   Idle = 'Idle',
-  Other = '-',
+  Other = 'Other',
 }
 
 export enum SucceedConditionReason {
@@ -44,20 +45,4 @@ export type TaskStatusTypes = {
   Cancelled: number;
   Failed: number;
   Skipped: number;
-};
-
-export const computedStatus: { [key: string]: string | ComputedStatus } = {
-  All: '',
-  Cancelling: ComputedStatus.Cancelling,
-  Succeeded: ComputedStatus.Succeeded,
-  Failed: ComputedStatus.Failed,
-  Running: ComputedStatus.Running,
-  'In Progress': ComputedStatus['In Progress'],
-  FailedToStart: ComputedStatus.FailedToStart,
-  PipelineNotStarted: ComputedStatus.PipelineNotStarted,
-  Skipped: ComputedStatus.Skipped,
-  Cancelled: ComputedStatus.Cancelled,
-  Pending: ComputedStatus.Pending,
-  Idle: ComputedStatus.Idle,
-  Other: ComputedStatus.Other,
 };

--- a/plugins/shared-react/src/utils/pipeline/pipeline.test.ts
+++ b/plugins/shared-react/src/utils/pipeline/pipeline.test.ts
@@ -13,15 +13,14 @@ describe('getRunStatusColor should handle ComputedStatus values', () => {
   it('should expect all but PipelineNotStarted to produce a non-default result', () => {
     // Verify that we cover colour states for all the ComputedStatus values
     const failCase = 'PipelineNotStarted';
-    const defaultCase = getRunStatusColor(ComputedStatus[failCase]);
-    const allOtherStatuses = Object.keys(ComputedStatus)
-      .filter(
-        status =>
-          status !== failCase &&
-          ComputedStatus[status as keyof typeof ComputedStatus] !==
-            ComputedStatus.Other,
-      )
-      .map(status => ComputedStatus[status as keyof typeof ComputedStatus]);
+    const defaultCase = getRunStatusColor(failCase);
+    const allStatuses = Object.keys(ComputedStatus) as ComputedStatus[];
+    const allOtherStatuses = allStatuses.filter(
+      status =>
+        status !== ComputedStatus.All &&
+        status !== ComputedStatus.Other &&
+        status !== failCase,
+    );
 
     expect(allOtherStatuses).not.toHaveLength(0);
     allOtherStatuses.forEach(statusValue => {

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunList.test.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunList.test.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { render } from '@testing-library/react';
 
-import { computedStatus } from '@janus-idp/shared-react';
+import { ComputedStatus } from '@janus-idp/shared-react';
 
 import { mockKubernetesPlrResponse } from '../../__fixtures__/1-pipelinesData';
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
@@ -35,7 +35,7 @@ describe('PipelineRunList', () => {
       selectedClusterErrors: [],
       clusters: ['ocp'],
       setSelectedCluster: () => {},
-      selectedStatus: '',
+      selectedStatus: ComputedStatus.All,
       setSelectedStatus: () => {},
       setIsExpanded: () => {},
     };
@@ -59,7 +59,7 @@ describe('PipelineRunList', () => {
       selectedClusterErrors: [],
       clusters: [],
       setSelectedCluster: () => {},
-      selectedStatus: '',
+      selectedStatus: ComputedStatus.All,
       setSelectedStatus: () => {},
       setIsExpanded: () => {},
     };
@@ -87,7 +87,7 @@ describe('PipelineRunList', () => {
       selectedClusterErrors: [],
       clusters: [],
       setSelectedCluster: () => {},
-      selectedStatus: '',
+      selectedStatus: ComputedStatus.All,
       setSelectedStatus: () => {},
       setIsExpanded: () => {},
     };
@@ -116,7 +116,7 @@ describe('PipelineRunList', () => {
       selectedClusterErrors: [],
       clusters: [],
       setSelectedCluster: () => {},
-      selectedStatus: '',
+      selectedStatus: ComputedStatus.All,
       setSelectedStatus: () => {},
       setIsExpanded: () => {},
     };
@@ -146,7 +146,7 @@ describe('PipelineRunList', () => {
       selectedClusterErrors: [{ message: '403 - forbidden' }],
       clusters: ['ocp'],
       setSelectedCluster: () => {},
-      selectedStatus: '',
+      selectedStatus: ComputedStatus.All,
       setSelectedStatus: () => {},
       setIsExpanded: () => {},
     };
@@ -175,7 +175,7 @@ describe('PipelineRunList', () => {
       selectedClusterErrors: [],
       clusters: ['ocp'],
       setSelectedCluster: () => {},
-      selectedStatus: computedStatus.Succeeded,
+      selectedStatus: ComputedStatus.Succeeded,
       setSelectedStatus: () => {},
       setIsExpanded: () => {},
     };
@@ -206,7 +206,7 @@ describe('PipelineRunList', () => {
       selectedClusterErrors: [],
       clusters: ['ocp'],
       setSelectedCluster: () => {},
-      selectedStatus: computedStatus.Cancelled,
+      selectedStatus: ComputedStatus.Cancelled,
       setSelectedStatus: () => {},
       setIsExpanded: () => {},
     };

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunListSearchBar.test.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunListSearchBar.test.tsx
@@ -4,14 +4,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { PipelineRunListSearchBar } from './PipelineRunListSearchBar';
 
-jest.mock('react-use/lib/useDebounce', () => {
-  return jest.fn(fn => fn);
-});
-
 describe('PipelineRunListSearchBar', () => {
   test('renders PipelineRunListSearchBar component', () => {
     const { getByPlaceholderText } = render(
-      <PipelineRunListSearchBar onSearch={() => {}} />,
+      <PipelineRunListSearchBar value="" onChange={() => {}} />,
     );
 
     screen.logTestingPlaygroundURL();
@@ -20,28 +16,29 @@ describe('PipelineRunListSearchBar', () => {
   });
 
   test('handles search input change', () => {
-    const { getByPlaceholderText } = render(
-      <PipelineRunListSearchBar onSearch={() => {}} />,
+    const onChange = jest.fn();
+    const { getByPlaceholderText, getByTestId } = render(
+      <PipelineRunListSearchBar value="" onChange={onChange} />,
     );
     const searchInput = getByPlaceholderText('Search');
+    const clearButton = getByTestId('clear-search');
+    expect(clearButton.getAttribute('disabled')).toBe(''); // disabled
 
     fireEvent.change(searchInput, { target: { value: 'example' } });
 
-    expect((searchInput as HTMLInputElement).value).toBe('example');
+    expect(onChange).toHaveBeenCalledWith('example');
   });
 
   test('clears search input', () => {
-    const { getByPlaceholderText, getByTestId } = render(
-      <PipelineRunListSearchBar onSearch={() => {}} />,
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <PipelineRunListSearchBar value="example" onChange={onChange} />,
     );
-    const searchInput = getByPlaceholderText('Search');
-
-    fireEvent.change(searchInput, { target: { value: 'example' } });
-
-    expect((searchInput as HTMLInputElement).value).toBe('example');
+    const clearButton = getByTestId('clear-search');
+    expect(clearButton.getAttribute('disabled')).toBe(null); // not disabled
 
     fireEvent.click(getByTestId('clear-search'));
 
-    expect((searchInput as HTMLInputElement).value).toBe('');
+    expect(onChange).toHaveBeenCalledWith('');
   });
 });

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunListSearchBar.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunListSearchBar.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import useDebounce from 'react-use/lib/useDebounce';
 
 import {
   FormControl,
@@ -11,11 +10,9 @@ import {
 import Clear from '@material-ui/icons/Clear';
 import Search from '@material-ui/icons/Search';
 
-import { PipelineRunKind } from '@janus-idp/shared-react';
-
 type PipelineRunListSearchBarProps = {
-  pipelineRuns?: PipelineRunKind[];
-  onSearch: React.Dispatch<React.SetStateAction<PipelineRunKind[] | undefined>>;
+  value: string;
+  onChange: (filter: string) => void;
 };
 
 const useStyles = makeStyles({
@@ -26,31 +23,10 @@ const useStyles = makeStyles({
 });
 
 export const PipelineRunListSearchBar = ({
-  pipelineRuns,
-  onSearch,
+  value,
+  onChange,
 }: PipelineRunListSearchBarProps) => {
-  const [search, setSearch] = React.useState<string>('');
   const classes = useStyles();
-
-  const searchByName = () => {
-    const filteredPipelineRuns =
-      pipelineRuns && search
-        ? pipelineRuns.filter((plr: PipelineRunKind) => {
-            const s = search.toUpperCase();
-            const n = plr.metadata?.name?.toUpperCase();
-            return n?.includes(s);
-          })
-        : undefined;
-    onSearch(filteredPipelineRuns);
-  };
-
-  useDebounce(
-    () => {
-      searchByName();
-    },
-    100,
-    [search],
-  );
 
   return (
     <FormControl className={classes.formControl}>
@@ -58,8 +34,8 @@ export const PipelineRunListSearchBar = ({
         aria-label="search"
         placeholder="Search"
         autoComplete="off"
-        onChange={event => setSearch(event.target.value)}
-        value={search}
+        onChange={event => onChange(event.target.value)}
+        value={value}
         startAdornment={
           <InputAdornment position="start">
             <Search />
@@ -69,9 +45,9 @@ export const PipelineRunListSearchBar = ({
           <InputAdornment position="end">
             <IconButton
               aria-label="clear search"
-              onClick={() => setSearch('')}
+              onClick={() => onChange('')}
               edge="end"
-              disabled={search.length === 0}
+              disabled={!value}
               data-testid="clear-search"
             >
               <Clear />

--- a/plugins/tekton/src/components/common/ClusterSelector.tsx
+++ b/plugins/tekton/src/components/common/ClusterSelector.tsx
@@ -52,7 +52,6 @@ export const ClusterSelector = () => {
         items={clusterOptions}
         selected={clusterSelected}
         margin="dense"
-        native
       />
     </div>
   );

--- a/plugins/tekton/src/components/common/StatusSelector.tsx
+++ b/plugins/tekton/src/components/common/StatusSelector.tsx
@@ -6,7 +6,7 @@ import { makeStyles, Theme, Typography } from '@material-ui/core';
 
 import './StatusSelector.css';
 
-import { computedStatus } from '@janus-idp/shared-react';
+import { ComputedStatus } from '@janus-idp/shared-react';
 
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
 
@@ -19,18 +19,18 @@ const useStyles = makeStyles<Theme>(theme => ({
   },
 }));
 
-export const statusOptions = Object.keys(computedStatus)
-  .sort((a, b) => {
-    if (a === b) {
+export const statusOptions = Object.entries(ComputedStatus)
+  .sort(([keyA], [keyB]) => {
+    if (keyA === keyB) {
       return 0;
-    } else if (a < b) {
+    } else if (keyA < keyB) {
       return -1;
     }
     return 1;
   })
-  .map((status: string) => ({
-    value: computedStatus[status],
-    label: status,
+  .map(([key, value]) => ({
+    value: key,
+    label: value,
   }));
 
 export const StatusSelector = () => {
@@ -40,7 +40,7 @@ export const StatusSelector = () => {
   );
 
   const onStatusChange = (status: SelectedItems) => {
-    setSelectedStatus(status as string);
+    setSelectedStatus(status as ComputedStatus);
   };
 
   return (
@@ -52,7 +52,6 @@ export const StatusSelector = () => {
         items={statusOptions}
         selected={selectedStatus}
         margin="dense"
-        native
       />
     </div>
   );

--- a/plugins/tekton/src/components/pipeline-topology/PipelineVisualizationView.test.tsx
+++ b/plugins/tekton/src/components/pipeline-topology/PipelineVisualizationView.test.tsx
@@ -3,6 +3,8 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { render } from '@testing-library/react';
 
+import { ComputedStatus } from '@janus-idp/shared-react';
+
 import { mockKubernetesPlrResponse } from '../../__fixtures__/1-pipelinesData';
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
 import { PipelineVisualizationView } from './PipelineVisualizationView';
@@ -28,7 +30,7 @@ describe('PipelineVisualizationView', () => {
       selectedClusterErrors: [],
       clusters: [],
       setSelectedCluster: () => {},
-      selectedStatus: '',
+      selectedStatus: ComputedStatus.All,
       setSelectedStatus: () => {},
       setIsExpanded: () => {},
     };

--- a/plugins/tekton/src/hooks/TektonResourcesContext.ts
+++ b/plugins/tekton/src/hooks/TektonResourcesContext.ts
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { computedStatus } from '@janus-idp/shared-react';
+import { ComputedStatus } from '@janus-idp/shared-react';
 
 import { TektonResourcesContextData } from '../types/types';
 
 export const TektonResourcesContext =
   React.createContext<TektonResourcesContextData>({
     clusters: [],
-    selectedStatus: computedStatus.All,
+    selectedStatus: ComputedStatus.All,
     setSelectedCluster: () => {},
     setSelectedStatus: () => {},
     setIsExpanded: () => {},

--- a/plugins/tekton/src/hooks/useTektonObjectsResponse.ts
+++ b/plugins/tekton/src/hooks/useTektonObjectsResponse.ts
@@ -6,7 +6,7 @@ import { useKubernetesObjects } from '@backstage/plugin-kubernetes';
 import { isEqual } from 'lodash';
 
 import {
-  computedStatus,
+  ComputedStatus,
   useDebounceCallback,
   useDeepCompareMemoize,
 } from '@janus-idp/shared-react';
@@ -21,8 +21,8 @@ export const useTektonObjectsResponse = (
   const { entity } = useEntity();
   const { kubernetesObjects, loading, error } = useKubernetesObjects(entity);
   const [selectedCluster, setSelectedCluster] = React.useState<number>(0);
-  const [selectedStatus, setSelectedStatus] = React.useState<string>(
-    computedStatus.All,
+  const [selectedStatus, setSelectedStatus] = React.useState<ComputedStatus>(
+    ComputedStatus.All,
   );
   const [isExpanded, setIsExpanded] = React.useState<boolean>(false);
   const [loaded, setLoaded] = React.useState<boolean>(false);

--- a/plugins/tekton/src/types/types.ts
+++ b/plugins/tekton/src/types/types.ts
@@ -1,3 +1,5 @@
+import { ComputedStatus } from '@janus-idp/shared-react';
+
 export const tektonGroupColor = '#38812f';
 
 export type GroupVersionKind = {
@@ -27,8 +29,8 @@ export type TektonResourcesContextData = {
   clusters: string[];
   selectedCluster?: number;
   setSelectedCluster: React.Dispatch<React.SetStateAction<number>>;
-  selectedStatus: string;
-  setSelectedStatus: React.Dispatch<React.SetStateAction<string>>;
+  selectedStatus: ComputedStatus;
+  setSelectedStatus: React.Dispatch<React.SetStateAction<ComputedStatus>>;
   isExpanded?: boolean;
   setIsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
 };

--- a/plugins/tekton/src/utils/pipeline-step-utils.test.ts
+++ b/plugins/tekton/src/utils/pipeline-step-utils.test.ts
@@ -87,7 +87,7 @@ describe('createStepStatus', () => {
     expect(stepStatus).toEqual({
       duration: undefined,
       name: '',
-      status: '-',
+      status: ComputedStatus.Other,
     });
   });
 });


### PR DESCRIPTION
Update the tekton plugin to fix #947 aka [](https://issues.redhat.com/browse/RHIDP-977):

1. Reset page to page 0 when the cluster, state filter or text-field changed
2. Calculate and set `filteredPipelineRuns` in a useMemo when some of the user states change, instead of having two states that are set when the search field changes.
3. Removed the `native` prop from the dropdowns so that the dropdowns are rendered with Material UI.

Before:

https://github.com/janus-idp/backstage-plugins/assets/139310/d1d717dd-7b52-49ee-8e2d-3439c8c97ba1

After:

https://github.com/janus-idp/backstage-plugins/assets/139310/31a6900e-5a0c-41a1-98ea-320d3e971308
