### PR TITLE
feat(rbac): use relative links

### DIFF
--- a/plugins/rbac/src/components/CreateRole/CreateRolePage.tsx
+++ b/plugins/rbac/src/components/CreateRole/CreateRolePage.tsx
@@ -37,7 +37,7 @@ export const CreateRolePage = () => {
       resourceRef={catalogEntityReadPermission.resourceType}
     >
       <Page themeId="tool">
-        <Header title="Create role" type="RBAC" typeLink="/rbac" />
+        <Header title="Create role" type="RBAC" typeLink=".." />
         <Content>
           <RoleForm
             initialValues={initialValues}

--- a/plugins/rbac/src/components/CreateRole/EditRolePage.tsx
+++ b/plugins/rbac/src/components/CreateRole/EditRolePage.tsx
@@ -50,7 +50,7 @@ export const EditRolePage = () => {
     }
     return (
       <>
-        <Header title="Edit role" type="RBAC" typeLink="/rbac" />
+        <Header title="Edit role" type="RBAC" typeLink=".." />
         <Content>
           <RoleForm
             initialValues={initialValues}

--- a/plugins/rbac/src/components/CreateRole/RoleForm.tsx
+++ b/plugins/rbac/src/components/CreateRole/RoleForm.tsx
@@ -67,9 +67,9 @@ export const RoleForm = ({
     if (step && roleName) {
       const { kind, namespace, name } = getKindNamespaceName(roleName);
 
-      navigate(`/rbac/roles/${kind}/${namespace}/${name}`);
+      navigate(`../roles/${kind}/${namespace}/${name}`);
     } else {
-      navigate('/rbac');
+      navigate('..');
     }
   };
 

--- a/plugins/rbac/src/components/EditRole.tsx
+++ b/plugins/rbac/src/components/EditRole.tsx
@@ -32,7 +32,7 @@ const EditRole = ({
           aria-label="Update"
           disabled={disable}
           title={tooltip || 'Edit Role'}
-          to={to || `/rbac/role/${kind}/${namespace}/${name}`}
+          to={to || `../role/${kind}/${namespace}/${name}`}
         >
           <EditIcon />
         </IconButton>

--- a/plugins/rbac/src/components/RbacPage.tsx
+++ b/plugins/rbac/src/components/RbacPage.tsx
@@ -8,20 +8,33 @@ import { policyEntityReadPermission } from '@janus-idp/backstage-plugin-rbac-com
 import { DeleteDialogContextProvider } from './RolesList/DeleteDialogContext';
 import { RolesList } from './RolesList/RolesList';
 
-export const RbacPage = () => (
-  <RequirePermission
-    permission={policyEntityReadPermission}
-    resourceRef={policyEntityReadPermission.resourceType}
-  >
-    <Page themeId="tool">
-      <Header title="Administration" />
-      <DeleteDialogContextProvider>
-        <TabbedLayout>
-          <TabbedLayout.Route path="/rbac" title="RBAC">
-            <RolesList />
-          </TabbedLayout.Route>
-        </TabbedLayout>
-      </DeleteDialogContextProvider>
-    </Page>
-  </RequirePermission>
+export const RbacPage = ({ useHeader = true }: { useHeader?: boolean }) => (
+  <>
+    {useHeader ? (
+      <RequirePermission
+        permission={policyEntityReadPermission}
+        resourceRef={policyEntityReadPermission.resourceType}
+      >
+        <Page themeId="tool">
+          <Header title="Administration" />
+          <DeleteDialogContextProvider>
+            <TabbedLayout>
+              <TabbedLayout.Route path="/rbac" title="RBAC">
+                <RolesList />
+              </TabbedLayout.Route>
+            </TabbedLayout>
+          </DeleteDialogContextProvider>
+        </Page>
+      </RequirePermission>
+    ) : (
+      <RequirePermission
+        permission={policyEntityReadPermission}
+        resourceRef={policyEntityReadPermission.resourceType}
+      >
+        <DeleteDialogContextProvider>
+          <RolesList />
+        </DeleteDialogContextProvider>
+      </RequirePermission>
+    )}
+  </>
 );

--- a/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
+++ b/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
@@ -36,7 +36,7 @@ const getEditIcon = (isAllowed: boolean, roleName: string) => {
       dataTestId={isAllowed ? 'update-members' : 'disable-update-members'}
       roleName={roleName}
       disable={!isAllowed}
-      to={`/rbac/role/${kind}/${namespace}/${name}?activeStep=${1}`}
+      to={`../../role/${kind}/${namespace}/${name}?activeStep=${1}`}
     />
   );
 };

--- a/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
+++ b/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
@@ -35,7 +35,7 @@ const getEditIcon = (isAllowed: boolean, roleName: string) => {
       dataTestId={isAllowed ? 'update-policies' : 'disable-update-policies'}
       roleName={roleName}
       disable={!isAllowed}
-      to={`/rbac/role/${kind}/${namespace}/${name}?activeStep=${2}`}
+      to={`../../role/${kind}/${namespace}/${name}?activeStep=${2}`}
     />
   );
 };

--- a/plugins/rbac/src/components/RoleOverview/RoleOverviewPage.tsx
+++ b/plugins/rbac/src/components/RoleOverview/RoleOverviewPage.tsx
@@ -26,7 +26,7 @@ export const RoleOverviewPage = () => {
         <Header
           title={`${roleKind}:${roleNamespace}/${roleName}`}
           type="RBAC"
-          typeLink="/rbac"
+          typeLink=".."
         />
         <TabbedLayout>
           <TabbedLayout.Route path="" title="Overview">

--- a/plugins/rbac/src/components/Router.tsx
+++ b/plugins/rbac/src/components/Router.tsx
@@ -19,10 +19,10 @@ import { ToastContextProvider } from './ToastContext';
  *
  * @public
  */
-export const Router = () => (
+export const Router = ({ useHeader = true }: { useHeader?: boolean }) => (
   <ToastContextProvider>
     <Routes>
-      <Route path="/" element={<RbacPage />} />
+      <Route path="/" element={<RbacPage useHeader={useHeader} />} />
       <Route path={roleRouteRef.path} element={<RoleOverviewPage />} />
       <Route
         path={createRoleRouteRef.path}


### PR DESCRIPTION
This change updates the links between components from absolute links to relative links to better support being run from a different route root. This commit also adds a property to help better integrate this plugin into the backstage-showcase Administration page while still retaining it's existing functionality.  Some examples:

![image](https://github.com/janus-idp/backstage-plugins/assets/351660/4f6ec94f-902f-493e-b5aa-a20b1e8927e7)

![image](https://github.com/janus-idp/backstage-plugins/assets/351660/08a5f22c-0010-4a2a-8972-e96d1bf8645d)

![image](https://github.com/janus-idp/backstage-plugins/assets/351660/878d04ba-0ee2-4be2-abde-c438c4dd7c64)

This fixes #1165 

Also note that this needs https://github.com/janus-idp/backstage-showcase/pull/955 to fully test this locally.
