### PR TITLE
fix(rbac): display resource typed permissions by name too

### DIFF
--- a/plugins/rbac-backend/src/service/plugin-endpoints.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoints.ts
@@ -119,13 +119,18 @@ export class PluginPermissionMetadataCollector {
 }
 
 function permissionsToCasbinPolicies(permissions: Permission[]): Policy[] {
-  return permissions.map(permission => {
-    const policy: Policy = {
-      permission: isResourcePermission(permission)
-        ? permission.resourceType
-        : permission.name,
+  const policies = [];
+  for (const permission of permissions) {
+    if (isResourcePermission(permission)) {
+      policies.push({
+        permission: permission.resourceType,
+        policy: permission.attributes.action || 'use',
+      });
+    }
+    policies.push({
+      permission: permission.name,
       policy: permission.attributes.action || 'use',
-    };
-    return policy;
-  });
+    });
+  }
+  return policies;
 }


### PR DESCRIPTION
### What does this pull request do:

- display resource typed permissions by name too. 
- add more tests to improve coverage for plugin-endpoints.ts

### What issue is referenced in this pull request?

https://issues.redhat.com/browse/RHIDP-1290

### Screenshot with fix result

<img width="1792" alt="Screenshot 2024-02-12 at 10 56 25" src="https://github.com/janus-idp/backstage-plugins/assets/6873095/d4c20f51-9424-45f6-a44c-c844669f6216">

