### PR TITLE
feat(orchestrator): add the ability to rerun workflows in a new instance

### DIFF
--- a/plugins/orchestrator-backend/src/service/DataIndexService.ts
+++ b/plugins/orchestrator-backend/src/service/DataIndexService.ts
@@ -5,7 +5,9 @@ import {
   fromWorkflowSource,
   getWorkflowCategory,
   Job,
+  parseWorkflowVariables,
   ProcessInstance,
+  ProcessInstanceVariables,
   WorkflowDefinition,
   WorkflowInfo,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
@@ -188,6 +190,25 @@ export class DataIndexService {
     }
 
     return result.data.Jobs;
+  }
+
+  public async fetchProcessInstanceVariables(
+    instanceId: string,
+  ): Promise<ProcessInstanceVariables | undefined> {
+    const graphQlQuery = `{ ProcessInstances (where: { id: {equal: "${instanceId}" } } ) { variables } }`;
+
+    const result = await this.client.query(graphQlQuery, {});
+
+    if (result.error) {
+      this.logger.error(
+        `Error when fetching process instance variables: ${result.error}`,
+      );
+      throw result.error;
+    }
+
+    const variables = result.data.ProcessInstances.pop().variables;
+
+    return parseWorkflowVariables(variables);
   }
 
   public async fetchProcessInstance(

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -249,9 +249,15 @@ export class SonataFlowService {
       const workflowEndpoint = args.businessKey
         ? `${args.endpoint}/${args.workflowId}?businessKey=${args.businessKey}`
         : `${args.endpoint}/${args.workflowId}`;
+
+      // No need to pass the business key as input value
+      // https://issues.redhat.com/browse/FLPATH-946
       const response = await fetch(workflowEndpoint, {
         method: 'POST',
-        body: JSON.stringify(args.inputData),
+        body: JSON.stringify({
+          ...args.inputData,
+          ...(args.businessKey ? { businessKey: args.businessKey } : {}),
+        }),
         headers: { 'content-type': 'application/json' },
       });
       return response.json();

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -250,14 +250,9 @@ export class SonataFlowService {
         ? `${args.endpoint}/${args.workflowId}?businessKey=${args.businessKey}`
         : `${args.endpoint}/${args.workflowId}`;
 
-      // No need to pass the business key as input value
-      // https://issues.redhat.com/browse/FLPATH-946
       const response = await fetch(workflowEndpoint, {
         method: 'POST',
-        body: JSON.stringify({
-          ...args.inputData,
-          ...(args.businessKey ? { businessKey: args.businessKey } : {}),
-        }),
+        body: JSON.stringify(args.inputData),
         headers: { 'content-type': 'application/json' },
       });
       return response.json();

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -243,10 +243,11 @@ export class SonataFlowService {
     workflowId: string;
     endpoint: string;
     inputData: Record<string, string>;
+    businessKey?: string;
   }): Promise<WorkflowExecutionResponse | undefined> {
     try {
-      const workflowEndpoint = args.inputData?.businessKey
-        ? `${args.endpoint}/${args.workflowId}?businessKey=${args.inputData.businessKey}`
+      const workflowEndpoint = args.businessKey
+        ? `${args.endpoint}/${args.workflowId}?businessKey=${args.businessKey}`
         : `${args.endpoint}/${args.workflowId}`;
       const response = await fetch(workflowEndpoint, {
         method: 'POST',

--- a/plugins/orchestrator-backend/src/service/constants.ts
+++ b/plugins/orchestrator-backend/src/service/constants.ts
@@ -1,0 +1,1 @@
+export const WORKFLOW_DATA_KEY = 'workflowdata';

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -11,7 +11,6 @@ import {
   AssessedProcessInstance,
   fromWorkflowSource,
   ORCHESTRATOR_SERVICE_READY_TOPIC,
-  parseWorkflowVariables,
   ProcessInstance,
   QUERY_PARAM_ASSESSMENT_INSTANCE_ID,
   QUERY_PARAM_BUSINESS_KEY,
@@ -294,18 +293,10 @@ function setupInternalRoutes(
 
     let assessedByInstance: ProcessInstance | undefined;
 
-    // We should take the business key from `instance.businessKey`
-    // https://issues.redhat.com/browse/FLPATH-946
-    if (!!includeAssessment && instance.variables) {
-      const parseVariables = parseWorkflowVariables(instance.variables);
-      const workflowData = parseVariables?.[WORKFLOW_DATA_KEY];
-      if (workflowData) {
-        const businessKey = (workflowData as JsonObject).businessKey as string;
-        if (businessKey) {
-          assessedByInstance =
-            await dataIndexService.fetchProcessInstance(businessKey);
-        }
-      }
+    if (!!includeAssessment && instance.businessKey) {
+      assessedByInstance = await dataIndexService.fetchProcessInstance(
+        instance.businessKey,
+      );
     }
 
     const response: AssessedProcessInstance = {

--- a/plugins/orchestrator-common/package.json
+++ b/plugins/orchestrator-common/package.json
@@ -37,6 +37,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
+    "@backstage/types": "^1.1.1",
     "@severlessworkflow/sdk-typescript": "^3.0.3",
     "js-yaml": "^4.1.0",
     "json-schema": "^0.4.0",

--- a/plugins/orchestrator-common/src/QueryParams.ts
+++ b/plugins/orchestrator-common/src/QueryParams.ts
@@ -1,0 +1,6 @@
+export const QUERY_PARAM_URI = 'uri' as const;
+export const QUERY_PARAM_BUSINESS_KEY = 'businessKey' as const;
+export const QUERY_PARAM_INSTANCE_ID = 'instanceId' as const;
+export const QUERY_PARAM_INCLUDE_ASSESSMENT = 'includeAssessment' as const;
+export const QUERY_PARAM_ASSESSMENT_INSTANCE_ID =
+  'assessmentInstanceId' as const;

--- a/plugins/orchestrator-common/src/constants.ts
+++ b/plugins/orchestrator-common/src/constants.ts
@@ -62,7 +62,7 @@ export const WORKFLOW_YAML_SAMPLE: WorkflowSample = {
 
 // Default values for the orchestrator plugin configuration
 export const DEFAULT_SONATAFLOW_CONTAINER_IMAGE =
-  'quay.io/kiegroup/kogito-swf-devmode-nightly:main-2024-01-29';
+  'quay.io/kiegroup/kogito-swf-devmode-nightly:main-2024-01-31';
 export const DEFAULT_SONATAFLOW_PERSISTANCE_PATH = '/home/kogito/persistence';
 export const DEFAULT_CATALOG_OWNER = 'orchestrator';
 export const DEFAULT_CATALOG_ENVIRONMENT = 'development';

--- a/plugins/orchestrator-common/src/constants.ts
+++ b/plugins/orchestrator-common/src/constants.ts
@@ -62,7 +62,7 @@ export const WORKFLOW_YAML_SAMPLE: WorkflowSample = {
 
 // Default values for the orchestrator plugin configuration
 export const DEFAULT_SONATAFLOW_CONTAINER_IMAGE =
-  'quay.io/kiegroup/kogito-swf-devmode-nightly:main-2024-01-08';
+  'quay.io/kiegroup/kogito-swf-devmode-nightly:main-2024-01-29';
 export const DEFAULT_SONATAFLOW_PERSISTANCE_PATH = '/home/kogito/persistence';
 export const DEFAULT_CATALOG_OWNER = 'orchestrator';
 export const DEFAULT_CATALOG_ENVIRONMENT = 'development';

--- a/plugins/orchestrator-common/src/index.ts
+++ b/plugins/orchestrator-common/src/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './constants';
 export * from './models';
 export * from './workflow';
+export * from './QueryParams';

--- a/plugins/orchestrator-common/src/models.ts
+++ b/plugins/orchestrator-common/src/models.ts
@@ -49,6 +49,9 @@ export interface ProcessInstanceError {
   nodeDefinitionId: string;
   message?: string;
 }
+
+export type ProcessInstanceVariables = Record<string, unknown>;
+
 export interface ProcessInstance {
   id: string;
   processId: string;
@@ -62,7 +65,7 @@ export interface ProcessInstance {
   serviceUrl?: string;
   nodes: NodeInstance[];
   milestones?: Milestone[];
-  variables?: Record<string, unknown> | string;
+  variables?: ProcessInstanceVariables | string;
   start: Date;
   end?: Date;
   parentProcessInstance?: ProcessInstance;

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -55,10 +55,16 @@ export interface WorkflowSpecFile {
   path: string;
   content: OpenAPIV3.Document;
 }
+
+export interface DataInputSchemaInitialState {
+  values: JsonObject[];
+  readonlyKeys: string[];
+}
+
 export interface WorkflowDataInputSchemaResponse {
   workflowItem: WorkflowItem;
   schemas: JSONSchema7[];
-  initialState: JsonObject[];
+  initialState: DataInputSchemaInitialState;
 }
 
 export interface WorkflowExecutionResponse {

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -1,8 +1,10 @@
+import { JsonObject } from '@backstage/types';
+
 import { Specification } from '@severlessworkflow/sdk-typescript';
 import { JSONSchema7 } from 'json-schema';
 import { OpenAPIV3 } from 'openapi-types';
 
-import { ProcessInstanceStateValues } from './models';
+import { ProcessInstance, ProcessInstanceStateValues } from './models';
 
 type Id<T> = { [P in keyof T]: T[P] };
 
@@ -56,6 +58,7 @@ export interface WorkflowSpecFile {
 export interface WorkflowDataInputSchemaResponse {
   workflowItem: WorkflowItem;
   schemas: JSONSchema7[];
+  initialState: JsonObject[];
 }
 
 export interface WorkflowExecutionResponse {
@@ -100,4 +103,9 @@ export interface Node {
   name?: string;
   uniqueId?: string;
   nodeDefinitionId?: string;
+}
+
+export interface AssessedProcessInstance {
+  instance: ProcessInstance;
+  assessedBy?: ProcessInstance;
 }

--- a/plugins/orchestrator-common/src/workflow.ts
+++ b/plugins/orchestrator-common/src/workflow.ts
@@ -2,6 +2,7 @@ import { Specification } from '@severlessworkflow/sdk-typescript';
 import { dump } from 'js-yaml';
 
 import { ASSESSMENT_WORKFLOW_TYPE } from './constants';
+import { ProcessInstanceVariables } from './models';
 import { WorkflowCategory, WorkflowDefinition, WorkflowFormat } from './types';
 
 export function fromWorkflowSource(content: string): WorkflowDefinition {
@@ -76,4 +77,24 @@ function removeProperty<T>(obj: T, propToDelete: string): T {
   }
 
   return newObj;
+}
+
+export function parseWorkflowVariables(
+  variables: ProcessInstanceVariables | string | undefined,
+): ProcessInstanceVariables | undefined {
+  if (variables === undefined) {
+    return undefined;
+  }
+
+  if (typeof variables === 'string') {
+    try {
+      return JSON.parse(variables) as ProcessInstanceVariables;
+    } catch {
+      throw new Error(
+        `Error when parsing process instance variables: ${variables}`,
+      );
+    }
+  }
+
+  return variables;
 }

--- a/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaDifferentTypes.ts
+++ b/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaDifferentTypes.ts
@@ -166,4 +166,5 @@ export const fakeDataInputSchemaDifferentTypes: WorkflowDataInputSchemaResponse 
         },
       },
     ],
+    initialState: [],
   };

--- a/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaDifferentTypes.ts
+++ b/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaDifferentTypes.ts
@@ -166,5 +166,5 @@ export const fakeDataInputSchemaDifferentTypes: WorkflowDataInputSchemaResponse 
         },
       },
     ],
-    initialState: [],
+    initialState: { values: [], readonlyKeys: [] },
   };

--- a/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaResponse.ts
+++ b/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaResponse.ts
@@ -1,6 +1,6 @@
 import { WorkflowDataInputSchemaResponse } from '@janus-idp/backstage-plugin-orchestrator-common';
 
-export const fakeDataInputSchemaReponse: WorkflowDataInputSchemaResponse = {
+export const fakeDataInputSchemaResponse: WorkflowDataInputSchemaResponse = {
   workflowItem: {
     uri: 'yamlgreet.sw.yaml',
     definition: {
@@ -91,4 +91,5 @@ export const fakeDataInputSchemaReponse: WorkflowDataInputSchemaResponse = {
       },
     },
   ],
+  initialState: [],
 };

--- a/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaResponse.ts
+++ b/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaResponse.ts
@@ -91,5 +91,5 @@ export const fakeDataInputSchemaResponse: WorkflowDataInputSchemaResponse = {
       },
     },
   ],
-  initialState: [],
+  initialState: { values: [], readonlyKeys: [] },
 };

--- a/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaResponseMultiStep.ts
+++ b/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaResponseMultiStep.ts
@@ -553,5 +553,5 @@ export const fakeDataInputSchemaMultiStepResponse: WorkflowDataInputSchemaRespon
         ],
       },
     ],
-    initialState: [],
+    initialState: { values: [], readonlyKeys: [] },
   };

--- a/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaResponseMultiStepInitialState.ts
+++ b/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaResponseMultiStepInitialState.ts
@@ -1,6 +1,6 @@
 import { WorkflowDataInputSchemaResponse } from '@janus-idp/backstage-plugin-orchestrator-common';
 
-export const fakeDataInputSchemaMultiStepResponse: WorkflowDataInputSchemaResponse =
+export const fakeDataInputSchemaMultiStepInitialStateResponse: WorkflowDataInputSchemaResponse =
   {
     workflowItem: {
       uri: 'quarkus-backend.sw.yaml',
@@ -553,5 +553,13 @@ export const fakeDataInputSchemaMultiStepResponse: WorkflowDataInputSchemaRespon
         ],
       },
     ],
-    initialState: [],
+    initialState: [
+      {
+        orgName: 'Org name',
+        repoName: 'Repo name',
+        description: 'Description',
+        owner: 'owner',
+        system: 'system',
+      },
+    ],
   };

--- a/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaResponseMultiStepInitialState.ts
+++ b/plugins/orchestrator/src/__fixtures__/fakeWorkflowDataInputSchemaResponseMultiStepInitialState.ts
@@ -553,13 +553,16 @@ export const fakeDataInputSchemaMultiStepInitialStateResponse: WorkflowDataInput
         ],
       },
     ],
-    initialState: [
-      {
-        orgName: 'Org name',
-        repoName: 'Repo name',
-        description: 'Description',
-        owner: 'owner',
-        system: 'system',
-      },
-    ],
+    initialState: {
+      values: [
+        {
+          orgName: 'Org name',
+          repoName: 'Repo name',
+          description: 'Description',
+          owner: 'owner',
+          system: 'system',
+        },
+      ],
+      readonlyKeys: ['orgName', 'system'],
+    },
   };

--- a/plugins/orchestrator/src/api/MockOrchestratorClient.ts
+++ b/plugins/orchestrator/src/api/MockOrchestratorClient.ts
@@ -148,6 +148,7 @@ export class MockOrchestratorClient implements OrchestratorApi {
   getWorkflowDataInputSchema(_args: {
     workflowId: string;
     instanceId?: string;
+    assessmentInstanceId?: string;
   }): Promise<WorkflowDataInputSchemaResponse> {
     if (
       !hasOwnProp(this._mockData, 'getWorkflowDataInputSchemaResponse') ||

--- a/plugins/orchestrator/src/api/MockOrchestratorClient.ts
+++ b/plugins/orchestrator/src/api/MockOrchestratorClient.ts
@@ -1,6 +1,7 @@
-import { JsonValue } from '@backstage/types';
+import { JsonObject } from '@backstage/types';
 
 import {
+  AssessedProcessInstance,
   Job,
   ProcessInstance,
   WorkflowDataInputSchemaResponse,
@@ -74,7 +75,7 @@ export class MockOrchestratorClient implements OrchestratorApi {
 
   executeWorkflow(_args: {
     workflowId: string;
-    parameters: Record<string, JsonValue>;
+    parameters: JsonObject;
   }): Promise<WorkflowExecutionResponse> {
     if (
       !hasOwnProp(this._mockData, 'executeWorkflowResponse') ||
@@ -86,7 +87,10 @@ export class MockOrchestratorClient implements OrchestratorApi {
     return this._mockData.executeWorkflowResponse();
   }
 
-  getInstance(_instanceId: string): Promise<ProcessInstance> {
+  getInstance(
+    _instanceId: string,
+    _includeAssessment: boolean,
+  ): Promise<AssessedProcessInstance> {
     if (
       !hasOwnProp(this._mockData, 'getInstanceResponse') ||
       !isNonNullable(this._mockData.getInstanceResponse)
@@ -141,9 +145,10 @@ export class MockOrchestratorClient implements OrchestratorApi {
     return Promise.resolve(this._mockData.getWorkflowResponse);
   }
 
-  getWorkflowDataInputSchema(
-    _workflowId: string,
-  ): Promise<WorkflowDataInputSchemaResponse> {
+  getWorkflowDataInputSchema(_args: {
+    workflowId: string;
+    instanceId?: string;
+  }): Promise<WorkflowDataInputSchemaResponse> {
     if (
       !hasOwnProp(this._mockData, 'getWorkflowDataInputSchemaResponse') ||
       !isNonNullable(this._mockData.getWorkflowDataInputSchemaResponse)

--- a/plugins/orchestrator/src/api/OrchestratorClient.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.ts
@@ -6,6 +6,11 @@ import {
   AssessedProcessInstance,
   Job,
   ProcessInstance,
+  QUERY_PARAM_ASSESSMENT_INSTANCE_ID,
+  QUERY_PARAM_BUSINESS_KEY,
+  QUERY_PARAM_INCLUDE_ASSESSMENT,
+  QUERY_PARAM_INSTANCE_ID,
+  QUERY_PARAM_URI,
   WorkflowDataInputSchemaResponse,
   WorkflowExecutionResponse,
   WorkflowItem,
@@ -15,11 +20,6 @@ import {
   WorkflowSpecFile,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
 
-import {
-  QUERY_PARAM_BUSINESS_KEY,
-  QUERY_PARAM_INCLUDE_ASSESSMENT,
-  QUERY_PARAM_INSTANCE_ID,
-} from '../constants';
 import { buildUrl } from '../utils/UrlUtils';
 import { OrchestratorApi } from './api';
 
@@ -140,11 +140,13 @@ export class OrchestratorClient implements OrchestratorApi {
   async getWorkflowDataInputSchema(args: {
     workflowId: string;
     instanceId?: string;
+    assessmentInstanceId?: string;
   }): Promise<WorkflowDataInputSchemaResponse> {
     const baseUrl = await this.getBaseUrl();
     const endpoint = `${baseUrl}/workflows/${args.workflowId}/inputSchema`;
     const urlToFetch = buildUrl(endpoint, {
       [QUERY_PARAM_INSTANCE_ID]: args.instanceId,
+      [QUERY_PARAM_ASSESSMENT_INSTANCE_ID]: args.assessmentInstanceId,
     });
     const res = await fetch(urlToFetch);
     if (!res.ok) {
@@ -158,7 +160,11 @@ export class OrchestratorClient implements OrchestratorApi {
     content: string,
   ): Promise<WorkflowItem> {
     const baseUrl = await this.getBaseUrl();
-    const res = await fetch(`${baseUrl}/workflows?uri=${uri}`, {
+    const endpoint = `${baseUrl}/workflows`;
+    const urlToFetch = buildUrl(endpoint, {
+      [QUERY_PARAM_URI]: uri,
+    });
+    const res = await fetch(urlToFetch, {
       method: 'POST',
       body: content,
       headers: {

--- a/plugins/orchestrator/src/api/api.ts
+++ b/plugins/orchestrator/src/api/api.ts
@@ -1,7 +1,8 @@
 import { createApiRef } from '@backstage/core-plugin-api';
-import { JsonValue } from '@backstage/types';
+import { JsonObject } from '@backstage/types';
 
 import {
+  AssessedProcessInstance,
   Job,
   ProcessInstance,
   WorkflowDataInputSchemaResponse,
@@ -18,7 +19,8 @@ export interface OrchestratorApi {
 
   executeWorkflow(args: {
     workflowId: string;
-    parameters: Record<string, JsonValue>;
+    parameters: JsonObject;
+    businessKey?: string;
   }): Promise<WorkflowExecutionResponse>;
 
   getWorkflow(workflowId: string): Promise<WorkflowItem>;
@@ -29,13 +31,17 @@ export interface OrchestratorApi {
 
   getInstances(): Promise<ProcessInstance[]>;
 
-  getInstance(instanceId: string): Promise<ProcessInstance>;
+  getInstance(
+    instanceId: string,
+    includeAssessment: boolean,
+  ): Promise<AssessedProcessInstance>;
 
   getInstanceJobs(instanceId: string): Promise<Job[]>;
 
-  getWorkflowDataInputSchema(
-    workflowId: string,
-  ): Promise<WorkflowDataInputSchemaResponse>;
+  getWorkflowDataInputSchema(args: {
+    workflowId: string;
+    instanceId?: string;
+  }): Promise<WorkflowDataInputSchemaResponse>;
 
   createWorkflowDefinition(
     uri: string,

--- a/plugins/orchestrator/src/api/api.ts
+++ b/plugins/orchestrator/src/api/api.ts
@@ -41,6 +41,7 @@ export interface OrchestratorApi {
   getWorkflowDataInputSchema(args: {
     workflowId: string;
     instanceId?: string;
+    assessmentInstanceId?: string;
   }): Promise<WorkflowDataInputSchemaResponse>;
 
   createWorkflowDefinition(

--- a/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.stories.tsx
+++ b/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.stories.tsx
@@ -7,8 +7,9 @@ import { Meta, StoryObj } from '@storybook/react';
 import { WorkflowDataInputSchemaResponse } from '@janus-idp/backstage-plugin-orchestrator-common';
 
 import { fakeDataInputSchemaDifferentTypes } from '../../__fixtures__/fakeWorkflowDataInputSchemaDifferentTypes';
-import { fakeDataInputSchemaReponse } from '../../__fixtures__/fakeWorkflowDataInputSchemaResponse';
-import { fakeDataInputSchemaMultiStepReponse } from '../../__fixtures__/fakeWorkflowDataInputSchemaResponseMultiStep';
+import { fakeDataInputSchemaResponse } from '../../__fixtures__/fakeWorkflowDataInputSchemaResponse';
+import { fakeDataInputSchemaMultiStepResponse } from '../../__fixtures__/fakeWorkflowDataInputSchemaResponseMultiStep';
+import { fakeDataInputSchemaMultiStepInitialStateResponse } from '../../__fixtures__/fakeWorkflowDataInputSchemaResponseMultiStepInitialState';
 import { orchestratorApiRef } from '../../api';
 import { MockOrchestratorClient } from '../../api/MockOrchestratorClient';
 import { orchestratorRootRouteRef } from '../../routes';
@@ -35,7 +36,7 @@ const meta = {
                 getWorkflowDataInputSchemaResponse: context?.args
                   ?.schemaResponse
                   ? context?.args?.schemaResponse()
-                  : Promise.resolve(fakeDataInputSchemaReponse),
+                  : Promise.resolve(fakeDataInputSchemaResponse),
                 executeWorkflowResponse: () => {
                   // eslint-disable-next-line no-alert
                   alert('Execute workflow API called');
@@ -67,7 +68,15 @@ export const ExecuteWorkflowPageStory: Story = {
 export const ExecuteWorkflowPageMultipleStepsStory: Story = {
   name: 'Multiple steps',
   args: {
-    schemaResponse: () => Promise.resolve(fakeDataInputSchemaMultiStepReponse),
+    schemaResponse: () => Promise.resolve(fakeDataInputSchemaMultiStepResponse),
+  },
+};
+
+export const ExecuteWorkflowPageMultipleStepsWithInitialStateStory: Story = {
+  name: 'Multiple steps with initial state',
+  args: {
+    schemaResponse: () =>
+      Promise.resolve(fakeDataInputSchemaMultiStepInitialStateResponse),
   },
 };
 
@@ -82,7 +91,7 @@ export const ExecuteWorkflowPageNoSchemaStory: Story = {
   name: 'No schema',
   args: {
     schemaResponse: () => ({
-      ...fakeDataInputSchemaReponse,
+      ...fakeDataInputSchemaResponse,
       schemas: [],
     }),
   },

--- a/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
+++ b/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
@@ -17,13 +17,13 @@ import { JsonObject } from '@backstage/types';
 
 import { Grid } from '@material-ui/core';
 
-import { WorkflowDataInputSchemaResponse } from '@janus-idp/backstage-plugin-orchestrator-common';
+import {
+  QUERY_PARAM_ASSESSMENT_INSTANCE_ID,
+  QUERY_PARAM_INSTANCE_ID,
+  WorkflowDataInputSchemaResponse,
+} from '@janus-idp/backstage-plugin-orchestrator-common';
 
 import { orchestratorApiRef } from '../../api';
-import {
-  QUERY_PARAM_ASSESSMENT_ID,
-  QUERY_PARAM_INSTANCE_ID,
-} from '../../constants';
 import {
   executeWorkflowRouteRef,
   workflowInstanceRouteRef,
@@ -39,7 +39,9 @@ export const ExecuteWorkflowPage = () => {
   const [isExecuting, setIsExecuting] = useState(false);
   const [updateError, setUpdateError] = React.useState<Error>();
   const [instanceId] = useQueryParamState<string>(QUERY_PARAM_INSTANCE_ID);
-  const [assessmentId] = useQueryParamState<string>(QUERY_PARAM_ASSESSMENT_ID);
+  const [assessmentInstanceId] = useQueryParamState<string>(
+    QUERY_PARAM_ASSESSMENT_INSTANCE_ID,
+  );
   const navigate = useNavigate();
   const instanceLink = useRouteRef(workflowInstanceRouteRef);
   const {
@@ -51,6 +53,7 @@ export const ExecuteWorkflowPage = () => {
       await orchestratorApi.getWorkflowDataInputSchema({
         workflowId,
         instanceId,
+        assessmentInstanceId,
       }),
     [orchestratorApi, workflowId],
   );
@@ -66,12 +69,11 @@ export const ExecuteWorkflowPage = () => {
         return;
       }
       try {
-        const businessKey = instanceId && assessmentId ? instanceId : undefined;
         setIsExecuting(true);
         const response = await orchestratorApi.executeWorkflow({
           workflowId,
           parameters,
-          businessKey,
+          businessKey: assessmentInstanceId,
         });
         navigate(instanceLink({ instanceId: response.id }));
       } catch (err) {
@@ -80,14 +82,7 @@ export const ExecuteWorkflowPage = () => {
         setIsExecuting(false);
       }
     },
-    [
-      orchestratorApi,
-      workflowId,
-      navigate,
-      instanceLink,
-      instanceId,
-      assessmentId,
-    ],
+    [orchestratorApi, workflowId, navigate, instanceLink, assessmentInstanceId],
   );
 
   let pageContent;
@@ -119,7 +114,6 @@ export const ExecuteWorkflowPage = () => {
                 refSchemas={schemaResponse.schemas}
                 initialState={schemaResponse.initialState}
                 handleExecute={handleExecute}
-                disableInitialState={!!assessmentId}
                 isExecuting={isExecuting}
               />
             ) : (

--- a/plugins/orchestrator/src/components/ExecuteWorkflowPage/JsonTextAreaForm.tsx
+++ b/plugins/orchestrator/src/components/ExecuteWorkflowPage/JsonTextAreaForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { JsonValue } from '@backstage/types';
+import { JsonObject } from '@backstage/types';
 
 import { Box, Grid, useTheme } from '@material-ui/core';
 import { Alert, AlertTitle } from '@material-ui/lab';
@@ -15,18 +15,16 @@ const JsonTextAreaForm = ({
   handleExecute,
 }: {
   isExecuting: boolean;
-  handleExecute: (
-    getParameters: () => Record<string, JsonValue>,
-  ) => Promise<void>;
+  handleExecute: (getParameters: () => JsonObject) => Promise<void>;
 }) => {
   const [jsonText, setJsonText] = React.useState(DEFAULT_VALUE);
   const theme = useTheme();
-  const getParameters = (): Record<string, JsonValue> => {
+  const getParameters = (): JsonObject => {
     if (!jsonText) {
       return {};
     }
     const parameters = JSON.parse(jsonText);
-    return parameters as Record<string, JsonValue>;
+    return parameters as JsonObject;
   };
 
   return (

--- a/plugins/orchestrator/src/components/OrchestratorPage.stories.tsx
+++ b/plugins/orchestrator/src/components/OrchestratorPage.stories.tsx
@@ -29,7 +29,7 @@ const TestRouter: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
 );
 
 const meta = {
-  title: 'Orchestrator/next/OrchestratorPage',
+  title: 'Orchestrator/OrchestratorPage',
   component: OrchestratorPage,
   decorators: [
     (

--- a/plugins/orchestrator/src/components/Router.tsx
+++ b/plugins/orchestrator/src/components/Router.tsx
@@ -9,7 +9,6 @@ import {
   createWorkflowRouteRef,
   editWorkflowRouteRef,
   executeWorkflowRouteRef,
-  executeWorkflowWithBusinessKeyRouteRef,
   newWorkflowRef,
   workflowDefinitionsRouteRef,
   workflowInstanceRouteRef,
@@ -59,10 +58,6 @@ export const Router = () => {
       />
       <Route
         path={executeWorkflowRouteRef.path}
-        element={<ExecuteWorkflowPage />}
-      />
-      <Route
-        path={executeWorkflowWithBusinessKeyRouteRef.path}
         element={<ExecuteWorkflowPage />}
       />
     </Routes>

--- a/plugins/orchestrator/src/components/WorkflowDefinitionViewerPage/WorkflowDefinitionViewerPage.stories.tsx
+++ b/plugins/orchestrator/src/components/WorkflowDefinitionViewerPage/WorkflowDefinitionViewerPage.stories.tsx
@@ -25,7 +25,7 @@ import {
 import { WorkflowDefinitionViewerPage } from './WorkflowDefinitionViewerPage';
 
 const meta = {
-  title: 'Orchestrator/next/WorkflowDefinitionViewerPage',
+  title: 'Orchestrator/WorkflowDefinitionViewerPage',
   component: WorkflowDefinitionViewerPage,
   decorators: [
     (

--- a/plugins/orchestrator/src/components/WorkflowInstancePage.stories.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePage.stories.tsx
@@ -5,6 +5,7 @@ import { TestApiProvider, wrapInTestApp } from '@backstage/test-utils';
 import { Meta, StoryObj } from '@storybook/react';
 
 import {
+  AssessedProcessInstance,
   ProcessInstance,
   WorkflowItem,
   WorkflowSpecFile,
@@ -60,6 +61,15 @@ const getFakeProcessInstance = async (
   throw new Error('This is an example error for non existing instance');
 };
 
+const getFakeAssessedProcessInstance = async (
+  context: { responseCounter?: number },
+  instanceId?: string,
+): Promise<AssessedProcessInstance> => {
+  return {
+    instance: await getFakeProcessInstance(context, instanceId),
+  };
+};
+
 const getFakeWorkflowItem = async (
   workflowId?: string,
 ): Promise<WorkflowItem> => {
@@ -77,7 +87,7 @@ const getFakeSpecs = async (): Promise<WorkflowSpecFile[]> => {
 };
 
 const meta = {
-  title: 'Orchestrator/next/WorkflowInstancePage',
+  title: 'Orchestrator/WorkflowInstancePage',
   component: WorkflowInstancePage,
   decorators: [
     (Story, context) =>
@@ -92,7 +102,7 @@ const meta = {
                   context.args.instanceId,
                 ),
                 getInstanceResponse: () => {
-                  return getFakeProcessInstance(
+                  return getFakeAssessedProcessInstance(
                     context as { responseCounter?: number },
                     context.args.instanceId,
                   );
@@ -105,7 +115,7 @@ const meta = {
         </TestApiProvider>,
         {
           mountedRoutes: {
-            '/orchestrator/next': orchestratorRootRouteRef,
+            '/orchestrator': orchestratorRootRouteRef,
           },
         },
       ),

--- a/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
@@ -14,14 +14,14 @@ import {
 
 import { Button, Grid } from '@material-ui/core';
 
-import { AssessedProcessInstance } from '@janus-idp/backstage-plugin-orchestrator-common';
+import {
+  AssessedProcessInstance,
+  QUERY_PARAM_ASSESSMENT_INSTANCE_ID,
+  QUERY_PARAM_INSTANCE_ID,
+} from '@janus-idp/backstage-plugin-orchestrator-common';
 
 import { orchestratorApiRef } from '../api';
-import {
-  QUERY_PARAM_ASSESSMENT_ID,
-  QUERY_PARAM_INSTANCE_ID,
-  SHORT_REFRESH_INTERVAL,
-} from '../constants';
+import { SHORT_REFRESH_INTERVAL } from '../constants';
 import usePolling from '../hooks/usePolling';
 import { executeWorkflowRouteRef, workflowInstanceRouteRef } from '../routes';
 import { isNonNullable } from '../utils/TypeGuards';
@@ -104,16 +104,10 @@ export const WorkflowInstancePage = ({
       workflowId: value.instance.processId,
     });
 
-    const queryParams = value.assessedBy
-      ? {
-          [QUERY_PARAM_INSTANCE_ID]: value.assessedBy.id,
-          [QUERY_PARAM_ASSESSMENT_ID]: value.assessedBy.processId,
-        }
-      : {
-          [QUERY_PARAM_INSTANCE_ID]: value.instance.id,
-        };
-
-    const urlToNavigate = buildUrl(routeUrl, queryParams);
+    const urlToNavigate = buildUrl(routeUrl, {
+      [QUERY_PARAM_INSTANCE_ID]: value.instance.id,
+      [QUERY_PARAM_ASSESSMENT_INSTANCE_ID]: value.assessedBy?.id,
+    });
     navigate(urlToNavigate);
   }, [value, navigate, executeWorkflowLink]);
 

--- a/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
@@ -17,7 +17,11 @@ import { Button, Grid } from '@material-ui/core';
 import { AssessedProcessInstance } from '@janus-idp/backstage-plugin-orchestrator-common';
 
 import { orchestratorApiRef } from '../api';
-import { QUERY_PARAM_INSTANCE_ID, SHORT_REFRESH_INTERVAL } from '../constants';
+import {
+  QUERY_PARAM_ASSESSMENT_ID,
+  QUERY_PARAM_INSTANCE_ID,
+  SHORT_REFRESH_INTERVAL,
+} from '../constants';
 import usePolling from '../hooks/usePolling';
 import { executeWorkflowRouteRef, workflowInstanceRouteRef } from '../routes';
 import { isNonNullable } from '../utils/TypeGuards';
@@ -99,9 +103,17 @@ export const WorkflowInstancePage = ({
     const routeUrl = executeWorkflowLink({
       workflowId: value.instance.processId,
     });
-    const urlToNavigate = buildUrl(routeUrl, {
-      [QUERY_PARAM_INSTANCE_ID]: value.instance.id,
-    });
+
+    const queryParams = value.assessedBy
+      ? {
+          [QUERY_PARAM_INSTANCE_ID]: value.assessedBy.id,
+          [QUERY_PARAM_ASSESSMENT_ID]: value.assessedBy.processId,
+        }
+      : {
+          [QUERY_PARAM_INSTANCE_ID]: value.instance.id,
+        };
+
+    const urlToNavigate = buildUrl(routeUrl, queryParams);
     navigate(urlToNavigate);
   }, [value, navigate, executeWorkflowLink]);
 

--- a/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
@@ -1,21 +1,27 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import {
   ContentHeader,
   Progress,
   ResponseErrorPanel,
 } from '@backstage/core-components';
-import { useApi, useRouteRefParams } from '@backstage/core-plugin-api';
+import {
+  useApi,
+  useRouteRef,
+  useRouteRefParams,
+} from '@backstage/core-plugin-api';
 
 import { Button, Grid } from '@material-ui/core';
 
-import { ProcessInstance } from '@janus-idp/backstage-plugin-orchestrator-common';
+import { AssessedProcessInstance } from '@janus-idp/backstage-plugin-orchestrator-common';
 
 import { orchestratorApiRef } from '../api';
-import { SHORT_REFRESH_INTERVAL } from '../constants';
+import { QUERY_PARAM_INSTANCE_ID, SHORT_REFRESH_INTERVAL } from '../constants';
 import usePolling from '../hooks/usePolling';
-import { workflowInstanceRouteRef } from '../routes';
+import { executeWorkflowRouteRef, workflowInstanceRouteRef } from '../routes';
 import { isNonNullable } from '../utils/TypeGuards';
+import { buildUrl } from '../utils/UrlUtils';
 import { BaseOrchestratorPage } from './BaseOrchestratorPage';
 import { WorkflowInstancePageContent } from './WorkflowInstancePageContent';
 
@@ -24,7 +30,9 @@ export const WorkflowInstancePage = ({
 }: {
   instanceId?: string;
 }) => {
+  const navigate = useNavigate();
   const orchestratorApi = useApi(orchestratorApiRef);
+  const executeWorkflowLink = useRouteRef(executeWorkflowRouteRef);
   const { instanceId: queryInstanceId } = useRouteRefParams(
     workflowInstanceRouteRef,
   );
@@ -33,16 +41,32 @@ export const WorkflowInstancePage = ({
     if (!instanceId && !queryInstanceId) {
       return undefined;
     }
-    return await orchestratorApi.getInstance(instanceId || queryInstanceId);
+    return await orchestratorApi.getInstance(
+      instanceId ?? queryInstanceId,
+      true,
+    );
   }, [instanceId, orchestratorApi, queryInstanceId]);
 
   const { loading, error, value, restart } = usePolling<
-    ProcessInstance | undefined
+    AssessedProcessInstance | undefined
   >(
     fetchInstance,
     SHORT_REFRESH_INTERVAL,
-    (curValue: ProcessInstance | undefined) =>
-      !!curValue && curValue.state === 'ACTIVE',
+    (curValue: AssessedProcessInstance | undefined) =>
+      !!curValue && curValue.instance.state === 'ACTIVE',
+  );
+
+  const canAbort = React.useMemo(
+    () =>
+      value?.instance.state === 'ACTIVE' || value?.instance.state === 'ERROR',
+    [value],
+  );
+
+  const canRerun = React.useMemo(
+    () =>
+      value?.instance.state === 'COMPLETED' ||
+      value?.instance.state === 'ABORTED',
+    [value],
   );
 
   const handleAbort = React.useCallback(async () => {
@@ -54,7 +78,7 @@ export const WorkflowInstancePage = ({
 
       if (yes) {
         try {
-          await orchestratorApi.abortWorkflow(value.id);
+          await orchestratorApi.abortWorkflow(value.instance.id);
           restart();
         } catch (e) {
           // eslint-disable-next-line no-alert
@@ -68,9 +92,22 @@ export const WorkflowInstancePage = ({
     }
   }, [orchestratorApi, restart, value]);
 
+  const handleRerun = React.useCallback(() => {
+    if (!value) {
+      return;
+    }
+    const routeUrl = executeWorkflowLink({
+      workflowId: value.instance.processId,
+    });
+    const urlToNavigate = buildUrl(routeUrl, {
+      [QUERY_PARAM_INSTANCE_ID]: value.instance.id,
+    });
+    navigate(urlToNavigate);
+  }, [value, navigate, executeWorkflowLink]);
+
   return (
     <BaseOrchestratorPage
-      title={value?.processId ?? value?.id ?? instanceId}
+      title={value?.instance.processId ?? value?.instance.id ?? instanceId}
       type="Workflow runs"
       typeLink="/orchestrator/instances"
     >
@@ -80,19 +117,33 @@ export const WorkflowInstancePage = ({
         <>
           <ContentHeader title="">
             <Grid container item justifyContent="flex-end" spacing={1}>
-              <Grid item>
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  disabled={value?.state !== 'ACTIVE'}
-                  onClick={value?.state === 'ACTIVE' ? handleAbort : undefined}
-                >
-                  Abort
-                </Button>
-              </Grid>
+              {!canRerun && (
+                <Grid item>
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    disabled={!canAbort}
+                    onClick={canAbort ? handleAbort : undefined}
+                  >
+                    Abort
+                  </Button>
+                </Grid>
+              )}
+              {!canAbort && (
+                <Grid item>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    disabled={!canRerun}
+                    onClick={canRerun ? handleRerun : undefined}
+                  >
+                    Rerun
+                  </Button>
+                </Grid>
+              )}
             </Grid>
           </ContentHeader>
-          <WorkflowInstancePageContent processInstance={value} />
+          <WorkflowInstancePageContent assessedInstance={value} />
         </>
       ) : null}
     </BaseOrchestratorPage>

--- a/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
@@ -12,13 +12,10 @@ import {
   parseWorkflowVariables,
   ProcessInstance,
   ProcessInstanceStateValues,
+  QUERY_PARAM_ASSESSMENT_INSTANCE_ID,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
 
-import {
-  QUERY_PARAM_ASSESSMENT_ID,
-  QUERY_PARAM_INSTANCE_ID,
-  VALUE_UNAVAILABLE,
-} from '../constants';
+import { VALUE_UNAVAILABLE } from '../constants';
 import { executeWorkflowRouteRef, workflowInstanceRouteRef } from '../routes';
 import { capitalize } from '../utils/StringUtils';
 import { buildUrl } from '../utils/UrlUtils';
@@ -75,8 +72,7 @@ const getNextWorkflows = (
           workflowId: nextWorkflowSuggestion.id,
         });
         const urlToNavigate = buildUrl(routeUrl, {
-          [QUERY_PARAM_INSTANCE_ID]: details.id,
-          [QUERY_PARAM_ASSESSMENT_ID]: details.workflowId,
+          [QUERY_PARAM_ASSESSMENT_INSTANCE_ID]: details.id,
         });
         nextWorkflows.push({
           title: nextWorkflowSuggestion.name,

--- a/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
@@ -137,9 +137,6 @@ export const WorkflowInstancePageContent: React.FC<{
         label: 'Assessed by',
         value: (
           <Link
-            // Remove `reloadDocument`
-            // https://issues.redhat.com/browse/FLPATH-945
-            reloadDocument
             to={workflowInstanceLink({
               instanceId: assessedInstance.assessedBy.id,
             })}

--- a/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
@@ -137,6 +137,9 @@ export const WorkflowInstancePageContent: React.FC<{
         label: 'Assessed by',
         value: (
           <Link
+            // Remove `reloadDocument`
+            // https://issues.redhat.com/browse/FLPATH-945
+            reloadDocument
             to={workflowInstanceLink({
               instanceId: assessedInstance.assessedBy.id,
             })}
@@ -242,6 +245,7 @@ export const WorkflowInstancePageContent: React.FC<{
           <Grid item xs={12}>
             <InfoCard
               title="Variables"
+              divider={false}
               className={styles.bottomRowCard}
               cardClassName={styles.autoOverflow}
             >

--- a/plugins/orchestrator/src/components/WorkflowProgress.stories.tsx
+++ b/plugins/orchestrator/src/components/WorkflowProgress.stories.tsx
@@ -6,7 +6,7 @@ import { fakeNodeInstances } from '../__fixtures__/fakeNodeInstances';
 import { WorkflowProgress } from './WorkflowProgress';
 
 const meta = {
-  title: 'Orchestrator/next/WorkflowProgress',
+  title: 'Orchestrator/WorkflowProgress',
   component: WorkflowProgress,
   decorators: [Story => <Story />],
   parameters: {

--- a/plugins/orchestrator/src/components/WorkflowRunDetail.ts
+++ b/plugins/orchestrator/src/components/WorkflowRunDetail.ts
@@ -6,7 +6,7 @@ export interface WorkflowSuggestion {
 export type WorkflowRunDetail = {
   id: string;
   name: string;
-  workflow: string;
+  workflowId: string;
   status: string;
   started: string;
   duration: string;

--- a/plugins/orchestrator/src/components/WorkflowRunsTabContent.stories.tsx
+++ b/plugins/orchestrator/src/components/WorkflowRunsTabContent.stories.tsx
@@ -12,7 +12,7 @@ import { orchestratorRootRouteRef } from '../routes';
 import { WorkflowRunsTabContent } from './WorkflowRunsTabContent';
 
 const meta = {
-  title: 'Orchestrator/next/WorkflowRunsTabContent',
+  title: 'Orchestrator/WorkflowRunsTabContent',
   component: WorkflowRunsTabContent,
   decorators: [
     (Story, context) => {
@@ -36,7 +36,7 @@ const meta = {
         </TestApiProvider>,
         {
           mountedRoutes: {
-            '/orchestrator/next': orchestratorRootRouteRef,
+            '/orchestrator': orchestratorRootRouteRef,
           },
         },
       );

--- a/plugins/orchestrator/src/components/WorkflowRunsTabContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowRunsTabContent.tsx
@@ -97,7 +97,7 @@ export const WorkflowRunsTabContent = () => {
 
   const filteredData = React.useMemo(
     () =>
-      (value || []).filter(
+      (value ?? []).filter(
         (row: WorkflowRunDetail) =>
           statusSelectorValue === Selector.AllItems ||
           row.status === statusSelectorValue,

--- a/plugins/orchestrator/src/components/WorkflowVariablesViewer.tsx
+++ b/plugins/orchestrator/src/components/WorkflowVariablesViewer.tsx
@@ -1,12 +1,14 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import ReactJson from 'react-json-view';
 
 import { useTheme } from '@material-ui/core';
 
+import { ProcessInstanceVariables } from '@janus-idp/backstage-plugin-orchestrator-common';
+
 import { Paragraph } from './Paragraph';
 
 interface ProcessVariablesViewerProps {
-  variables?: string | Record<string, unknown>;
+  variables?: ProcessInstanceVariables;
   emptyState?: React.ReactNode;
 }
 
@@ -16,24 +18,11 @@ export const WorkflowVariablesViewer: React.FC<ProcessVariablesViewerProps> = ({
 }) => {
   const theme = useTheme();
 
-  const jsonSource = useMemo(() => {
-    let value = variables;
-    if (typeof variables === 'string') {
-      try {
-        value = JSON.parse(variables) as Record<string, unknown>;
-      } catch {
-        value = { error: 'Failed to parse workflow variables' };
-      }
-    }
-
-    return value;
-  }, [variables]);
-
   return !variables ? (
     <>{emptyState}</>
   ) : (
     <ReactJson
-      src={jsonSource as object}
+      src={variables}
       name={false}
       theme={theme.palette.type === 'dark' ? 'monokai' : 'rjv-default'}
     />

--- a/plugins/orchestrator/src/components/WorkflowsTable.stories.tsx
+++ b/plugins/orchestrator/src/components/WorkflowsTable.stories.tsx
@@ -13,7 +13,7 @@ import { orchestratorRootRouteRef } from '../routes';
 import { WorkflowsTable } from './WorkflowsTable';
 
 const meta = {
-  title: 'Orchestrator/next/WorkflowsTable',
+  title: 'Orchestrator/WorkflowsTable',
   component: WorkflowsTable,
   decorators: [
     (Story, context) =>
@@ -37,7 +37,7 @@ const meta = {
         </TestApiProvider>,
         {
           mountedRoutes: {
-            '/orchestrator/next': orchestratorRootRouteRef,
+            '/orchestrator': orchestratorRootRouteRef,
           },
         },
       ),

--- a/plugins/orchestrator/src/constants.ts
+++ b/plugins/orchestrator/src/constants.ts
@@ -1,4 +1,10 @@
 export const VALUE_UNAVAILABLE = '---' as const;
+
+export const QUERY_PARAM_BUSINESS_KEY = 'businessKey' as const;
+export const QUERY_PARAM_INSTANCE_ID = 'instanceId' as const;
+export const QUERY_PARAM_INCLUDE_ASSESSMENT = 'includeAssessment' as const;
+export const QUERY_PARAM_ASSESSMENT_ID = 'assessmentId' as const;
+
 export const SHORT_REFRESH_INTERVAL = 5000;
 export const LONG_REFRESH_INTERVAL = 15000;
 export const DEFAULT_TABLE_PAGE_SIZE = 20;

--- a/plugins/orchestrator/src/constants.ts
+++ b/plugins/orchestrator/src/constants.ts
@@ -1,10 +1,5 @@
 export const VALUE_UNAVAILABLE = '---' as const;
 
-export const QUERY_PARAM_BUSINESS_KEY = 'businessKey' as const;
-export const QUERY_PARAM_INSTANCE_ID = 'instanceId' as const;
-export const QUERY_PARAM_INCLUDE_ASSESSMENT = 'includeAssessment' as const;
-export const QUERY_PARAM_ASSESSMENT_ID = 'assessmentId' as const;
-
 export const SHORT_REFRESH_INTERVAL = 5000;
 export const LONG_REFRESH_INTERVAL = 15000;
 export const DEFAULT_TABLE_PAGE_SIZE = 20;

--- a/plugins/orchestrator/src/routes.ts
+++ b/plugins/orchestrator/src/routes.ts
@@ -45,9 +45,3 @@ export const executeWorkflowRouteRef = createSubRouteRef({
   parent: orchestratorRootRouteRef,
   path: '/workflows/:workflowId/execute',
 });
-
-export const executeWorkflowWithBusinessKeyRouteRef = createSubRouteRef({
-  id: 'orchestrator/assessmentworkflows/execute',
-  parent: orchestratorRootRouteRef,
-  path: '/workflows/:workflowId/execute/:businessKey',
-});

--- a/plugins/orchestrator/src/utils/UrlUtils.ts
+++ b/plugins/orchestrator/src/utils/UrlUtils.ts
@@ -10,7 +10,7 @@ export function buildUrl(
     .filter(([, value]) => value !== undefined)
     .map(
       ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(value!)}`,
+        `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
     )
     .join('&');
 

--- a/plugins/orchestrator/src/utils/UrlUtils.ts
+++ b/plugins/orchestrator/src/utils/UrlUtils.ts
@@ -1,0 +1,18 @@
+export function buildUrl(
+  baseUrl: string,
+  queryParams?: Record<string, any>,
+): string {
+  if (!queryParams || Object.keys(queryParams).length === 0) {
+    return baseUrl;
+  }
+
+  const queryString = Object.entries(queryParams)
+    .filter(([, value]) => value !== undefined)
+    .map(
+      ([key, value]) =>
+        `${encodeURIComponent(key)}=${encodeURIComponent(value!)}`,
+    )
+    .join('&');
+
+  return queryString ? `${baseUrl}?${queryString}` : baseUrl;
+}


### PR DESCRIPTION
Closes:
- https://issues.redhat.com/browse/FLPATH-844
- https://issues.redhat.com/browse/FLPATH-858
- https://issues.redhat.com/browse/FLPATH-882
- https://issues.redhat.com/browse/FLPATH-883
- https://issues.redhat.com/browse/FLPATH-946

Also:
- Updated the dev mode image tag to the latest one
- Removed "next" from SB
- Unified parse workflow variables
- Moved some BusinessKey-related logic to BE
- Fixed some typos
- Removed redundant route

