### PR TITLE
fix: add missing alpha  dynamic plugin entry points

### DIFF
--- a/plugins/ocm-backend/src/alpha.ts
+++ b/plugins/ocm-backend/src/alpha.ts
@@ -16,3 +16,4 @@
 
 export { catalogModuleOCMEntityProvider } from './providers';
 export { ocmPlugin } from './service/router';
+export { dynamicPluginInstaller } from './dynamic/alpha';

--- a/plugins/orchestrator-backend/src/alpha.ts
+++ b/plugins/orchestrator-backend/src/alpha.ts
@@ -1,2 +1,3 @@
 export { orchestratorPlugin } from './OrchestratorPlugin';
 export { orchestratorModuleEntityProvider } from './module';
+export { dynamicPluginInstaller } from './dynamic/alpha';


### PR DESCRIPTION
When embedding alpha modules, the embedded module dependencies were not hoisted to the embedding module.

This PR fixes this issue.