### PR TITLE
fix(tekton): external sbom view action should not open logs modal

### DIFF
--- a/plugins/tekton/src/__fixtures__/1-pipelinesData.ts
+++ b/plugins/tekton/src/__fixtures__/1-pipelinesData.ts
@@ -3,6 +3,8 @@ import {
   acsImageCheckTaskRun,
   acsImageScanTaskRun,
   enterpriseContractTaskRun,
+  taskRunWithSBOMResult,
+  taskRunWithSBOMResultExternalLink,
 } from './taskRunData';
 
 export const mockKubernetesPlrResponse = {
@@ -396,6 +398,66 @@ export const mockKubernetesPlrResponse = {
         startTime: new Date('2023-12-08T12:19:38Z'),
       },
     },
+    {
+      metadata: {
+        name: 'pipelinerun-with-sbom-task-t237ev-sbom-task-pod',
+        namespace: 'karthik',
+        uid: '055cc13a-bd3e-414e-9eb6-e6cb72870578',
+        resourceVersion: '379623',
+        labels: {
+          'backstage.io/kubernetes-id': 'developer-portal',
+          'janus-idp.io/tekton': 'developer-portal',
+          'tekton.dev/pipeline': 'test-pipeline',
+          'tekton.dev/pipelineRun': 'pipelinerun-with-sbom-task',
+          'tekton.dev/pipelineTask': 'sbom-task',
+          'tekton.dev/task': 'sbom-task',
+          'tekton.dev/taskRun': 'test-pipeline-8e09zm-sbom-task',
+        },
+      },
+      spec: {
+        containers: [
+          {
+            name: 'step-print-sbom-results',
+          },
+        ],
+      },
+      status: {
+        phase: 'Succeeded',
+        conditions: [],
+
+        startTime: new Date('2023-12-08T12:19:38Z'),
+      },
+    },
+    {
+      metadata: {
+        name: 'pipelinerun-with-sbom-task-with-external-pod',
+        namespace: 'karthik',
+        uid: '055cc13a-bd3e-414e-9eb6-e6cb72870578',
+        resourceVersion: '379623',
+        labels: {
+          'backstage.io/kubernetes-id': 'developer-portal',
+          'janus-idp.io/tekton': 'developer-portal',
+          'tekton.dev/pipeline': 'test-pipeline',
+          'tekton.dev/pipelineRun': 'pipelinerun-with-external-sbom-task',
+          'tekton.dev/pipelineTask': 'sbom-task-with-external-link',
+          'tekton.dev/task': 'sbom-task-with-external-link',
+          'tekton.dev/taskRun': 'test-pipeline-8e09zm-sbom-task',
+        },
+      },
+      spec: {
+        containers: [
+          {
+            name: 'step-print-sbom-results',
+          },
+        ],
+      },
+      status: {
+        phase: 'Succeeded',
+        conditions: [],
+
+        startTime: new Date('2023-12-08T12:19:38Z'),
+      },
+    },
   ],
   pipelineruns: [
     {
@@ -637,6 +699,126 @@ export const mockKubernetesPlrResponse = {
               '{"vulnerabilities":{\n"critical": 13,\n"high": 29,\n"medium": 32,\n"low": 3,\n"unknown": 0},\n"unpatched_vulnerabilities": {\n"critical": 0,\n"high": 1,\n"medium": 0,\n"low":1}\n}\n',
           },
         ],
+        startTime: '2023-04-11T05:49:05Z',
+      },
+    },
+    {
+      apiVersion: 'tekton.dev/v1',
+      kind: 'PipelineRun',
+      metadata: {
+        annotations: {
+          'pipeline.openshift.io/started-by': 'kube-admin',
+          'chains.tekton.dev/signed': 'false',
+        },
+        labels: {
+          'backstage.io/kubernetes-id': 'test-backstage',
+          'tekton.dev/pipeline': 'pipeline-test',
+          'app.kubernetes.io/instance': 'abs',
+          'app.kubernetes.io/name': 'ghg',
+          'operator.tekton.dev/operand-name': 'ytui',
+          'pipeline.openshift.io/runtime-version': 'hjkhk',
+          'pipeline.openshift.io/type': 'hhu',
+          'pipeline.openshift.io/runtime': 'node',
+        },
+        name: 'pipelinerun-with-sbom-task',
+        namespace: 'deb-test',
+        resourceVersion: '117337',
+        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b24',
+        creationTimestamp: new Date('2023-04-11T12:31:56Z'),
+      },
+      spec: {
+        pipelineRef: {
+          name: 'pipeline-test',
+        },
+        serviceAccountName: 'pipeline',
+        workspaces: [],
+      },
+      status: {
+        completionTime: '2023-04-11T06:49:05Z',
+        conditions: [
+          {
+            lastTransitionTime: '2023-03-30T07:05:13Z',
+            message: 'Tasks Completed: 3 (Failed: 0, Cancelled 0), Skipped: 0',
+            reason: 'Succeeded',
+            status: 'True',
+            type: 'Succeeded',
+          },
+        ],
+        pipelineSpec: {
+          tasks: [
+            {
+              name: 'sbom-task',
+              params: [],
+              taskRef: {
+                kind: 'ClusterTask',
+                name: 'sbom-task',
+              },
+              workspaces: [],
+            },
+          ],
+          workspaces: [],
+          startTime: '2023-04-11T06:48:50Z',
+        },
+        startTime: '2023-04-11T05:49:05Z',
+      },
+    },
+    {
+      apiVersion: 'tekton.dev/v1',
+      kind: 'PipelineRun',
+      metadata: {
+        annotations: {
+          'pipeline.openshift.io/started-by': 'kube-admin',
+          'chains.tekton.dev/signed': 'false',
+        },
+        labels: {
+          'backstage.io/kubernetes-id': 'test-backstage',
+          'tekton.dev/pipeline': 'pipeline-test',
+          'app.kubernetes.io/instance': 'abs',
+          'app.kubernetes.io/name': 'ghg',
+          'operator.tekton.dev/operand-name': 'ytui',
+          'pipeline.openshift.io/runtime-version': 'hjkhk',
+          'pipeline.openshift.io/type': 'hhu',
+          'pipeline.openshift.io/runtime': 'node',
+        },
+        name: 'pipelinerun-with-external-sbom-task',
+        namespace: 'deb-test',
+        resourceVersion: '117337',
+        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b24',
+        creationTimestamp: new Date('2023-04-11T12:31:56Z'),
+      },
+      spec: {
+        pipelineRef: {
+          name: 'pipeline-test',
+        },
+        serviceAccountName: 'pipeline',
+        workspaces: [],
+      },
+      status: {
+        completionTime: '2023-04-11T06:49:05Z',
+        conditions: [
+          {
+            lastTransitionTime: '2023-03-30T07:05:13Z',
+            message: 'Tasks Completed: 3 (Failed: 0, Cancelled 0), Skipped: 0',
+            reason: 'Succeeded',
+            status: 'True',
+            type: 'Succeeded',
+          },
+        ],
+        pipelineSpec: {
+          tasks: [
+            {
+              name: 'sbom-task-with-external-link',
+              params: [],
+              taskRef: {
+                kind: 'ClusterTask',
+                name: 'sbom-task-with-external-link',
+              },
+              workspaces: [],
+            },
+          ],
+          workspaces: [],
+          startTime: '2023-04-11T06:48:50Z',
+        },
         startTime: '2023-04-11T05:49:05Z',
       },
     },
@@ -1051,6 +1233,8 @@ export const mockKubernetesPlrResponse = {
         },
       },
     },
+    taskRunWithSBOMResult,
+    taskRunWithSBOMResultExternalLink,
     enterpriseContractTaskRun,
     acsImageScanTaskRun,
     acsImageCheckTaskRun,

--- a/plugins/tekton/src/__fixtures__/taskRunData.ts
+++ b/plugins/tekton/src/__fixtures__/taskRunData.ts
@@ -77,15 +77,26 @@ export const taskRunWithSBOMResult = {
       'task.results.key': 'LINK_TO_SBOM',
     },
     labels: {
-      [TEKTON_PIPELINE_RUN]: 'test-plr',
+      [TEKTON_PIPELINE_RUN]: 'pipelinerun-with-sbom-task',
+      'tekton.dev/pipelineTask': 'sbom-task',
     },
+    ownerReferences: [
+      {
+        apiVersion: 'tekton.dev/v1',
+        blockOwnerDeletion: true,
+        controller: true,
+        kind: 'PipelineRun',
+        name: 'pipelinerun-with-sbom-task',
+        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b24',
+      },
+    ],
     name: 'pipelinerun-with-sbom-task-t237ev-sbom-task',
     uid: '764d0a6c-a4f6-419c-a3c3-585c2a9eb67c',
   },
   spec: {
     serviceAccountName: 'pipeline',
     taskRef: {
-      kind: 'Task',
+      kind: 'ClusterTask',
       name: 'sbom-task',
     },
     timeout: '1h0m0s',
@@ -126,6 +137,20 @@ export const taskRunWithSBOMResultExternalLink: TaskRunKind = {
       'task.results.type': 'external-link',
       'task.results.key': 'LINK_TO_SBOM',
     },
+    labels: {
+      [TEKTON_PIPELINE_RUN]: 'pipelinerun-with-external-sbom-task',
+      'tekton.dev/pipelineTask': 'sbom-task-with-external-link',
+    },
+    ownerReferences: [
+      {
+        apiVersion: 'tekton.dev/v1',
+        blockOwnerDeletion: true,
+        controller: true,
+        kind: 'PipelineRun',
+        name: 'pipelinerun-with-external-sbom-task',
+        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b24',
+      },
+    ],
     resourceVersion: '197373',
     name: 'pipelinerun-with-sbom-task-t237ev-sbom-task',
     uid: '764d0a6c-a4f6-419c-a3c3-585c2a9eb67c',
@@ -134,8 +159,8 @@ export const taskRunWithSBOMResultExternalLink: TaskRunKind = {
   spec: {
     serviceAccountName: 'pipeline',
     taskRef: {
-      kind: 'Task',
-      name: 'sbom-task',
+      kind: 'ClusterTask',
+      name: 'sbom-task-with-external-link',
     },
     timeout: '1h0m0s',
   },
@@ -150,12 +175,13 @@ export const taskRunWithSBOMResultExternalLink: TaskRunKind = {
         type: 'Succeeded',
       },
     ],
-    podName: 'pipelinerun-with-sbom-task-t237ev-sbom-task-pod',
+    podName: 'pipelinerun-with-sbom-task-with-external-pod',
     results: [
       {
         name: 'LINK_TO_SBOM',
         type: 'string',
-        value: 'http://quay.io/test/image:build-8e536-1692702836',
+        value:
+          'https://quay.io/repository/janus-idp/backstage-showcase?tab=tags',
       },
     ],
   },

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
@@ -14,6 +14,7 @@ import {
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
 import {
   getTaskrunsOutputGroup,
+  hasExternalLink,
   isSbomTaskRun,
 } from '../../utils/taskRun-utils';
 import OutputIcon from '../Icons/OutputIcon';
@@ -115,9 +116,12 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
             }
           >
             <IconButton
+              data-testid="view-sbom-icon"
               disabled={!sbomTaskRun || !isSbomTaskRun(sbomTaskRun)}
               size="small"
-              onClick={() => openDialog()}
+              onClick={
+                !hasExternalLink(sbomTaskRun) ? () => openDialog() : undefined
+              }
               style={{ pointerEvents: 'auto', padding: 0 }}
             >
               <PipelineRunSBOMLink sbomTaskRun={sbomTaskRun} />
@@ -133,6 +137,7 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
             }
           >
             <IconButton
+              data-testid="view-output-icon"
               disabled={disabled}
               size="small"
               onClick={() => openOutputDialog()}

--- a/plugins/tekton/src/components/PipelineRunList/__tests__/PipelineRunRowActions.test.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/__tests__/PipelineRunRowActions.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import { BrowserRouter } from 'react-router-dom';
+
+import { LinkProps } from '@backstage/core-components';
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+
+import { ComputedStatus, PipelineRunKind } from '@janus-idp/shared-react';
+
+import { mockKubernetesPlrResponse } from '../../../__fixtures__/1-pipelinesData';
+import { TektonResourcesContext } from '../../../hooks/TektonResourcesContext';
+import { TektonResourcesContextData } from '../../../types/types';
+import PipelineRunRowActions from '../PipelineRunRowActions';
+
+jest.mock('@material-ui/core', () => ({
+  ...jest.requireActual('@material-ui/core'),
+  makeStyles: () => () => {
+    return {
+      titleContainer: 'title',
+      closeButton: 'close',
+    };
+  },
+  Dialog: (props: any) => (
+    <div data-testid={props['data-testid']}>
+      {props.open && <span>Logs modal content</span>}
+    </div>
+  ),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    Link: (props: LinkProps) => (
+      <a href={props.to} data-test={props.to}>
+        {props.children}
+      </a>
+    ),
+  };
+});
+
+const tektonResourceContextData: TektonResourcesContextData = {
+  watchResourcesData: {
+    pipelineruns: {
+      data: mockKubernetesPlrResponse.pipelineruns,
+    },
+    taskruns: {
+      data: mockKubernetesPlrResponse.taskruns,
+    },
+    pods: {
+      data: mockKubernetesPlrResponse.pods,
+    },
+  },
+  loaded: true,
+  responseError: '',
+  selectedClusterErrors: [],
+  clusters: ['ocp'],
+  setSelectedCluster: () => {},
+  selectedStatus: ComputedStatus.Other,
+  setSelectedStatus: () => {},
+  setIsExpanded: () => {},
+};
+
+const TestPipelineRunRowActions = ({
+  pipelineRun,
+}: {
+  pipelineRun: PipelineRunKind;
+}) => (
+  <TektonResourcesContext.Provider value={tektonResourceContextData}>
+    <BrowserRouter>
+      <PipelineRunRowActions pipelineRun={pipelineRun} />
+    </BrowserRouter>
+  </TektonResourcesContext.Provider>
+);
+
+describe('PipelineRunRowActions', () => {
+  it('should render the icon space holder', () => {
+    render(
+      <TestPipelineRunRowActions
+        pipelineRun={mockKubernetesPlrResponse.pipelineruns[0]}
+      />,
+    );
+
+    expect(screen.queryByTestId('icon-space-holder')).toBeInTheDocument();
+  });
+
+  it('should render the internal sbom link', () => {
+    render(
+      <TestPipelineRunRowActions
+        pipelineRun={mockKubernetesPlrResponse.pipelineruns[3]}
+      />,
+    );
+
+    expect(screen.queryByTestId('internal-sbom-link')).toBeInTheDocument();
+  });
+
+  it('should open sbom logs modal when the view SBOM link is clicked', async () => {
+    render(
+      <TestPipelineRunRowActions
+        pipelineRun={mockKubernetesPlrResponse.pipelineruns[3]}
+      />,
+    );
+
+    expect(screen.queryByTestId('internal-sbom-link')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.queryByTestId('view-sbom-icon') as HTMLElement);
+    });
+
+    await waitFor(() => {
+      within(
+        screen.getByTestId('pipelinerun-logs-dialog') as HTMLElement,
+      ).getByText('Logs modal content');
+    });
+  });
+
+  it('should render the external sbom link', () => {
+    render(
+      <TestPipelineRunRowActions
+        pipelineRun={mockKubernetesPlrResponse.pipelineruns[4]}
+      />,
+    );
+
+    expect(screen.queryByTestId('external-sbom-link')).toBeInTheDocument();
+  });
+
+  it('should not open sbom logs modal when the view external SBOM link is clicked', async () => {
+    render(
+      <TestPipelineRunRowActions
+        pipelineRun={mockKubernetesPlrResponse.pipelineruns[4]}
+      />,
+    );
+
+    expect(screen.queryByTestId('external-sbom-link')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.queryByTestId('view-sbom-icon') as HTMLElement);
+    });
+
+    await waitFor(() => {
+      expect(
+        within(
+          screen.getByTestId('pipelinerun-logs-dialog') as HTMLElement,
+        ).queryByText('Logs modal content'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('should disable the view output action', () => {
+    render(
+      <TestPipelineRunRowActions
+        pipelineRun={mockKubernetesPlrResponse.pipelineruns[1]}
+      />,
+    );
+
+    expect(screen.queryByTestId('view-output-icon')).toBeInTheDocument();
+
+    expect(
+      screen.queryByTestId('view-output-icon')?.getAttribute('disabled'),
+    ).toBeDefined();
+  });
+
+  it('should enable the view output action', () => {
+    render(
+      <TestPipelineRunRowActions
+        pipelineRun={mockKubernetesPlrResponse.pipelineruns[2]}
+      />,
+    );
+
+    expect(screen.queryByTestId('view-output-icon')).toBeInTheDocument();
+
+    expect(
+      screen.queryByTestId('view-output-icon')?.getAttribute('disabled'),
+    ).toBeNull();
+  });
+});

--- a/plugins/tekton/src/hooks/useAllWatchResources.test.ts
+++ b/plugins/tekton/src/hooks/useAllWatchResources.test.ts
@@ -29,7 +29,7 @@ describe('useAllWatchResources', () => {
     const { result } = renderHook(() =>
       useAllWatchResources(k8sObjectsResponse, 0, watchedResources),
     );
-    expect(result.current?.pipelineruns?.data).toHaveLength(3);
+    expect(result.current?.pipelineruns?.data).toHaveLength(5);
     expect(result.current?.taskruns).toBeUndefined();
   });
 
@@ -61,6 +61,6 @@ describe('useAllWatchResources', () => {
       error: '',
     } as KubernetesObjects;
     rerender();
-    expect(result.current?.pipelineruns?.data).toHaveLength(3);
+    expect(result.current?.pipelineruns?.data).toHaveLength(5);
   });
 });

--- a/plugins/tekton/src/utils/taskRun-utils.test.ts
+++ b/plugins/tekton/src/utils/taskRun-utils.test.ts
@@ -44,7 +44,7 @@ describe('taskRun-utils', () => {
       getSortedTaskRuns(mockKubernetesPlrResponse.taskruns),
       '',
     );
-    expect(activeTaskRun).toBe('ec-taskrun');
+    expect(activeTaskRun).toBe('pipelinerun-with-sbom-task-t237ev-sbom-task');
   });
 
   it('should return active taskrun when active task is present', () => {


### PR DESCRIPTION
**Fixes:**

https://github.com/janus-idp/backstage-plugins/issues/1151

This PR contains the following changes:

1. Logs modal will be opened only for internal sbom task.
2. Add unit tests to cover pipelinerun  actions component.

**Description:**

On clicking on View SBOM action, the users is properly redirected to external-link when the task contains external-link annotation, but the internal sbom logs dialog is also opened at the same time. Logs modal should be opened only when this external-link annotation is not set.



**Before:**

https://github.com/janus-idp/backstage-plugins/assets/9964343/1cc83a4f-8a10-4f3f-aabb-7f059197f728


**After:**


https://github.com/janus-idp/backstage-plugins/assets/9964343/8f9df0b7-bada-4125-bc54-0da7eb210b74

**How to test:**

1. After checking out this PR, run `yarn start` to run dev-mode
2. Find pipelineRun name `pipelinerun-with-external-sbom-task` and click on the View SBOM action
3. You should be redirected to an external link and when you come back to your original tab then logs modal shouldn't be open.

**Unit tests**:

```
  PipelineRunRowActions
    ✓ should render the icon space holder (114 ms)
    ✓ should render the internal sbom link (43 ms)
    ✓ should open sbom logs modal when the view SBOM link is clicked (59 ms)
    ✓ should render the external sbom link (34 ms)
    ✓ should not open sbom logs modal when the view external SBOM link is clicked (39 ms)
    ✓ should disable the view output action (29 ms)
    ✓ should enable the view output action (25 ms)
```

/cc @jeff-phillips-18 @rohitkrai03 