### PR TITLE
fix(rbac): csv updates no longer require server restarts

### DIFF
--- a/plugins/rbac-backend/README.md
+++ b/plugins/rbac-backend/README.md
@@ -143,6 +143,16 @@ permission:
     policies-csv-file: /some/path/rbac-policy.csv
 ```
 
+Also, there is an additional configuration value that allows for the reloading of the CSV file without the need to restart.
+
+```YAML
+permission:
+  enabled: true
+  rbac:
+    policies-csv-file: /some/path/rbac-policy.csv
+    policyFileReload: true
+```
+
 For more information on the available permissions within Showcase and RHDH, refer to the [permissions documentation](./docs/permissions.md).
 
 ### Configuring Database Storage for policies

--- a/plugins/rbac-backend/config.d.ts
+++ b/plugins/rbac-backend/config.d.ts
@@ -3,6 +3,11 @@ export interface Config {
     rbac: {
       'policies-csv-file'?: string;
       /**
+       * Allow for reloading of the CSV file.
+       * @visibility frontend
+       */
+      policyFileReload?: boolean;
+      /**
        * Optional configuration for admins, can declare individual users and / or groups
        * @visibility frontend
        */

--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/duplicate-policies-actions.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/duplicate-policies-actions.csv
@@ -1,0 +1,3 @@
+p, role:default/catalog-writer, catalog.entity.create, use, allow
+
+p, role:default/catalog-writer, catalog.entity.create, use, deny

--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/duplicate-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/duplicate-policy.csv
@@ -1,0 +1,9 @@
+g, user:default/guest, role:default/catalog-deleter
+g, user:default/guest, role:default/catalog-deleter
+
+g, user:default/guest, role:default/catalog-updater
+
+p, role:default/catalog-writer, catalog.entity.create, use, allow
+p, role:default/catalog-writer, catalog.entity.create, use, allow
+
+p, role:default/catalog-writer, catalog-entity, delete, allow

--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/entityref-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/entityref-policy.csv
@@ -1,0 +1,1 @@
+g, user:default/, role:default/catalog-deleter

--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/permission-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/permission-policy.csv
@@ -1,0 +1,1 @@
+p, role:default/, catalog.entity.create, use, allow

--- a/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/role-entityref-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/invalid-csv/role-entityref-policy.csv
@@ -1,0 +1,1 @@
+g, user:default/test, role:default/

--- a/plugins/rbac-backend/src/__fixtures__/data/valid-csv/rbac-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/valid-csv/rbac-policy.csv
@@ -7,4 +7,6 @@ p, role:default/catalog-writer, catalog-entity, read, allow
 p, role:default/catalog-writer, catalog.entity.create, use, allow
 p, role:default/catalog-deleter, catalog-entity, delete, deny
 
-p, user:default/known_user, test.resource.deny, use, allow
+p, role:default/known_role, test.resource.deny, use, allow
+
+g, user:default/known_user, role:default/known_role

--- a/plugins/rbac-backend/src/__fixtures__/data/valid-csv/rbac-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/valid-csv/rbac-policy.csv
@@ -1,0 +1,10 @@
+g, user:default/guest, role:default/catalog-writer
+g, user:default/guest, role:default/catalog-reader
+g, user:default/guest, role:default/catalog-deleter
+
+p, role:default/catalog-writer, catalog-entity, update, allow
+p, role:default/catalog-writer, catalog-entity, read, allow
+p, role:default/catalog-writer, catalog.entity.create, use, allow
+p, role:default/catalog-deleter, catalog-entity, delete, deny
+
+p, user:default/known_user, test.resource.deny, use, allow

--- a/plugins/rbac-backend/src/__fixtures__/data/valid-csv/updated-rbac-policy.csv
+++ b/plugins/rbac-backend/src/__fixtures__/data/valid-csv/updated-rbac-policy.csv
@@ -1,0 +1,10 @@
+g, user:default/guest, role:default/catalog-writer
+g, user:default/guest, role:default/catalog-updater
+
+g, user:default/guest, role:default/catalog-tester
+
+p, role:default/catalog-writer, catalog-entity, update, allow
+p, role:default/catalog-writer, catalog.entity.create, use, deny
+p, role:default/catalog-deleter, catalog-entity, delete, allow
+
+p, role:default/catalog-writer, catalog.entity.delete, delete, allow

--- a/plugins/rbac-backend/src/file-permissions/csv.test.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv.test.ts
@@ -1,0 +1,973 @@
+import { TokenManager } from '@backstage/backend-common';
+
+import {
+  Adapter,
+  Enforcer,
+  FileAdapter,
+  Model,
+  newEnforcer,
+  newModelFromString,
+  StringAdapter,
+} from 'casbin';
+import * as Knex from 'knex';
+import { MockClient } from 'knex-mock-client';
+import { isEqual } from 'lodash';
+import { Logger } from 'winston';
+
+import {
+  PermissionPolicyMetadata,
+  RoleMetadata,
+  Source,
+} from '@janus-idp/backstage-plugin-rbac-common';
+
+import { resolve } from 'path';
+
+import {
+  PermissionPolicyMetadataDao,
+  PolicyMetadataStorage,
+} from '../database/policy-metadata-storage';
+import { RoleMetadataStorage } from '../database/role-metadata';
+import { EnforcerDelegate } from '../service/enforcer-delegate';
+import { MODEL } from '../service/permission-model';
+import { BackstageRoleManager } from '../service/role-manager';
+import {
+  addPermissionPoliciesFileData,
+  loadFilteredGroupingPoliciesFromCSV,
+  loadFilteredPoliciesFromCSV,
+} from './csv';
+
+const catalogApi = {
+  getEntityAncestors: jest.fn().mockImplementation(),
+  getLocationById: jest.fn().mockImplementation(),
+  getEntities: jest.fn().mockImplementation(),
+  getEntitiesByRefs: jest.fn().mockImplementation(),
+  queryEntities: jest.fn().mockImplementation(),
+  getEntityByRef: jest.fn().mockImplementation(),
+  refreshEntity: jest.fn().mockImplementation(),
+  getEntityFacets: jest.fn().mockImplementation(),
+  addLocation: jest.fn().mockImplementation(),
+  getLocationByRef: jest.fn().mockImplementation(),
+  removeLocationById: jest.fn().mockImplementation(),
+  removeEntityByUid: jest.fn().mockImplementation(),
+  validateEntity: jest.fn().mockImplementation(),
+};
+
+const roleMetadataStorageMock: RoleMetadataStorage = {
+  findRoleMetadata: jest
+    .fn()
+    .mockImplementation(
+      async (
+        _roleEntityRef: string,
+        _trx: Knex.Knex.Transaction,
+      ): Promise<RoleMetadata> => {
+        return { source: 'csv-file' };
+      },
+    ),
+  createRoleMetadata: jest.fn().mockImplementation(),
+  updateRoleMetadata: jest.fn().mockImplementation(),
+  removeRoleMetadata: jest.fn().mockImplementation(),
+};
+
+const policyMetadataStorageMock: PolicyMetadataStorage = {
+  findPolicyMetadataBySource: jest
+    .fn()
+    .mockImplementation(
+      async (_source: Source): Promise<PermissionPolicyMetadataDao[]> => {
+        return [];
+      },
+    ),
+  findPolicyMetadata: jest
+    .fn()
+    .mockImplementation(
+      async (
+        _policy: string[],
+        _trx: Knex.Knex.Transaction,
+      ): Promise<PermissionPolicyMetadata> => {
+        const test: PermissionPolicyMetadata = {
+          source: 'csv-file',
+        };
+        return test;
+      },
+    ),
+  createPolicyMetadata: jest.fn().mockImplementation(),
+  removePolicyMetadata: jest.fn().mockImplementation(),
+};
+
+const tokenManagerMock = {
+  getToken: jest.fn().mockImplementation(async () => {
+    return Promise.resolve({ token: 'some-token' });
+  }),
+  authenticate: jest.fn().mockImplementation(),
+};
+
+const loggerMock: any = {
+  warn: jest.fn().mockImplementation(),
+  debug: jest.fn().mockImplementation(),
+};
+
+async function createEnforcer(
+  theModel: Model,
+  adapter: Adapter,
+  log: Logger,
+  tokenManager: TokenManager,
+): Promise<Enforcer> {
+  const enf = await newEnforcer(theModel, adapter);
+
+  const rm = new BackstageRoleManager(catalogApi, log, tokenManager);
+  enf.setRoleManager(rm);
+  enf.enableAutoBuildRoleLinks(false);
+  await enf.buildRoleLinks();
+
+  return enf;
+}
+
+describe('CSV file', () => {
+  let enfAddPolicySpy: jest.SpyInstance<Promise<boolean>, string[], any>;
+  let enfRemovePolicySpy: jest.SpyInstance<Promise<boolean>, string[], any>;
+  let enfAddGroupingSpy: jest.SpyInstance<Promise<boolean>, string[], any>;
+  let enfRemoveGroupingSpy: jest.SpyInstance<Promise<boolean>, string[], any>;
+
+  const user: string = 'user:default/guest';
+  const resourceType: string = 'catalog.entity.create';
+  const action: string = 'use';
+
+  describe('Loading filtered policies from a CSV file', () => {
+    let csvPermFile: string;
+    let enf: Enforcer;
+    let enfDelegate: EnforcerDelegate;
+    let knex: Knex.Knex;
+    beforeEach(async () => {
+      loggerMock.warn = jest.fn().mockImplementation();
+      policyMetadataStorageMock.findPolicyMetadata = jest
+        .fn()
+        .mockImplementation(
+          async (
+            _policy: string[],
+            _trx: Knex.Knex.Transaction,
+          ): Promise<PermissionPolicyMetadata> => {
+            const test: PermissionPolicyMetadata = {
+              source: 'csv-file',
+            };
+            return test;
+          },
+        );
+
+      csvPermFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/rbac-policy.csv',
+      );
+      const adapter = new FileAdapter(csvPermFile);
+
+      const stringModel = newModelFromString(MODEL);
+      enf = await createEnforcer(
+        stringModel,
+        adapter,
+        loggerMock,
+        tokenManagerMock,
+      );
+
+      knex = Knex.knex({ client: MockClient });
+
+      enfDelegate = new EnforcerDelegate(
+        enf,
+        policyMetadataStorageMock,
+        roleMetadataStorageMock,
+        knex,
+      );
+
+      enfAddPolicySpy = jest.spyOn(enf, 'addPolicy');
+      enfRemovePolicySpy = jest.spyOn(enf, 'removePolicy');
+      enfAddGroupingSpy = jest.spyOn(enf, 'addGroupingPolicy');
+      enfRemoveGroupingSpy = jest.spyOn(enf, 'removeGroupingPolicy');
+    });
+
+    afterEach(() => {
+      (loggerMock.warn as jest.Mock).mockReset();
+      (policyMetadataStorageMock.findPolicyMetadata as jest.Mock).mockReset();
+    });
+
+    it('should update a policy that has changed in the file (allow -> deny)', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+      const updatedPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'deny',
+      ];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(true);
+      expect(await enfDelegate.hasPolicy(...updatedPolicy)).toBe(false);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        resourceType,
+        action,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(enfAddPolicySpy).toHaveBeenCalledWith(...updatedPolicy);
+      expect(enfRemovePolicySpy).toHaveBeenCalledWith(...originalPolicy);
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(false);
+      expect(await enfDelegate.hasPolicy(...updatedPolicy)).toBe(true);
+    });
+
+    it('should update a policy that has changed in the file (deny -> allow)', async () => {
+      const originalPolicy = [
+        'role:default/catalog-deleter',
+        'catalog-entity',
+        'delete',
+        'deny',
+      ];
+      const updatedPolicy = [
+        'role:default/catalog-deleter',
+        'catalog-entity',
+        'delete',
+        'allow',
+      ];
+      const denyResource = 'catalog-entity';
+      const denyAction = 'delete';
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(true);
+      expect(await enfDelegate.hasPolicy(...updatedPolicy)).toBe(false);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        denyResource,
+        denyAction,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(enfAddPolicySpy).toHaveBeenCalledWith(...updatedPolicy);
+      expect(enfRemovePolicySpy).toHaveBeenCalledWith(...originalPolicy);
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(false);
+      expect(await enfDelegate.hasPolicy(...updatedPolicy)).toBe(true);
+    });
+
+    it('should add a policy that is new in the file', async () => {
+      const newPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.delete',
+        'delete',
+        'allow',
+      ];
+
+      const newResourceType = 'catalog.entity.delete';
+      const newAction = 'delete';
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enfDelegate.hasPolicy(...newPolicy)).toBe(false);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        newResourceType,
+        newAction,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(enfAddPolicySpy).toHaveBeenCalledWith(...newPolicy);
+
+      expect(await enfDelegate.hasPolicy(...newPolicy)).toBe(true);
+    });
+
+    it('should remove a policy that is no longer in the file', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog-entity',
+        'read',
+        'allow',
+      ];
+
+      const originalResource = 'catalog-entity';
+      const originalAction = 'read';
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        originalResource,
+        originalAction,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(enfRemovePolicySpy).toHaveBeenCalledWith(...originalPolicy);
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(false);
+    });
+
+    it('should do nothing if there is no change', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+      const originalPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/rbac-policy.csv',
+      );
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredPoliciesFromCSV(
+        originalPolicyFile,
+        enfDelegate,
+        user,
+        resourceType,
+        action,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(enfAddPolicySpy).toHaveBeenCalledTimes(0);
+      expect(enfRemovePolicySpy).toHaveBeenCalledTimes(0);
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(true);
+    });
+
+    // Validation tests
+    it('should fail to update a policy that has changed in the file, entityRef error', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+      const updatedPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'deny',
+      ];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/permission-policy.csv',
+      );
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(true);
+      expect(await enfDelegate.hasPolicy(...updatedPolicy)).toBe(false);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        resourceType,
+        action,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        `Failed to validate policy from file ${updatedPolicyFile}. Cause: Entity reference \"role:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to update a policy that has changed in the file, duplicate error', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/duplicate-policy.csv',
+      );
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        resourceType,
+        action,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        1,
+        `Duplicate policy: ${originalPolicy} found in the file ${updatedPolicyFile}`,
+      );
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        2,
+        `Duplicate policy: ${originalPolicy} found in the file ${updatedPolicyFile}`,
+      );
+    });
+
+    it('should fail to update a policy that has changed in the file, duplicate error different actions', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/duplicate-policies-actions.csv',
+      );
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        resourceType,
+        action,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        1,
+        `Duplicate policy: ${originalPolicy.at(0)}, ${originalPolicy.at(
+          1,
+        )}, ${originalPolicy.at(
+          2,
+        )} with different actions found with the source csv-file`,
+      );
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        2,
+        `Duplicate policy: ${originalPolicy.at(0)}, ${originalPolicy.at(
+          1,
+        )}, ${originalPolicy.at(
+          2,
+        )} with different actions found with the source csv-file`,
+      );
+    });
+
+    it('should fail to update a policy that has changed in the file, duplicate error different source', async () => {
+      const originalPolicy = [
+        'role:default/catalog-writer',
+        'catalog-entity',
+        'delete',
+        'allow',
+      ];
+
+      await enfDelegate.addPolicy(originalPolicy, 'rest');
+
+      policyMetadataStorageMock.findPolicyMetadata = jest
+        .fn()
+        .mockImplementation(
+          async (
+            policy: string[],
+            _trx: Knex.Knex.Transaction,
+          ): Promise<PermissionPolicyMetadata> => {
+            if (isEqual(policy, originalPolicy)) {
+              return { source: 'rest' };
+            }
+            return { source: 'csv-file' };
+          },
+        );
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/duplicate-policy.csv',
+      );
+
+      expect(await enfDelegate.hasPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        'catalog-entity',
+        'delete',
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        `Duplicate policy: ${originalPolicy.at(0)}, ${originalPolicy.at(
+          1,
+        )}, ${originalPolicy.at(2)} found with the source rest`,
+      );
+    });
+  });
+
+  describe('Loading filtered grouping policies from a CSV file', () => {
+    let csvPermFile: string;
+    let enf: Enforcer;
+    let enfDelegate: EnforcerDelegate;
+    beforeEach(async () => {
+      policyMetadataStorageMock.findPolicyMetadata = jest
+        .fn()
+        .mockImplementation(
+          async (
+            _policy: string[],
+            _trx: Knex.Knex.Transaction,
+          ): Promise<PermissionPolicyMetadata> => {
+            const test: PermissionPolicyMetadata = {
+              source: 'csv-file',
+            };
+            return test;
+          },
+        );
+
+      csvPermFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/rbac-policy.csv',
+      );
+      const adapter = new FileAdapter(csvPermFile);
+
+      const stringModel = newModelFromString(MODEL);
+      enf = await createEnforcer(
+        stringModel,
+        adapter,
+        loggerMock,
+        tokenManagerMock,
+      );
+
+      const knex = Knex.knex({ client: MockClient });
+
+      enfDelegate = new EnforcerDelegate(
+        enf,
+        policyMetadataStorageMock,
+        roleMetadataStorageMock,
+        knex,
+      );
+
+      enfAddPolicySpy = jest.spyOn(enf, 'addPolicy');
+      enfRemovePolicySpy = jest.spyOn(enf, 'removePolicy');
+      enfAddGroupingSpy = jest.spyOn(enf, 'addGroupingPolicy');
+      enfRemoveGroupingSpy = jest.spyOn(enf, 'removeGroupingPolicy');
+    });
+
+    afterEach(() => {
+      (loggerMock.warn as jest.Mock).mockReset();
+      (policyMetadataStorageMock.findPolicyMetadata as jest.Mock).mockReset();
+    });
+
+    it('should update a policy that has changed in the file', async () => {
+      const originalPolicy = [
+        'user:default/guest',
+        'role:default/catalog-reader',
+      ];
+      const updatedPolicy = [
+        'user:default/guest',
+        'role:default/catalog-updater',
+      ];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enfDelegate.hasGroupingPolicy(...originalPolicy)).toBe(true);
+      expect(await enfDelegate.hasGroupingPolicy(...updatedPolicy)).toBe(false);
+
+      await loadFilteredGroupingPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(enfAddGroupingSpy).toHaveBeenCalledWith(...updatedPolicy);
+      expect(enfRemoveGroupingSpy).toHaveBeenCalledWith(...originalPolicy);
+
+      expect(await enfDelegate.hasGroupingPolicy(...originalPolicy)).toBe(
+        false,
+      );
+      expect(await enfDelegate.hasGroupingPolicy(...updatedPolicy)).toBe(true);
+    });
+
+    it('should add a role that is new in the file', async () => {
+      const newPolicy = ['user:default/guest', 'role:default/catalog-tester'];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enfDelegate.hasGroupingPolicy(...newPolicy)).toBe(false);
+
+      await loadFilteredGroupingPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(enfAddGroupingSpy).toHaveBeenCalledWith(...newPolicy);
+
+      expect(await enfDelegate.hasGroupingPolicy(...newPolicy)).toBe(true);
+    });
+
+    it('should remove a policy that is no longer in the file', async () => {
+      const originalPolicy = [
+        'user:default/guest',
+        'role:default/catalog-deleter',
+      ];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/updated-rbac-policy.csv',
+      );
+
+      expect(await enfDelegate.hasGroupingPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredGroupingPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(enfRemoveGroupingSpy).toHaveBeenCalledWith(...originalPolicy);
+
+      expect(await enfDelegate.hasGroupingPolicy(...originalPolicy)).toBe(
+        false,
+      );
+    });
+
+    it('should do nothing if there is no change', async () => {
+      const originalPolicy = [
+        'user:default/guest',
+        'role:default/catalog-writer',
+      ];
+      const originalPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/rbac-policy.csv',
+      );
+
+      expect(await enfDelegate.hasGroupingPolicy(...originalPolicy)).toBe(true);
+
+      await loadFilteredGroupingPoliciesFromCSV(
+        originalPolicyFile,
+        enfDelegate,
+        user,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(enfAddGroupingSpy).toHaveBeenCalledTimes(0);
+      expect(enfRemoveGroupingSpy).toHaveBeenCalledTimes(0);
+
+      expect(await enfDelegate.hasGroupingPolicy(...originalPolicy)).toBe(true);
+    });
+
+    // Validation tests
+    it('should fail to update a policy that has changed in the file, user entityRef error', async () => {
+      const originalPolicy = [
+        'user:default/guest',
+        'role:default/catalog-deleter',
+      ];
+      const updatedPolicy = [
+        'user:default/test',
+        'role:default/catalog-deleter',
+      ];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/entityref-policy.csv',
+      );
+
+      expect(await enfDelegate.hasGroupingPolicy(...originalPolicy)).toBe(true);
+      expect(await enfDelegate.hasGroupingPolicy(...updatedPolicy)).toBe(false);
+
+      await loadFilteredGroupingPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        user,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        `Failed to validate role from file ${updatedPolicyFile}. Cause: Entity reference \"user:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to update a policy that has changed in the file, role entityRef error', async () => {
+      const newUser = 'user:default/test';
+      const newPolicy = ['user:default/test', 'role:default/catalog-reader'];
+
+      const updatedPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/role-entityref-policy.csv',
+      );
+
+      expect(await enfDelegate.hasGroupingPolicy(...newPolicy)).toBe(false);
+
+      await loadFilteredGroupingPoliciesFromCSV(
+        updatedPolicyFile,
+        enfDelegate,
+        newUser,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        `Failed to validate role from file ${updatedPolicyFile}. Cause: Entity reference \"role:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to update a policy that has changed in the file, duplicate error with and without different sources', async () => {
+      const duplicateCSV = [
+        'user:default/guest',
+        'role:default/catalog-deleter',
+      ];
+      const duplicateRest = [
+        'user:default/guest',
+        'role:default/catalog-updater',
+      ];
+
+      policyMetadataStorageMock.findPolicyMetadata = jest
+        .fn()
+        .mockImplementation(
+          async (
+            policy: string[],
+            _trx: Knex.Knex.Transaction,
+          ): Promise<PermissionPolicyMetadata> => {
+            if (isEqual(policy, duplicateRest)) {
+              return { source: 'rest' };
+            }
+            return { source: 'csv-file' };
+          },
+        );
+
+      await enfDelegate.addGroupingPolicy(duplicateRest, 'rest');
+
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/duplicate-policy.csv',
+      );
+
+      await loadFilteredGroupingPoliciesFromCSV(
+        errorPolicyFile,
+        enfDelegate,
+        user,
+        loggerMock,
+        policyMetadataStorageMock,
+      );
+
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        1,
+        `Duplicate role: ${duplicateCSV} found in the file ${errorPolicyFile}`,
+      );
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        2,
+        `Duplicate role: ${duplicateCSV} found in the file ${errorPolicyFile}`,
+      );
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        3,
+        `Duplicate role: ${duplicateRest[0]}, ${duplicateRest[1]} found with the source rest`,
+      );
+    });
+  });
+
+  describe('Loading policies from a CSV file', () => {
+    let csvPermFile: string;
+    let enf: Enforcer;
+    let enfDelegate: EnforcerDelegate;
+
+    beforeEach(async () => {
+      const adapter = new StringAdapter(
+        `
+          p, user:default/known_user, test.resource.deny, use, allow
+        `,
+      );
+      csvPermFile = resolve(
+        __dirname,
+        './../__fixtures__/data/valid-csv/rbac-policy.csv',
+      );
+
+      const stringModel = newModelFromString(MODEL);
+      enf = await createEnforcer(
+        stringModel,
+        adapter,
+        loggerMock,
+        tokenManagerMock,
+      );
+
+      const knex = Knex.knex({ client: MockClient });
+
+      enfDelegate = new EnforcerDelegate(
+        enf,
+        policyMetadataStorageMock,
+        roleMetadataStorageMock,
+        knex,
+      );
+    });
+
+    afterEach(() => {
+      (loggerMock.warn as jest.Mock).mockReset();
+    });
+
+    it('should add policies from the CSV file', async () => {
+      const test = [
+        'role:default/catalog-writer',
+        'catalog-entity',
+        'update',
+        'allow',
+      ];
+      await addPermissionPoliciesFileData(
+        csvPermFile,
+        enfDelegate,
+        roleMetadataStorageMock,
+        loggerMock,
+      );
+
+      expect(await enfDelegate.hasPolicy(...test)).toBe(true);
+    });
+
+    // Validation tests
+    it('should fail to add policies from the CSV file, user entityRef group error', async () => {
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/entityref-policy.csv',
+      );
+
+      await addPermissionPoliciesFileData(
+        errorPolicyFile,
+        enfDelegate,
+        roleMetadataStorageMock,
+        loggerMock,
+      );
+
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        `Failed to validate group policy user:default/,role:default/catalog-deleter from file ${errorPolicyFile}. Cause: Entity reference \"user:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to add policies from the CSV file, role entityRef group error', async () => {
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/role-entityref-policy.csv',
+      );
+
+      await addPermissionPoliciesFileData(
+        errorPolicyFile,
+        enfDelegate,
+        roleMetadataStorageMock,
+        loggerMock,
+      );
+
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        `Failed to validate group policy user:default/test,role:default/ from file ${errorPolicyFile}. Cause: Entity reference \"role:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to add policies from the CSV file, role entityRef permission policy error', async () => {
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/permission-policy.csv',
+      );
+
+      await addPermissionPoliciesFileData(
+        errorPolicyFile,
+        enfDelegate,
+        roleMetadataStorageMock,
+        loggerMock,
+      );
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        `Failed to validate policy from file ${errorPolicyFile}. Cause: Entity reference \"role:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
+    });
+
+    it('should fail to add policies from the CSV file, duplicate permission policies in CSV and in enforcer', async () => {
+      const duplicatePolicyCSV = [
+        'role:default/catalog-writer',
+        'catalog.entity.create',
+        'use',
+        'allow',
+      ];
+
+      const duplicateRoleCSV = [
+        'user:default/guest',
+        'role:default/catalog-deleter',
+      ];
+
+      const duplicatePolicyEnforcer = [
+        'role:default/catalog-writer',
+        'catalog-entity',
+        'delete',
+        'allow',
+      ];
+
+      const duplicateRoleEnforcer = [
+        'user:default/guest',
+        'role:default/catalog-updater',
+      ];
+
+      await enfDelegate.addPolicy(duplicatePolicyEnforcer, 'rest');
+      await enfDelegate.addGroupingPolicy(duplicateRoleEnforcer, 'rest');
+
+      const errorPolicyFile = resolve(
+        __dirname,
+        './../__fixtures__/data/invalid-csv/duplicate-policy.csv',
+      );
+
+      await addPermissionPoliciesFileData(
+        errorPolicyFile,
+        enfDelegate,
+        roleMetadataStorageMock,
+        loggerMock,
+      );
+
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        1,
+        `Duplicate policy: ${duplicatePolicyEnforcer} found in the file ${errorPolicyFile}`,
+      );
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        2,
+        `Duplicate policy: ${duplicatePolicyCSV} found in the file ${errorPolicyFile}`,
+      );
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        3,
+        `Duplicate policy: ${duplicatePolicyCSV} found in the file ${errorPolicyFile}`,
+      );
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        4,
+        `Duplicate role: ${duplicateRoleCSV} found in the file ${errorPolicyFile}`,
+      );
+      expect(loggerMock.warn).toHaveBeenNthCalledWith(
+        5,
+        `Duplicate role: ${duplicateRoleCSV} found in the file ${errorPolicyFile}`,
+      );
+    });
+  });
+});

--- a/plugins/rbac-backend/src/file-permissions/csv.test.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv.test.ts
@@ -127,9 +127,11 @@ describe('CSV file', () => {
   let enfAddGroupingSpy: jest.SpyInstance<Promise<boolean>, string[], any>;
   let enfRemoveGroupingSpy: jest.SpyInstance<Promise<boolean>, string[], any>;
 
-  const user: string = 'user:default/guest';
-  const resourceType: string = 'catalog.entity.create';
-  const action: string = 'use';
+  const policyFilter: string[] = [
+    'user:default/guest',
+    'catalog.entity.create',
+    'use',
+  ];
 
   describe('Loading filtered policies from a CSV file', () => {
     let csvPermFile: string;
@@ -211,9 +213,7 @@ describe('CSV file', () => {
       await loadFilteredPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
-        resourceType,
-        action,
+        policyFilter,
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -226,6 +226,11 @@ describe('CSV file', () => {
     });
 
     it('should update a policy that has changed in the file (deny -> allow)', async () => {
+      const tempFilter: string[] = [
+        policyFilter[0],
+        'catalog-entity',
+        'delete',
+      ];
       const originalPolicy = [
         'role:default/catalog-deleter',
         'catalog-entity',
@@ -238,8 +243,6 @@ describe('CSV file', () => {
         'delete',
         'allow',
       ];
-      const denyResource = 'catalog-entity';
-      const denyAction = 'delete';
 
       const updatedPolicyFile = resolve(
         __dirname,
@@ -252,9 +255,7 @@ describe('CSV file', () => {
       await loadFilteredPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
-        denyResource,
-        denyAction,
+        tempFilter,
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -267,15 +268,17 @@ describe('CSV file', () => {
     });
 
     it('should add a policy that is new in the file', async () => {
+      const tempFilter: string[] = [
+        policyFilter[0],
+        'catalog.entity.delete',
+        'delete',
+      ];
       const newPolicy = [
         'role:default/catalog-writer',
         'catalog.entity.delete',
         'delete',
         'allow',
       ];
-
-      const newResourceType = 'catalog.entity.delete';
-      const newAction = 'delete';
 
       const updatedPolicyFile = resolve(
         __dirname,
@@ -287,9 +290,7 @@ describe('CSV file', () => {
       await loadFilteredPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
-        newResourceType,
-        newAction,
+        tempFilter,
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -300,15 +301,13 @@ describe('CSV file', () => {
     });
 
     it('should remove a policy that is no longer in the file', async () => {
+      const tempFilter: string[] = [policyFilter[0], 'catalog-entity', 'read'];
       const originalPolicy = [
         'role:default/catalog-writer',
         'catalog-entity',
         'read',
         'allow',
       ];
-
-      const originalResource = 'catalog-entity';
-      const originalAction = 'read';
 
       const updatedPolicyFile = resolve(
         __dirname,
@@ -320,9 +319,7 @@ describe('CSV file', () => {
       await loadFilteredPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
-        originalResource,
-        originalAction,
+        tempFilter,
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -349,9 +346,7 @@ describe('CSV file', () => {
       await loadFilteredPoliciesFromCSV(
         originalPolicyFile,
         enfDelegate,
-        user,
-        resourceType,
-        action,
+        policyFilter,
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -388,14 +383,12 @@ describe('CSV file', () => {
       await loadFilteredPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
-        resourceType,
-        action,
+        policyFilter,
         loggerMock,
         policyMetadataStorageMock,
       );
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        `Failed to validate policy from file ${updatedPolicyFile}. Cause: Entity reference \"role:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+        `Failed to validate policy from file ${updatedPolicyFile}. Cause: Entity reference "role:default/" was not on the form [<kind>:][<namespace>/]<name>`,
       );
     });
 
@@ -416,9 +409,7 @@ describe('CSV file', () => {
       await loadFilteredPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
-        resourceType,
-        action,
+        policyFilter,
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -450,9 +441,7 @@ describe('CSV file', () => {
       await loadFilteredPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
-        resourceType,
-        action,
+        policyFilter,
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -476,6 +465,11 @@ describe('CSV file', () => {
     });
 
     it('should fail to update a policy that has changed in the file, duplicate error different source', async () => {
+      const tempFilter: string[] = [
+        policyFilter[0],
+        'catalog-entity',
+        'delete',
+      ];
       const originalPolicy = [
         'role:default/catalog-writer',
         'catalog-entity',
@@ -509,9 +503,7 @@ describe('CSV file', () => {
       await loadFilteredPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
-        'catalog-entity',
-        'delete',
+        tempFilter,
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -598,7 +590,7 @@ describe('CSV file', () => {
       await loadFilteredGroupingPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
+        policyFilter[0],
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -625,7 +617,7 @@ describe('CSV file', () => {
       await loadFilteredGroupingPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
+        policyFilter[0],
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -651,7 +643,7 @@ describe('CSV file', () => {
       await loadFilteredGroupingPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
+        policyFilter[0],
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -678,7 +670,7 @@ describe('CSV file', () => {
       await loadFilteredGroupingPoliciesFromCSV(
         originalPolicyFile,
         enfDelegate,
-        user,
+        policyFilter[0],
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -711,13 +703,13 @@ describe('CSV file', () => {
       await loadFilteredGroupingPoliciesFromCSV(
         updatedPolicyFile,
         enfDelegate,
-        user,
+        policyFilter[0],
         loggerMock,
         policyMetadataStorageMock,
       );
 
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        `Failed to validate role from file ${updatedPolicyFile}. Cause: Entity reference \"user:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+        `Failed to validate role from file ${updatedPolicyFile}. Cause: Entity reference "user:default/" was not on the form [<kind>:][<namespace>/]<name>`,
       );
     });
 
@@ -741,7 +733,7 @@ describe('CSV file', () => {
       );
 
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        `Failed to validate role from file ${updatedPolicyFile}. Cause: Entity reference \"role:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+        `Failed to validate role from file ${updatedPolicyFile}. Cause: Entity reference "role:default/" was not on the form [<kind>:][<namespace>/]<name>`,
       );
     });
 
@@ -779,7 +771,7 @@ describe('CSV file', () => {
       await loadFilteredGroupingPoliciesFromCSV(
         errorPolicyFile,
         enfDelegate,
-        user,
+        policyFilter[0],
         loggerMock,
         policyMetadataStorageMock,
       );
@@ -869,7 +861,7 @@ describe('CSV file', () => {
       );
 
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        `Failed to validate group policy user:default/,role:default/catalog-deleter from file ${errorPolicyFile}. Cause: Entity reference \"user:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+        `Failed to validate group policy user:default/,role:default/catalog-deleter from file ${errorPolicyFile}. Cause: Entity reference "user:default/" was not on the form [<kind>:][<namespace>/]<name>`,
       );
     });
 
@@ -887,7 +879,7 @@ describe('CSV file', () => {
       );
 
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        `Failed to validate group policy user:default/test,role:default/ from file ${errorPolicyFile}. Cause: Entity reference \"role:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+        `Failed to validate group policy user:default/test,role:default/ from file ${errorPolicyFile}. Cause: Entity reference "role:default/" was not on the form [<kind>:][<namespace>/]<name>`,
       );
     });
 
@@ -904,7 +896,7 @@ describe('CSV file', () => {
         loggerMock,
       );
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        `Failed to validate policy from file ${errorPolicyFile}. Cause: Entity reference \"role:default/\" was not on the form [<kind>:][<namespace>/]<name>`,
+        `Failed to validate policy from file ${errorPolicyFile}. Cause: Entity reference "role:default/" was not on the form [<kind>:][<namespace>/]<name>`,
       );
     });
 

--- a/plugins/rbac-backend/src/file-permissions/csv.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv.ts
@@ -113,6 +113,13 @@ export const loadFilteredPoliciesFromCSV = async (
     );
   }
 
+  await removeEnforcerPolicies(
+    enforcerPolicies,
+    tempEnforcer,
+    enf,
+    policyMetadataStorage,
+  );
+
   for (const policy of policies) {
     const err = validatePolicy(transformArraytoPolicy(policy));
     if (err) {
@@ -164,13 +171,6 @@ export const loadFilteredPoliciesFromCSV = async (
 
     await addPolicy(policy, enf, policyMetadataStorage, logger);
   }
-
-  await removeEnforcerPolicies(
-    enforcerPolicies,
-    tempEnforcer,
-    enf,
-    policyMetadataStorage,
-  );
 };
 
 export const loadFilteredGroupingPoliciesFromCSV = async (

--- a/plugins/rbac-backend/src/file-permissions/csv.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv.ts
@@ -1,0 +1,338 @@
+import { Enforcer, FileAdapter, newEnforcer, newModelFromString } from 'casbin';
+import { isEqual } from 'lodash';
+import { Logger } from 'winston';
+
+import { PolicyMetadataStorage } from '../database/policy-metadata-storage';
+import { RoleMetadataStorage } from '../database/role-metadata';
+import { metadataStringToPolicy, transformArraytoPolicy } from '../helper';
+import { EnforcerDelegate } from '../service/enforcer-delegate';
+import { MODEL } from '../service/permission-model';
+import {
+  checkForDuplicateGroupPolicies,
+  checkForDuplicatePolicies,
+  validateAllPredefinedPolicies,
+  validateEntityReference,
+  validatePolicy,
+} from '../service/policies-validation';
+
+export const loadFilteredPoliciesFromCSV = async (
+  policyFile: string,
+  enf: EnforcerDelegate,
+  entityRef: string,
+  resource: string,
+  action: string,
+  logger: Logger,
+  policyMetadataStorage: PolicyMetadataStorage,
+  fileEnf?: Enforcer,
+) => {
+  const tempEnforcer =
+    fileEnf ??
+    (await newEnforcer(newModelFromString(MODEL), new FileAdapter(policyFile)));
+
+  const roles = await enf.getFilteredGroupingPolicy(0, entityRef);
+
+  const policies: string[][] = [];
+  let enforcerPolicies: string[][] = [];
+
+  for (const role of roles) {
+    const policyByRole = await tempEnforcer.getFilteredPolicy(
+      0,
+      role[1],
+      resource,
+      action,
+    );
+    policies.push(...policyByRole);
+    const enforcerPolicy = await enf.getFilteredPolicy(
+      0,
+      role[1],
+      resource,
+      action,
+    );
+    enforcerPolicies.push(...enforcerPolicy);
+  }
+
+  if (isEqual(policies, enforcerPolicies)) {
+    return;
+  }
+
+  if (policies.length === 0) {
+    policies.push(
+      ...(await tempEnforcer.getFilteredPolicy(1, resource, action)),
+    );
+  }
+
+  for (const policy of policies) {
+    const err = validatePolicy(transformArraytoPolicy(policy));
+    if (err) {
+      logger.warn(
+        `Failed to validate policy from file ${policyFile}. Cause: ${err.message}`,
+      );
+      continue;
+    }
+
+    const duplicateError = await checkForDuplicatePolicies(
+      tempEnforcer,
+      policy,
+      policyFile,
+    );
+    if (duplicateError) {
+      logger.warn(duplicateError.message);
+    }
+
+    const effectFlipPolicy = [
+      policy.at(0)!,
+      policy.at(1)!,
+      policy.at(2)!,
+      policy.at(3)! === 'deny' ? 'allow' : 'deny',
+    ];
+
+    const flipSource =
+      await policyMetadataStorage?.findPolicyMetadata(effectFlipPolicy);
+    const isDupFlipPolicy = await enf.hasPolicy(...effectFlipPolicy);
+    const isFileFlipPolicy = await tempEnforcer.hasPolicy(...effectFlipPolicy);
+    const isCSVSource = flipSource?.source === 'csv-file';
+
+    if (
+      (isDupFlipPolicy && !isCSVSource) ||
+      (isFileFlipPolicy && isCSVSource)
+    ) {
+      logger.warn(
+        `Duplicate policy: ${policy[0]}, ${policy[1]}, ${policy[2]} with different actions found with the source ${flipSource?.source}`,
+      );
+      continue;
+    }
+
+    if (isDupFlipPolicy && isCSVSource) {
+      await enf.removePolicy(effectFlipPolicy, 'csv-file', true);
+
+      enforcerPolicies = enforcerPolicies.filter(
+        policyCheck => !isEqual(policyCheck, effectFlipPolicy),
+      );
+    }
+
+    const source = await policyMetadataStorage?.findPolicyMetadata(policy);
+
+    if (!(await enf.hasPolicy(...policy))) {
+      await enf.addPolicy(policy, 'csv-file');
+    } else if (source?.source !== 'csv-file') {
+      logger.warn(
+        `Duplicate policy: ${policy[0]}, ${policy[1]}, ${policy[2]} found with the source ${source?.source}`,
+      );
+      continue;
+    }
+  }
+
+  for (const policy of enforcerPolicies) {
+    const enfPolicySource =
+      await policyMetadataStorage?.findPolicyMetadata(policy);
+    if (
+      !(await tempEnforcer.hasPolicy(...policy)) &&
+      enfPolicySource?.source === 'csv-file'
+    ) {
+      await enf.removePolicy(policy, 'csv-file', true);
+    }
+  }
+};
+
+export const loadFilteredGroupingPoliciesFromCSV = async (
+  policyFile: string,
+  enf: EnforcerDelegate,
+  entityRef: string,
+  logger: Logger,
+  policyMetadataStorage: PolicyMetadataStorage,
+  fileEnf?: Enforcer,
+) => {
+  const tempEnforcer =
+    fileEnf ??
+    (await newEnforcer(newModelFromString(MODEL), new FileAdapter(policyFile)));
+  const roleIssues: string[][] = [];
+
+  const roles = await tempEnforcer.getFilteredGroupingPolicy(0, entityRef);
+  const enforcerRoles = await enf.getFilteredGroupingPolicy(0, entityRef);
+
+  if (isEqual(roles, enforcerRoles)) {
+    return;
+  }
+
+  for (const role of roles) {
+    const duplicateError = await checkForDuplicateGroupPolicies(
+      tempEnforcer,
+      role,
+      policyFile,
+    );
+
+    if (duplicateError) {
+      logger.warn(duplicateError.message);
+    }
+
+    const err = validateEntityReference(role[1]);
+    if (err) {
+      logger.warn(
+        `Failed to validate role from file ${policyFile}. Cause: ${err.message}`,
+      );
+      continue;
+    }
+
+    const roleSource = await policyMetadataStorage?.findPolicyMetadata(role);
+
+    // Role exists in the file but not the enforcer
+    if (!(await enf.hasGroupingPolicy(...role))) {
+      await enf.addOrUpdateGroupingPolicy(role, 'csv-file');
+    } else if (roleSource?.source !== 'csv-file') {
+      logger.warn(
+        `Duplicate role: ${role[0]}, ${role[1]} found with the source ${roleSource?.source}`,
+      );
+      continue;
+    }
+  }
+
+  for (const role of enforcerRoles) {
+    // This is to catch stray issues with roles that have problems with their users
+    roleIssues.push(
+      ...(await tempEnforcer.getFilteredGroupingPolicy(1, role[1])),
+    );
+
+    // Role exists in the enforcer but not the file
+    const enfRoleSource = await policyMetadataStorage?.findPolicyMetadata(role);
+
+    if (
+      !(await tempEnforcer.hasGroupingPolicy(...role)) &&
+      enfRoleSource?.source === 'csv-file'
+    ) {
+      await enf.removeGroupingPolicy(role, 'csv-file', true, true);
+    }
+  }
+
+  // Role Issues was meant to catch things with messed up users,
+  for (const role of roleIssues) {
+    const err = validateEntityReference(role[0]);
+    if (err) {
+      logger.warn(
+        `Failed to validate role from file ${policyFile}. Cause: ${err.message}`,
+      );
+      continue;
+    }
+  }
+};
+
+export const loadFilteredCSV = async (
+  policyFile: string,
+  enf: EnforcerDelegate,
+  entityRef: string,
+  resource: string,
+  action: string,
+  logger: Logger,
+  policyMetadataStorage: PolicyMetadataStorage,
+) => {
+  const fileEnf = await newEnforcer(
+    newModelFromString(MODEL),
+    new FileAdapter(policyFile),
+  );
+
+  await loadFilteredPoliciesFromCSV(
+    policyFile,
+    enf,
+    entityRef,
+    resource,
+    action,
+    logger,
+    policyMetadataStorage,
+    fileEnf,
+  );
+  await loadFilteredGroupingPoliciesFromCSV(
+    policyFile,
+    enf,
+    entityRef,
+    logger,
+    policyMetadataStorage,
+    fileEnf,
+  );
+};
+
+export const removedOldPermissionPoliciesFileData = async (
+  enf: EnforcerDelegate,
+  fileEnf?: Enforcer,
+) => {
+  const tempEnforcer =
+    fileEnf ?? (await newEnforcer(newModelFromString(MODEL)));
+  const oldFilePolicies = new Set<string[]>();
+  const policiesMetadata = await enf.getFilteredPolicyMetadata('csv-file');
+  for (const policyMetadata of policiesMetadata) {
+    oldFilePolicies.add(metadataStringToPolicy(policyMetadata.policy));
+  }
+
+  const policiesToDelete: string[][] = [];
+  const groupPoliciesToDelete: string[][] = [];
+  for (const oldFilePolicy of oldFilePolicies) {
+    if (
+      oldFilePolicy.length === 2 &&
+      !(await tempEnforcer.hasGroupingPolicy(...oldFilePolicy))
+    ) {
+      groupPoliciesToDelete.push(oldFilePolicy);
+    } else if (
+      oldFilePolicy.length > 2 &&
+      !(await tempEnforcer.hasPolicy(...oldFilePolicy))
+    ) {
+      policiesToDelete.push(oldFilePolicy);
+    }
+  }
+
+  if (groupPoliciesToDelete.length > 0) {
+    await enf.removeGroupingPolicies(groupPoliciesToDelete, 'csv-file', true);
+  }
+  if (policiesToDelete.length > 0) {
+    await enf.removePolicies(policiesToDelete, 'csv-file', true);
+  }
+};
+
+export const addPermissionPoliciesFileData = async (
+  preDefinedPoliciesFile: string,
+  enf: EnforcerDelegate,
+  roleMetadataStorage: RoleMetadataStorage,
+  logger: Logger,
+) => {
+  const fileEnf = await newEnforcer(
+    newModelFromString(MODEL),
+    new FileAdapter(preDefinedPoliciesFile),
+  );
+  const policies = await fileEnf.getPolicy();
+  const groupPolicies = await fileEnf.getGroupingPolicy();
+
+  const validationError = await validateAllPredefinedPolicies(
+    policies,
+    groupPolicies,
+    preDefinedPoliciesFile,
+    roleMetadataStorage,
+    enf,
+  );
+  if (validationError) {
+    logger.warn(validationError.message);
+  }
+
+  await removedOldPermissionPoliciesFileData(enf, fileEnf);
+
+  for (const policy of policies) {
+    const duplicateError = await checkForDuplicatePolicies(
+      fileEnf,
+      policy,
+      preDefinedPoliciesFile,
+    );
+    if (duplicateError) {
+      logger.warn(duplicateError.message);
+    }
+    await enf.addOrUpdatePolicy(policy, 'csv-file', true);
+  }
+
+  for (const groupPolicy of groupPolicies) {
+    const duplicateError = await checkForDuplicateGroupPolicies(
+      fileEnf,
+      groupPolicy,
+      preDefinedPoliciesFile,
+    );
+
+    if (duplicateError) {
+      logger.warn(duplicateError.message);
+    }
+    await enf.addOrUpdateGroupingPolicy(groupPolicy, 'csv-file', false);
+  }
+};

--- a/plugins/rbac-backend/src/helper.ts
+++ b/plugins/rbac-backend/src/helper.ts
@@ -1,6 +1,9 @@
 import { difference } from 'lodash';
 
-import { Source } from '@janus-idp/backstage-plugin-rbac-common';
+import {
+  RoleBasedPolicy,
+  Source,
+} from '@janus-idp/backstage-plugin-rbac-common';
 
 import { EnforcerDelegate } from './service/enforcer-delegate';
 
@@ -35,3 +38,10 @@ export async function removeTheDifference(
     await enf.removeGroupingPolicy(role, source, true);
   }
 }
+
+export const transformArraytoPolicy = (
+  policyArray: string[],
+): RoleBasedPolicy => {
+  const [entityReference, permission, policy, effect] = policyArray;
+  return { entityReference, permission, policy, effect };
+};

--- a/plugins/rbac-backend/src/helper.ts
+++ b/plugins/rbac-backend/src/helper.ts
@@ -39,9 +39,7 @@ export async function removeTheDifference(
   }
 }
 
-export const transformArraytoPolicy = (
-  policyArray: string[],
-): RoleBasedPolicy => {
+export function transformArraytoPolicy(policyArray: string[]): RoleBasedPolicy {
   const [entityReference, permission, policy, effect] = policyArray;
   return { entityReference, permission, policy, effect };
-};
+}

--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -259,6 +259,33 @@ describe('RBACPermissionPolicy Tests', () => {
   });
 
   describe('Policy checks for clean up old policies for csv file', () => {
+    const allEnfRoles = [
+      'role:default/some-role',
+      'role:default/catalog-writer',
+      'role:default/catalog-reader',
+      'role:default/catalog-deleter',
+      'role:default/known_role',
+    ];
+
+    const allEnfGroupPolicies = [
+      ['user:default/tester', 'role:default/some-role'],
+      ['user:default/guest', 'role:default/catalog-writer'],
+      ['user:default/guest', 'role:default/catalog-reader'],
+      ['user:default/guest', 'role:default/catalog-deleter'],
+      ['user:default/known_user', 'role:default/known_role'],
+    ];
+
+    const allEnfPolicies = [
+      // stored policy
+      ['role:default/some-role', 'test.some.resource', 'use', 'allow'],
+      // policies from csv file
+      ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
+      ['role:default/catalog-writer', 'catalog-entity', 'read', 'allow'],
+      ['role:default/catalog-writer', 'catalog.entity.create', 'use', 'allow'],
+      ['role:default/catalog-deleter', 'catalog-entity', 'delete', 'deny'],
+      ['role:default/known_role', 'test.resource.deny', 'use', 'allow'],
+    ];
+
     const logger = getVoidLogger();
 
     const dbManagerMock: DatabaseService = {
@@ -398,35 +425,11 @@ describe('RBACPermissionPolicy Tests', () => {
       );
       await createRBACPolicy(enf);
 
-      expect(await enf.getGroupingPolicy()).toEqual([
-        ['user:default/tester', 'role:default/some-role'], // stored group policy
-        ['user:default/guest', 'role:default/catalog-writer'], // group policy from csv file
-        ['user:default/guest', 'role:default/catalog-reader'],
-        ['user:default/guest', 'role:default/catalog-deleter'],
-      ]);
+      expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getAllRoles()).toEqual([
-        'role:default/some-role', // stored role
-        'role:default/catalog-writer', // role from csv file
-        'role:default/catalog-reader',
-        'role:default/catalog-deleter',
-      ]);
+      expect(await enf.getAllRoles()).toEqual(allEnfRoles);
 
-      expect(await enf.getPolicy()).toEqual([
-        // stored policy
-        ['role:default/some-role', 'test.some.resource', 'use', 'allow'],
-        // policies from csv file
-        ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
-        ['role:default/catalog-writer', 'catalog-entity', 'read', 'allow'],
-        [
-          'role:default/catalog-writer',
-          'catalog.entity.create',
-          'use',
-          'allow',
-        ],
-        ['role:default/catalog-deleter', 'catalog-entity', 'delete', 'deny'],
-        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
-      ]);
+      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(
@@ -486,35 +489,11 @@ describe('RBACPermissionPolicy Tests', () => {
       );
       await createRBACPolicy(enf);
 
-      expect(await enf.getAllRoles()).toEqual([
-        'role:default/some-role', // stored role
-        'role:default/catalog-writer', // role from csv file
-        'role:default/catalog-reader',
-        'role:default/catalog-deleter',
-      ]);
+      expect(await enf.getAllRoles()).toEqual(allEnfRoles);
 
-      expect(await enf.getGroupingPolicy()).toEqual([
-        ['user:default/tester', 'role:default/some-role'], // stored group policy
-        ['user:default/guest', 'role:default/catalog-writer'], // group policy from csv file
-        ['user:default/guest', 'role:default/catalog-reader'],
-        ['user:default/guest', 'role:default/catalog-deleter'],
-      ]);
+      expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getPolicy()).toEqual([
-        // stored policy
-        ['role:default/some-role', 'test.some.resource', 'use', 'allow'],
-        // policies from csv file
-        ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
-        ['role:default/catalog-writer', 'catalog-entity', 'read', 'allow'],
-        [
-          'role:default/catalog-writer',
-          'catalog.entity.create',
-          'use',
-          'allow',
-        ],
-        ['role:default/catalog-deleter', 'catalog-entity', 'delete', 'deny'],
-        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
-      ]);
+      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(
@@ -595,35 +574,11 @@ describe('RBACPermissionPolicy Tests', () => {
       );
       await createRBACPolicy(enf);
 
-      expect(await enf.getAllRoles()).toEqual([
-        'role:default/some-role', // stored role
-        'role:default/catalog-writer', // role from csv file
-        'role:default/catalog-reader',
-        'role:default/catalog-deleter',
-      ]);
+      expect(await enf.getAllRoles()).toEqual(allEnfRoles);
 
-      expect(await enf.getGroupingPolicy()).toEqual([
-        ['user:default/tester', 'role:default/some-role'],
-        ['user:default/guest', 'role:default/catalog-writer'], // stored group policy
-        ['user:default/guest', 'role:default/catalog-reader'],
-        ['user:default/guest', 'role:default/catalog-deleter'],
-      ]);
+      expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getPolicy()).toEqual([
-        // stored policy
-        ['role:default/some-role', 'test.some.resource', 'use', 'allow'],
-        // policies from csv file
-        ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
-        ['role:default/catalog-writer', 'catalog-entity', 'read', 'allow'],
-        [
-          'role:default/catalog-writer',
-          'catalog.entity.create',
-          'use',
-          'allow',
-        ],
-        ['role:default/catalog-deleter', 'catalog-entity', 'delete', 'deny'],
-        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
-      ]);
+      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(
@@ -700,35 +655,11 @@ describe('RBACPermissionPolicy Tests', () => {
       );
       await createRBACPolicy(enf);
 
-      expect(await enf.getAllRoles()).toEqual([
-        'role:default/some-role',
-        'role:default/catalog-writer', // stored role
-        'role:default/catalog-reader',
-        'role:default/catalog-deleter',
-      ]);
+      expect(await enf.getAllRoles()).toEqual(allEnfRoles);
 
-      expect(await enf.getGroupingPolicy()).toEqual([
-        ['user:default/tester', 'role:default/some-role'],
-        ['user:default/guest', 'role:default/catalog-writer'], // stored group policy
-        ['user:default/guest', 'role:default/catalog-reader'],
-        ['user:default/guest', 'role:default/catalog-deleter'],
-      ]);
+      expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getPolicy()).toEqual([
-        // stored policy
-        ['role:default/some-role', 'test.some.resource', 'use', 'allow'],
-        // policies from csv file
-        ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
-        ['role:default/catalog-writer', 'catalog-entity', 'read', 'allow'],
-        [
-          'role:default/catalog-writer',
-          'catalog.entity.create',
-          'use',
-          'allow',
-        ],
-        ['role:default/catalog-deleter', 'catalog-entity', 'delete', 'deny'],
-        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
-      ]);
+      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(
@@ -788,35 +719,11 @@ describe('RBACPermissionPolicy Tests', () => {
       );
       await createRBACPolicy(enf);
 
-      expect(await enf.getAllRoles()).toEqual([
-        'role:default/some-role',
-        'role:default/catalog-writer', // stored role
-        'role:default/catalog-reader',
-        'role:default/catalog-deleter',
-      ]);
+      expect(await enf.getAllRoles()).toEqual(allEnfRoles);
 
-      expect(await enf.getGroupingPolicy()).toEqual([
-        ['user:default/tester', 'role:default/some-role'],
-        ['user:default/guest', 'role:default/catalog-writer'], // stored group policy
-        ['user:default/guest', 'role:default/catalog-reader'],
-        ['user:default/guest', 'role:default/catalog-deleter'],
-      ]);
+      expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getPolicy()).toEqual([
-        // stored policy
-        ['role:default/some-role', 'test.some.resource', 'use', 'allow'],
-        // policies from csv file
-        ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
-        ['role:default/catalog-writer', 'catalog-entity', 'read', 'allow'],
-        [
-          'role:default/catalog-writer',
-          'catalog.entity.create',
-          'use',
-          'allow',
-        ],
-        ['role:default/catalog-deleter', 'catalog-entity', 'delete', 'deny'],
-        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
-      ]);
+      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(
@@ -891,35 +798,11 @@ describe('RBACPermissionPolicy Tests', () => {
       );
       await createRBACPolicy(enf);
 
-      expect(await enf.getAllRoles()).toEqual([
-        'role:default/some-role',
-        'role:default/catalog-writer', // stored role
-        'role:default/catalog-reader',
-        'role:default/catalog-deleter',
-      ]);
+      expect(await enf.getAllRoles()).toEqual(allEnfRoles);
 
-      expect(await enf.getGroupingPolicy()).toEqual([
-        ['user:default/tester', 'role:default/some-role'],
-        ['user:default/guest', 'role:default/catalog-writer'], // stored group policy
-        ['user:default/guest', 'role:default/catalog-reader'],
-        ['user:default/guest', 'role:default/catalog-deleter'],
-      ]);
+      expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getPolicy()).toEqual([
-        // stored policy
-        ['role:default/some-role', 'test.some.resource', 'use', 'allow'],
-        // policies from csv file
-        ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
-        ['role:default/catalog-writer', 'catalog-entity', 'read', 'allow'],
-        [
-          'role:default/catalog-writer',
-          'catalog.entity.create',
-          'use',
-          'allow',
-        ],
-        ['role:default/catalog-deleter', 'catalog-entity', 'delete', 'deny'],
-        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
-      ]);
+      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -143,6 +143,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
   private readonly conditionStorage: ConditionalStorage;
   private readonly policyMetadataStorage: PolicyMetadataStorage;
   private readonly policiesFile?: string;
+  private readonly allowReload?: boolean;
 
   public static async build(
     logger: Logger,
@@ -159,6 +160,10 @@ export class RBACPermissionPolicy implements PermissionPolicy {
 
     const policiesFile = configApi.getOptionalString(
       'permission.rbac.policies-csv-file',
+    );
+
+    const allowReload = configApi.getOptionalBoolean(
+      'permission.rbac.policyFileReload',
     );
 
     if (adminUsers && adminUsers.length > 0) {
@@ -192,6 +197,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       conditionalStorage,
       policyMetaDataStorage,
       policiesFile,
+      allowReload,
     );
   }
 
@@ -201,12 +207,14 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     conditionStorage: ConditionalStorage,
     policyMetadataStorage: PolicyMetadataStorage,
     policiesFile?: string,
+    allowReload?: boolean,
   ) {
     this.enforcer = enforcer;
     this.logger = logger;
     this.conditionStorage = conditionStorage;
     this.policyMetadataStorage = policyMetadataStorage;
     this.policiesFile = policiesFile;
+    this.allowReload = allowReload;
   }
 
   async handle(
@@ -299,7 +307,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     action: string,
   ): Promise<boolean> => {
     const filter: string[] = [userIdentity, permission, action];
-    if (this.policiesFile) {
+    if (this.policiesFile && this.allowReload) {
       await loadFilteredCSV(
         this.policiesFile,
         this.enforcer,

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -298,13 +298,12 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     permission: string,
     action: string,
   ): Promise<boolean> => {
+    const filter: string[] = [userIdentity, permission, action];
     if (this.policiesFile) {
       await loadFilteredCSV(
         this.policiesFile,
         this.enforcer,
-        userIdentity,
-        permission,
-        action,
+        filter,
         this.logger,
         this.policyMetadataStorage,
       );

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -11,23 +11,24 @@ import {
   PolicyQuery,
 } from '@backstage/plugin-permission-node';
 
-import { Enforcer, FileAdapter, newEnforcer, newModelFromString } from 'casbin';
 import { Knex } from 'knex';
 import { Logger } from 'winston';
 
 import { ConditionalStorage } from '../database/conditional-storage';
+import { PolicyMetadataStorage } from '../database/policy-metadata-storage';
 import { RoleMetadataStorage } from '../database/role-metadata';
+import {
+  addPermissionPoliciesFileData,
+  loadFilteredCSV,
+  removedOldPermissionPoliciesFileData,
+} from '../file-permissions/csv';
 import { metadataStringToPolicy, removeTheDifference } from '../helper';
 import { EnforcerDelegate } from './enforcer-delegate';
-import { MODEL } from './permission-model';
-import {
-  validateAllPredefinedPolicies,
-  validateEntityReference,
-} from './policies-validation';
+import { validateEntityReference } from './policies-validation';
 
 const adminRoleName = 'role:default/rbac_admin';
 
-const useAdmins = async (
+const useAdminsFromConfig = async (
   admins: Config[],
   enf: EnforcerDelegate,
   roleMetadataStorage: RoleMetadataStorage,
@@ -92,7 +93,9 @@ const useAdmins = async (
     adminRoleName,
     enf,
   );
+};
 
+const setAdminPermissions = async (enf: EnforcerDelegate) => {
   const adminReadPermission = [adminRoleName, 'policy-entity', 'read', 'allow'];
   await enf.addOrUpdatePolicy(adminReadPermission, 'configuration', false);
 
@@ -134,76 +137,12 @@ const useAdmins = async (
   );
 };
 
-const removedOldPermissionPoliciesFileData = async (
-  enf: EnforcerDelegate,
-  fileEnf?: Enforcer,
-) => {
-  const tempEnforcer =
-    fileEnf ?? (await newEnforcer(newModelFromString(MODEL)));
-  const oldFilePolicies = new Set<string[]>();
-  const policiesMetadata = await enf.getFilteredPolicyMetadata('csv-file');
-  for (const policyMetadata of policiesMetadata) {
-    oldFilePolicies.add(metadataStringToPolicy(policyMetadata.policy));
-  }
-
-  const policiesToDelete: string[][] = [];
-  const groupPoliciesToDelete: string[][] = [];
-  for (const oldFilePolicy of oldFilePolicies) {
-    if (
-      oldFilePolicy.length === 2 &&
-      !(await tempEnforcer.hasGroupingPolicy(...oldFilePolicy))
-    ) {
-      groupPoliciesToDelete.push(oldFilePolicy);
-    } else if (
-      oldFilePolicy.length > 2 &&
-      !(await tempEnforcer.hasPolicy(...oldFilePolicy))
-    ) {
-      policiesToDelete.push(oldFilePolicy);
-    }
-  }
-
-  if (groupPoliciesToDelete.length > 0) {
-    await enf.removeGroupingPolicies(groupPoliciesToDelete, 'csv-file', true);
-  }
-  if (policiesToDelete.length > 0) {
-    await enf.removePolicies(policiesToDelete, 'csv-file', true);
-  }
-};
-
-const addPermissionPoliciesFileData = async (
-  preDefinedPoliciesFile: string,
-  enf: EnforcerDelegate,
-  roleMetadataStorage: RoleMetadataStorage,
-) => {
-  const fileEnf = await newEnforcer(
-    newModelFromString(MODEL),
-    new FileAdapter(preDefinedPoliciesFile),
-  );
-  const policies = await fileEnf.getPolicy();
-  const groupPolicies = await fileEnf.getGroupingPolicy();
-
-  await validateAllPredefinedPolicies(
-    Array.from(policies),
-    Array.from(groupPolicies),
-    preDefinedPoliciesFile,
-    roleMetadataStorage,
-  );
-
-  await removedOldPermissionPoliciesFileData(enf, fileEnf);
-
-  for (const policy of policies) {
-    await enf.addOrUpdatePolicy(policy, 'csv-file', true);
-  }
-
-  for (const groupPolicy of groupPolicies) {
-    await enf.addOrUpdateGroupingPolicy(groupPolicy, 'csv-file', false);
-  }
-};
-
 export class RBACPermissionPolicy implements PermissionPolicy {
   private readonly enforcer: EnforcerDelegate;
   private readonly logger: Logger;
   private readonly conditionStorage: ConditionalStorage;
+  private readonly policyMetadataStorage: PolicyMetadataStorage;
+  private readonly policiesFile?: string;
 
   public static async build(
     logger: Logger,
@@ -211,6 +150,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     conditionalStorage: ConditionalStorage,
     enforcerDelegate: EnforcerDelegate,
     roleMetadataStorage: RoleMetadataStorage,
+    policyMetaDataStorage: PolicyMetadataStorage,
     knex: Knex,
   ): Promise<RBACPermissionPolicy> {
     const adminUsers = configApi.getOptionalConfigArray(
@@ -222,7 +162,13 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     );
 
     if (adminUsers && adminUsers.length > 0) {
-      await useAdmins(adminUsers, enforcerDelegate, roleMetadataStorage, knex);
+      await useAdminsFromConfig(
+        adminUsers,
+        enforcerDelegate,
+        roleMetadataStorage,
+        knex,
+      );
+      await setAdminPermissions(enforcerDelegate);
     } else {
       logger.warn(
         'There are no admins configured for the RBAC-backend plugin. The plugin may not work properly.',
@@ -234,6 +180,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
         policiesFile,
         enforcerDelegate,
         roleMetadataStorage,
+        logger,
       );
     } else {
       await removedOldPermissionPoliciesFileData(enforcerDelegate);
@@ -243,6 +190,8 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       enforcerDelegate,
       logger,
       conditionalStorage,
+      policyMetaDataStorage,
+      policiesFile,
     );
   }
 
@@ -250,10 +199,14 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     enforcer: EnforcerDelegate,
     logger: Logger,
     conditionStorage: ConditionalStorage,
+    policyMetadataStorage: PolicyMetadataStorage,
+    policiesFile?: string,
   ) {
     this.enforcer = enforcer;
     this.logger = logger;
     this.conditionStorage = conditionStorage;
+    this.policyMetadataStorage = policyMetadataStorage;
+    this.policiesFile = policiesFile;
   }
 
   async handle(
@@ -288,7 +241,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
         // Let's set up higher priority for permission specified by name, than by resource type
         const obj = hasNamedPermission ? permissionName : resourceType;
 
-        status = await this.enforcer.enforce(userEntityRef, obj, action);
+        status = await this.isAuthorized(userEntityRef, obj, action);
 
         if (status && identityResp) {
           const conditionalDecision =
@@ -301,11 +254,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
           }
         }
       } else {
-        status = await this.enforcer.enforce(
-          userEntityRef,
-          permissionName,
-          action,
-        );
+        status = await this.isAuthorized(userEntityRef, permissionName, action);
       }
 
       const result = status ? AuthorizeResult.ALLOW : AuthorizeResult.DENY;
@@ -343,4 +292,24 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     }
     return false;
   }
+
+  private isAuthorized = async (
+    userIdentity: string,
+    permission: string,
+    action: string,
+  ): Promise<boolean> => {
+    if (this.policiesFile) {
+      await loadFilteredCSV(
+        this.policiesFile,
+        this.enforcer,
+        userIdentity,
+        permission,
+        action,
+        this.logger,
+        this.policyMetadataStorage,
+      );
+    }
+
+    return await this.enforcer.enforce(userIdentity, permission, action);
+  };
 }

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -23,6 +23,7 @@ import {
   Source,
 } from '@janus-idp/backstage-plugin-rbac-common';
 
+import { PolicyMetadataStorage } from '../database/policy-metadata-storage';
 import { RoleMetadataStorage } from '../database/role-metadata';
 import { EnforcerDelegate } from './enforcer-delegate';
 import { RBACPermissionPolicy } from './permission-policy';
@@ -141,6 +142,13 @@ const roleMetadataStorageMock: RoleMetadataStorage = {
   removeRoleMetadata: jest.fn().mockImplementation(),
 };
 
+const policyMetadataStorageMock: PolicyMetadataStorage = {
+  findPolicyMetadataBySource: jest.fn().mockImplementation(),
+  findPolicyMetadata: jest.fn().mockImplementation(),
+  createPolicyMetadata: jest.fn().mockImplementation(),
+  removePolicyMetadata: jest.fn().mockImplementation(),
+};
+
 const conditionalStorage = {
   getConditions: jest.fn().mockImplementation(),
   createCondition: jest.fn().mockImplementation(),
@@ -231,6 +239,7 @@ describe('REST policies api', () => {
         conditionalStorage,
         mockEnforcer as EnforcerDelegate,
         roleMetadataStorageMock,
+        policyMetadataStorageMock,
         knex,
       ),
     };

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -102,6 +102,7 @@ export class PolicyBuilder {
         conditionStorage,
         enforcerDelegate,
         roleMetadataStorage,
+        policyMetadataStorage,
         knex,
       ),
     };

--- a/plugins/rbac-backend/src/service/test/data/rbac-policy.csv
+++ b/plugins/rbac-backend/src/service/test/data/rbac-policy.csv
@@ -1,8 +1,0 @@
-
-g, user:default/guest, role:default/catalog-writer
-
-p, role:default/catalog-writer, catalog-entity, update, allow
-p, user:default/guest, catalog-entity, read, allow
-p, user:default/guest, catalog.entity.create, use, allow
-
-p, user:default/known_user, test.resource.deny, use, allow


### PR DESCRIPTION
## Description

This PR introduces new functionality to facilitate the reloading of permission policies sourced from the CSV file. The issue at hand was the necessity of restarting the server every time there was an update to the permission policies in the CSV, which was quite inconvenient. The added feature enables the dynamic reloading of permission policies and roles directly from the CSV.

It leverages information provided by the permission framework (entity reference, permission, policy). This approach allows us to focus solely on roles associated with the entity reference in the CSV, subsequently retrieving permissions linked to that role, matching the given permission and policy. The aim is to enhance efficiency by selectively reloading relevant portions of the file, rather than the entire dataset.

There are duplication checks within this proposed PR that checks if there are duplicates within just the CSV file as well as duplication coming from the REST API and app configuration file. This will throw warnings to the console for the Admin to deal with.

## Fixes

- Fixes #908 

## How to test changes / Special notes to the reviewer

1. Create an RBAC permission policy CSV file
```csv
g, user:default/<your-user>, role:default/test

p, role:default/test, catalog-entity, read, allow
```
2. Update app-config to include your CSV file
```yaml
permission:
  enabled: true
  rbac:
    policies-csv-file: ./some/path/<permission-policy>.csv
```
3. Start the server and notice that you can read catalog entities
4. update the read permission in the CSV file from `allow` to `deny`
5. Notice that you can no longer read the catalog entities

***

One caveat, as of right now there is no full synchronization of the CSV file. I originally elected to avoid this approach to ensure that we are as efficient as possible. The problem with this is that the RBAC Frontend plugin will occasionally be out of sync with the CSV file. This is apparent whenever you create a new role or permissions that you are not directly attached to. The mechanism for reloading the permissions and roles will only look at the user that is being checked and the permission that will will be looking to authorize. Which will result in the frontend only being updated whenever a particular user makes an action.

To solve this problem will result in either a change in how our GET endpoints are called or adding an additional endpoint. 

We could update the GET endpoints to refresh the CSV file to ensure that we are as up to date as possible (costly as this will reload the entire CSV file whenever an admin navigates to the Administrators page) 

Or we can add an additional endpoint that could be used to refresh the page on demand (less costly as this will only reload the CSV file when called, however will be out of sync until a refresh occurs)

***