### PR TITLE
chore(dynamic-plugins-info): export config

### DIFF
--- a/plugins/dynamic-plugins-info/package.json
+++ b/plugins/dynamic-plugins-info/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "dist-scalprum"
+    "dist-scalprum",
+    "app-config.janus-idp.yaml"
   ],
   "scalprum": {
     "name": "janus-idp.backstage-plugin-dynamic-plugins-info",


### PR DESCRIPTION
This commit ensures the plugin configuration is also exported when the package is released.

@invincibleJai FYI missed this bit in the initial spike of this component.