### PR TITLE
docs:  Add dynamic plugin setup/installation instruction for the janus-idp plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,50 @@ A subset of available Janus IDP plugins is available at our [community site](htt
 
 You can also see the [Plugin Marketplace](https://backstage.io/plugins) for other open-source plugins you can add to your Backstage instance.
 
+## Dynamic Plugins Installation
+
+It is possible to install plugins without code changes in a backstage that supports [Dynamic Plugins](https://github.com/janus-idp/backstage-showcase/blob/main/showcase-docs/dynamic-plugins.md) (e.g. [Janus IDP](https://janus-idp.io/) and [Red Hat Developer Hub](https://developers.redhat.com/rhdh)). Follow the steps below to install a dynamic plugin:
+
+- Map the dynamic plugins root directory in `app-config.yaml`:
+
+```
+dynamicPlugins:
+  rootDirectory: dynamic-plugins-root
+```
+
+- Place your package inside the plugins root directly. You can pack a local plugin or download from NPM using `npm pack`, then make sure to extract it correctly into the plugin root directory:
+
+```
+cd dynamic-plugins-root
+mkdir {plugin name}
+tar -xzvf {path to the NPM package tgz file} -C {plugin name}  --strip-components=1
+```
+
+- Configure your plugin in `app-config.yaml`. For example, the configuration below will make a new menu item to access the plugin on route `my-plugin`:
+
+```
+dynamicPlugins:
+  rootDirectory: dynamic-plugins-root
+  frontend:
+    {plugin name}:   # this should match the plugin name in package.json, remember to remove "@" and replace "/" by dots (".")
+      pluginConfig:
+      dynamicRoutes:
+        - path: /my-plugin
+          importName: MyPlugin   # the exported react component that should be rendered
+          menuItem:
+            text: My Plugin
+```
+
+- Start backstage and you should see in logs that your plugin was correctly scanned by Backstage:
+
+```
+scalprum info Loaded dynamic frontend plugin '{plugin name}' from '${Backstage path}/dynamic-plugins-root/{plugin name}'  type=plugin
+```
+
+Now when accessing Backstage you should see a new menu item with name `My Plugin` and when clicking on it your plugin will be rendered.
+
+For more information check the [Dynamic Plugins Guide](https://github.com/janus-idp/backstage-showcase/blob/main/showcase-docs/dynamic-plugins.md).
+
 ---
 
 ✨ We would love for you to contribute to Janus IDP's collection of Backstage plugins and help make it even better than it is today! ✨

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can also see the [Plugin Marketplace](https://backstage.io/plugins) for othe
 
 It is possible to install plugins without code changes in a backstage that supports [Dynamic Plugins](https://github.com/janus-idp/backstage-showcase/blob/main/showcase-docs/dynamic-plugins.md) (e.g. [Janus IDP](https://janus-idp.io/) and [Red Hat Developer Hub](https://developers.redhat.com/rhdh)). Follow the steps below to install a dynamic plugin:
 
-- Map the dynamic plugins root directory in `app-config.yaml`:
+- Map the dynamic plugins root directory in `app-config.local.yaml`:
 
 ```
 dynamicPlugins:
@@ -31,7 +31,7 @@ mkdir {plugin name}
 tar -xzvf {path to the NPM package tgz file} -C {plugin name}  --strip-components=1
 ```
 
-- Configure your plugin in `app-config.yaml`. For example, the configuration below will make a new menu item to access the plugin on route `my-plugin`:
+- Configure your plugin in `app-config.local.yaml`. For example, the configuration below will make a new menu item to access the plugin on route `my-plugin`:
 
 ```
 dynamicPlugins:


### PR DESCRIPTION
Added brief information about dynamic plugins installation to the README.md, but linking the main Dynamic Plugins docs to avoid information duplication. The README.md instruction is just to let users know about this possibility and direct them to a more complete document.