### PR TITLE
fix(kiali): namespaceSelector is removing options

### DIFF
--- a/plugins/kiali/src/pages/Kiali/Header/NamespaceSelector.tsx
+++ b/plugins/kiali/src/pages/Kiali/Header/NamespaceSelector.tsx
@@ -58,7 +58,7 @@ export const NamespaceSelector = (props: { page?: boolean }) => {
         MenuProps={MenuProps}
         style={{ color: props.page ? 'white' : undefined }}
       >
-        {kialiState.namespaces.activeNamespaces.map(ns => (
+        {(kialiState.namespaces.items || []).map(ns => (
           <MenuItem key={ns.name} value={ns.name}>
             <Checkbox
               checked={


### PR DESCRIPTION
When you remove a namespace in selector, this option is removed from items. The behaviour should be keep the namespace unselected.

## Before Fix
[before_fix.webm](https://github.com/janus-idp/backstage-plugins/assets/3019213/f4d70167-f99b-43fb-8b30-2e768ff89cac)


## After fix
[after_fix.webm](https://github.com/janus-idp/backstage-plugins/assets/3019213/7fad824e-6393-4709-a3c4-b9aae4c51a86)
