### PR TITLE
fix(orchestrator): resolve inconsistency with workflow run average duration format 

### DIFF
--- a/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.test.ts
+++ b/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.test.ts
@@ -28,7 +28,7 @@ describe('WorkflowOverviewAdapter', () => {
     );
     expect(adaptedData.lastRunStatus).toBe(mockWorkflowOverview.lastRunStatus);
     expect(adaptedData.category).toBe(mockWorkflowOverview.category);
-    expect(adaptedData.avgDuration).toBe('2 min');
+    expect(adaptedData.avgDuration).toBe('3 minutes');
     expect(adaptedData.description).toBe(mockWorkflowOverview.description);
     expect(adaptedData.format).toBe('yaml'); // Adjust based on your expected value
   });

--- a/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
+++ b/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
@@ -20,29 +20,8 @@ export interface FormattedWorkflowOverview {
   readonly format: WorkflowFormat;
 }
 
-const formatDuration = (milliseconds: number): string => {
-  let sec = Math.round(milliseconds / 1000);
-  let min = 0;
-  let hr = 0;
-  if (sec >= 60) {
-    min = Math.floor(sec / 60);
-    sec %= 60;
-  }
-  if (min >= 60) {
-    hr = Math.floor(min / 60);
-    min %= 60;
-  }
-  if (hr > 0) {
-    return `${hr} h`;
-  }
-  if (min > 0) {
-    return `${min} min`;
-  }
-  if (sec > 0) {
-    return `${sec} sec`;
-  }
-  return 'less than a sec';
-};
+const formatDuration = (milliseconds: number): string =>
+  moment.duration(milliseconds).humanize();
 
 const WorkflowOverviewFormatter: DataFormatter<
   WorkflowOverview,


### PR DESCRIPTION
[FLPATH-968](https://issues.redhat.com/browse/FLPATH-968)

fixed average duration field in workflows table to be the same as duration field in workflow runs