### PR TITLE
fix(3scale): modify 3scale environment variables

### DIFF
--- a/plugins/3scale-backend/app-config.janus-idp.yaml
+++ b/plugins/3scale-backend/app-config.janus-idp.yaml
@@ -2,8 +2,8 @@ catalog:
   providers:
     threeScaleApiEntity:
       dev:
-        baseUrl: '${3SCALE_BASE_URL}' # https://<TENANT>-admin.3scale.net
-        accessToken: '${3SCALE_ACCESS_TOKEN}'
+        baseUrl: '${_3SCALE_BASE_URL}' # https://<TENANT>-admin.3scale.net
+        accessToken: '${_3SCALE_ACCESS_TOKEN}'
         schedule: # optional; same options as in TaskScheduleDefinition
           # supports cron, ISO duration, "human duration" as used in code
           frequency: { minutes: 1 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHIDP-1030
Upstream issue: https://github.com/janus-idp/backstage-showcase/issues/849


In fact environment variables starting with digits are not recommended in POSIX:

> Environment variable names used by the utilities in the Shell and Utilities volume of POSIX.1-2017 consist solely of uppercase letters, digits, and the <underscore> ( '_' ) from the characters defined in [Portable Character Set](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap06.html#tagtcjh_3) and **do not begin with a digit**

Hence I am adding an underscore ("_") as initial character. 

Notice I didn't find it documented, hence I am not changing documentation. Let me know if I should document this.

Thanks!

[1] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html