### PR TITLE
fix(rbac): reduce the catalog calls when build graph

### DIFF
--- a/plugins/rbac-backend/src/file-permissions/csv.test.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv.test.ts
@@ -27,9 +27,9 @@ import {
   PolicyMetadataStorage,
 } from '../database/policy-metadata-storage';
 import { RoleMetadataStorage } from '../database/role-metadata';
+import { BackstageRoleManager } from '../role-manager/role-manager';
 import { EnforcerDelegate } from '../service/enforcer-delegate';
 import { MODEL } from '../service/permission-model';
-import { BackstageRoleManager } from '../service/role-manager';
 import {
   addPermissionPoliciesFileData,
   loadFilteredGroupingPoliciesFromCSV,

--- a/plugins/rbac-backend/src/role-manager/ancestor-search-memo.ts
+++ b/plugins/rbac-backend/src/role-manager/ancestor-search-memo.ts
@@ -93,7 +93,7 @@ export class AncestorSearchMemo {
     const groupName = `group:${group.metadata.namespace?.toLocaleLowerCase(
       'en-US',
     )}/${group.metadata.name.toLocaleLowerCase('en-US')}`;
-    if (!memo.hasEntityRef(group.metadata.name)) {
+    if (!memo.hasEntityRef(groupName)) {
       memo.setNode(groupName);
     }
 

--- a/plugins/rbac-backend/src/role-manager/ancestor-search-memo.ts
+++ b/plugins/rbac-backend/src/role-manager/ancestor-search-memo.ts
@@ -109,10 +109,7 @@ export class AncestorSearchMemo {
   async buildUserGraph(memo: AncestorSearchMemo) {
     const userGroups = this.allGroups.filter(group => {
       const members = group.spec?.members as string[];
-      if (members && members.includes(this.userName)) {
-        return true;
-      }
-      return false;
+      return members?.includes(this.userName);
     });
     userGroups.forEach(group => this.traverseGroups(memo, group));
   }

--- a/plugins/rbac-backend/src/role-manager/ancestor-search-memo.ts
+++ b/plugins/rbac-backend/src/role-manager/ancestor-search-memo.ts
@@ -15,7 +15,7 @@ export class AncestorSearchMemo {
   private tokenManager: TokenManager;
   private catalogApi: CatalogApi;
 
-  private userEntityRef: string;
+  private userName: string;
 
   private allGroups: Entity[];
 
@@ -25,7 +25,7 @@ export class AncestorSearchMemo {
     catalogApi: CatalogApi,
   ) {
     this.graph = new Graph({ directed: true });
-    this.userEntityRef = userEntityRef.split('/')[1];
+    this.userName = userEntityRef.split('/')[1];
     this.tokenManager = tokenManager;
     this.catalogApi = catalogApi;
     this.allGroups = [];
@@ -109,7 +109,7 @@ export class AncestorSearchMemo {
   async buildUserGraph(memo: AncestorSearchMemo) {
     const userGroups = this.allGroups.filter(group => {
       const members = group.spec?.members as string[];
-      if (members && members.includes(this.userEntityRef)) {
+      if (members && members.includes(this.userName)) {
         return true;
       }
       return false;

--- a/plugins/rbac-backend/src/role-manager/ancestor-search-memo.ts
+++ b/plugins/rbac-backend/src/role-manager/ancestor-search-memo.ts
@@ -1,0 +1,119 @@
+import { TokenManager } from '@backstage/backend-common';
+import { CatalogApi } from '@backstage/catalog-client';
+import { Entity } from '@backstage/catalog-model';
+
+import { alg, Graph } from '@dagrejs/graphlib';
+import { Logger } from 'winston';
+
+// AncestorSearchMemo - should be used to build group hierarchy graph for User entity reference.
+// It supports search group entity reference link in the graph.
+// Also AncestorSearchMemo supports detection cycle dependencies between groups in the graph.
+//
+export class AncestorSearchMemo {
+  private graph: Graph;
+
+  private tokenManager: TokenManager;
+  private catalogApi: CatalogApi;
+
+  private userEntityRef: string;
+
+  private allGroups: Entity[];
+
+  constructor(
+    userEntityRef: string,
+    tokenManager: TokenManager,
+    catalogApi: CatalogApi,
+  ) {
+    this.graph = new Graph({ directed: true });
+    this.userEntityRef = userEntityRef.split('/')[1];
+    this.tokenManager = tokenManager;
+    this.catalogApi = catalogApi;
+    this.allGroups = [];
+  }
+
+  isAcyclic(): boolean {
+    return alg.isAcyclic(this.graph);
+  }
+
+  findCycles(): string[][] {
+    return alg.findCycles(this.graph);
+  }
+
+  setEdge(parentEntityRef: string, childEntityRef: string) {
+    this.graph.setEdge(parentEntityRef, childEntityRef);
+  }
+
+  setNode(entityRef: string): void {
+    this.graph.setNode(entityRef);
+  }
+
+  hasEntityRef(groupRef: string): boolean {
+    return this.graph.hasNode(groupRef);
+  }
+
+  debugNodesAndEdges(log: Logger, userEntity: string): void {
+    log.debug(
+      `SubGraph edges: ${JSON.stringify(this.graph.edges())} for ${userEntity}`,
+    );
+    log.debug(
+      `SubGraph nodes: ${JSON.stringify(this.graph.nodes())} for ${userEntity}`,
+    );
+  }
+
+  getNodes(): string[] {
+    return this.graph.nodes();
+  }
+
+  async getAllGroups(): Promise<void> {
+    const { token } = await this.tokenManager.getToken();
+    const { items } = await this.catalogApi.getEntities(
+      {
+        filter: { kind: 'Group' },
+        fields: [
+          'metadata.name',
+          'metadata.namespace',
+          'spec.parent',
+          'spec.members',
+        ],
+      },
+      { token },
+    );
+    this.allGroups = items;
+  }
+
+  traverseGroups(memo: AncestorSearchMemo, group: Entity) {
+    const groupsRefs = new Set<string>();
+    const groupName = `group:${group.metadata.namespace?.toLocaleLowerCase(
+      'en-US',
+    )}/${group.metadata.name.toLocaleLowerCase('en-US')}`;
+    if (!memo.hasEntityRef(group.metadata.name)) {
+      memo.setNode(groupName);
+    }
+
+    const parent = group.spec?.parent as string;
+    const parentGroup = this.allGroups.find(g => g.metadata.name === parent);
+
+    if (parentGroup) {
+      const parentName = `group:${group.metadata.namespace?.toLocaleLowerCase(
+        'en-US',
+      )}/${parent.toLocaleLowerCase('en-US')}`;
+      memo.setEdge(parentName, groupName);
+      groupsRefs.add(parentName);
+    }
+
+    if (groupsRefs.size > 0 && memo.isAcyclic()) {
+      this.traverseGroups(memo, parentGroup!);
+    }
+  }
+
+  async buildUserGraph(memo: AncestorSearchMemo) {
+    const userGroups = this.allGroups.filter(group => {
+      const members = group.spec?.members as string[];
+      if (members && members.includes(this.userEntityRef)) {
+        return true;
+      }
+      return false;
+    });
+    userGroups.forEach(group => this.traverseGroups(memo, group));
+  }
+}

--- a/plugins/rbac-backend/src/role-manager/role-list.ts
+++ b/plugins/rbac-backend/src/role-manager/role-list.ts
@@ -1,0 +1,41 @@
+export class RoleList {
+  public name: string;
+
+  private roles: RoleList[];
+
+  public constructor(name: string) {
+    this.name = name;
+    this.roles = [];
+  }
+
+  public addRole(role: RoleList): void {
+    if (this.roles.some(n => n.name === role.name)) {
+      return;
+    }
+    this.roles.push(role);
+  }
+
+  public deleteRole(role: RoleList): void {
+    this.roles = this.roles.filter(n => n.name !== role.name);
+  }
+
+  public hasRole(name: string, hierarchyLevel: number): boolean {
+    if (this.name === name) {
+      return true;
+    }
+    if (hierarchyLevel <= 0) {
+      return false;
+    }
+    for (const role of this.roles) {
+      if (role.hasRole(name, hierarchyLevel - 1)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  getRoles(): RoleList[] {
+    return this.roles;
+  }
+}

--- a/plugins/rbac-backend/src/role-manager/role-manager.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.test.ts
@@ -267,7 +267,11 @@ describe('BackstageRoleManager', () => {
         'team-b',
       ]);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupMock] };
+        }
         return { items: [groupMock, groupParentMock] };
       });
 
@@ -294,7 +298,11 @@ describe('BackstageRoleManager', () => {
         'team-b',
       ]);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupMock] };
+        }
         return { items: [groupMock, groupParentMock] };
       });
 
@@ -327,7 +335,11 @@ describe('BackstageRoleManager', () => {
       const groupCMock = createGroupEntity('team-c', 'team-a', [], ['tom']);
       const groupDMock = createGroupEntity('team-d', 'team-a', [], ['john']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupBMock] };
+        }
         return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
@@ -349,16 +361,20 @@ describe('BackstageRoleManager', () => {
     //   user:default/tom     user:default/mike     user:default:john
     //
     it('should return true for hasLink, when user:default/mike inherits role:default/team-b from group:default/team-b', async () => {
-      const groupAMock = createGroupEntity('team-a', undefined, [
-        'team-b',
+      const groupBMock = createGroupEntity('team-b', undefined, [
+        'team-a',
         'team-c',
         'team-d',
       ]);
-      const groupBMock = createGroupEntity('team-b', 'team-a', [], ['mike']);
+      const groupAMock = createGroupEntity('team-a', 'team-b', [], ['mike']);
       const groupCMock = createGroupEntity('team-c', 'team-a', [], ['tom']);
       const groupDMock = createGroupEntity('team-d', 'team-a', [], ['john']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupAMock] };
+        }
         return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
@@ -385,7 +401,11 @@ describe('BackstageRoleManager', () => {
       const groupBMock = createGroupEntity('team-b', 'team-a', ['mike']);
       const groupAMock = createGroupEntity('team-a', undefined, ['team-b']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupBMock] };
+        }
         return { items: [groupAMock, groupBMock] };
       });
 
@@ -410,7 +430,11 @@ describe('BackstageRoleManager', () => {
       const groupBMock = createGroupEntity('team-b', 'team-a', ['mike']);
       const groupAMock = createGroupEntity('team-a', undefined, ['team-b']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupBMock] };
+        }
         return { items: [groupAMock, groupBMock] };
       });
 
@@ -439,7 +463,11 @@ describe('BackstageRoleManager', () => {
       const groupAMock = createGroupEntity('team-a', undefined, [], ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, [], ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock, groupDMock] };
+        }
         return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
@@ -466,7 +494,11 @@ describe('BackstageRoleManager', () => {
       const groupAMock = createGroupEntity('team-a', undefined, ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock, groupDMock] };
+        }
         return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
@@ -495,7 +527,11 @@ describe('BackstageRoleManager', () => {
       const groupAMock = createGroupEntity('team-a', undefined, ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock, groupDMock] };
+        }
         return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
@@ -522,7 +558,11 @@ describe('BackstageRoleManager', () => {
       const groupAMock = createGroupEntity('team-a', undefined, ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock, groupDMock] };
+        }
         return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
@@ -550,7 +590,11 @@ describe('BackstageRoleManager', () => {
       const groupBMock = createGroupEntity('team-b', 'team-a', [], ['mike']);
       const groupAMock = createGroupEntity('team-a', 'team-b', ['team-b']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupBMock] };
+        }
         return { items: [groupBMock, groupAMock] };
       });
 
@@ -588,7 +632,11 @@ describe('BackstageRoleManager', () => {
       const groupBMock = createGroupEntity('team-b', 'team-a', ['mike']);
       const groupAMock = createGroupEntity('team-a', 'team-b', ['team-b']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupBMock] };
+        }
         return { items: [groupBMock, groupAMock] };
       });
 
@@ -743,7 +791,11 @@ describe('BackstageRoleManager', () => {
       const groupAMock = createGroupEntity('team-a', 'team-c', ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock, groupDMock] };
+        }
         return { items: [groupCMock, groupDMock, groupAMock, groupBMock] };
       });
 
@@ -774,7 +826,11 @@ describe('BackstageRoleManager', () => {
       const groupAMock = createGroupEntity('team-a', 'team-c', ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock, groupDMock] };
+        }
         return { items: [groupCMock, groupDMock, groupAMock, groupBMock] };
       });
 
@@ -789,6 +845,147 @@ describe('BackstageRoleManager', () => {
       expect(loggerMock.warn).toHaveBeenCalledWith(
         'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
       );
+    });
+
+    // user:default/mike should inherits role from group:default/team-f, and we have a complex graph, and cycle dependency
+    // So return false on call hasLink.
+    //
+    //     Hierarchy:
+    //                                                        role:default/team-e
+    //                                                                ↓
+    //                                     |----------------- group:default/team-e ---------|
+    //                                     ↓                                                |
+    //       | ----------------- group:default/team-f ----|                                 |
+    //       ↓                                            ↓                                 |
+    // group:default/team-a -> role:default/team-a   group:default/team-b                   |
+    //       ↓      ↑                                     ↓                                 ↓
+    // group:default/team-c -> role:default/team-c   group:default/team-d         group:default/team-g -> role:default/team-g
+    //               ↓                                    ↓                                 ↓
+    //               user:default/mike -------------------|---------------------------------|
+    //
+    it('should return false for hasLink, when user:default/mike inherits role from group tree with group:default/team-e, complex tree', async () => {
+      const groupCMock = createGroupEntity('team-c', 'team-a', [], ['mike']);
+      const groupDMock = createGroupEntity('team-d', 'team-b', [], ['mike']);
+      const groupAMock = createGroupEntity('team-a', 'team-c', ['team-c']);
+      const groupBMock = createGroupEntity('team-b', 'team-f', ['team-d']);
+      const groupFMock = createGroupEntity('team-f', 'team-e', [
+        'team-a',
+        'team-b',
+      ]);
+      const groupEMock = createGroupEntity('team-e', undefined, [
+        'team-f',
+        'team-g',
+      ]);
+      const groupGMock = createGroupEntity(
+        'team-g',
+        'team-e',
+        ['team-d'],
+        ['mike'],
+      );
+
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock, groupDMock, groupGMock] };
+        }
+        return {
+          items: [
+            groupCMock,
+            groupDMock,
+            groupAMock,
+            groupBMock,
+            groupFMock,
+            groupEMock,
+            groupGMock,
+          ],
+        };
+      });
+
+      roleManager.addLink('group:default/team-a', 'role:default/team-a');
+      roleManager.addLink('group:default/team-c', 'role:default/team-c');
+      roleManager.addLink('group:default/team-e', 'role:default/team-e');
+      roleManager.addLink('group:default/team-g', 'role:default/team-g');
+
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'role:default/team-e',
+      );
+      expect(result).toBeFalsy();
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
+      );
+
+      const test = await roleManager.hasLink(
+        'user:default/mike',
+        'role:default/team-g',
+      );
+      expect(test).toBeFalsy();
+    });
+
+    // user:default/mike should inherits role from group:default/team-f, and we have a complex graph
+    // So return true on call hasLink.
+    //
+    //     Hierarchy:
+    //                                                        role:default/team-e
+    //                                                                ↓
+    //                                     |----------------- group:default/team-e ---------|
+    //                                     ↓                                                |
+    //       | ----------------- group:default/team-f ----|                                 |
+    //       ↓                                            ↓                                 |
+    // group:default/team-a -> role:default/team-a   group:default/team-b                   |
+    //       ↓                                            ↓                                 ↓
+    // group:default/team-c -> role:default/team-c   group:default/team-d         group:default/team-g -> role:default/team-g
+    //               ↓                                    ↓                                 ↓
+    //               user:default/mike -------------------|---------------------------------|
+    //
+    it('should return true for hasLink, when user:default/mike inherits role from group tree with group:default/team-e, complex tree', async () => {
+      const groupCMock = createGroupEntity('team-c', 'team-a', [], ['mike']);
+      const groupDMock = createGroupEntity('team-d', 'team-b', [], ['mike']);
+      const groupAMock = createGroupEntity('team-a', 'team-f', ['team-c']);
+      const groupBMock = createGroupEntity('team-b', 'team-f', ['team-d']);
+      const groupFMock = createGroupEntity('team-f', 'team-e', [
+        'team-a',
+        'team-b',
+      ]);
+      const groupEMock = createGroupEntity('team-e', undefined, [
+        'team-f',
+        'team-g',
+      ]);
+      const groupGMock = createGroupEntity(
+        'team-g',
+        'team-e',
+        ['team-d'],
+        ['mike'],
+      );
+
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock, groupDMock, groupGMock] };
+        }
+        return {
+          items: [
+            groupCMock,
+            groupDMock,
+            groupAMock,
+            groupBMock,
+            groupFMock,
+            groupEMock,
+            groupGMock,
+          ],
+        };
+      });
+
+      roleManager.addLink('group:default/team-a', 'role:default/team-a');
+      roleManager.addLink('group:default/team-c', 'role:default/team-c');
+      roleManager.addLink('group:default/team-e', 'role:default/team-e');
+      roleManager.addLink('group:default/team-g', 'role:default/team-g');
+
+      const result = await roleManager.hasLink(
+        'user:default/mike',
+        'role:default/team-e',
+      );
+      expect(result).toBeTruthy();
     });
 
     // user:default/mike should inherits from group:default/team-a, but we have cycle dependency: team-a -> team-c.

--- a/plugins/rbac-backend/src/role-manager/role-manager.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.test.ts
@@ -4,7 +4,7 @@ import { Entity } from '@backstage/catalog-model';
 
 import { Logger } from 'winston';
 
-import { BackstageRoleManager } from './role-manager';
+import { BackstageRoleManager } from '../role-manager/role-manager';
 
 describe('BackstageRoleManager', () => {
   const catalogApiMock: any = {
@@ -112,14 +112,12 @@ describe('BackstageRoleManager', () => {
         {
           filter: {
             kind: 'Group',
-            'relations.hasMember': ['user:default/mike'],
           },
           fields: [
             'metadata.name',
-            'kind',
             'metadata.namespace',
             'spec.parent',
-            'spec.children',
+            'spec.members',
           ],
         },
         { token: 'some-token' },
@@ -142,14 +140,12 @@ describe('BackstageRoleManager', () => {
         {
           filter: {
             kind: 'Group',
-            'relations.hasMember': ['user:default/mike'],
           },
           fields: [
             'metadata.name',
-            'kind',
             'metadata.namespace',
             'spec.parent',
-            'spec.children',
+            'spec.members',
           ],
         },
         { token: 'some-token' },
@@ -182,7 +178,12 @@ describe('BackstageRoleManager', () => {
     //  user:default/mike
     //
     it('should return true for hasLink when user:default/mike inherits from group:default/somegroup', async () => {
-      const entityMock = createGroupEntity('somegroup', undefined, []);
+      const entityMock = createGroupEntity(
+        'somegroup',
+        undefined,
+        [],
+        ['mike'],
+      );
       catalogApiMock.getEntities.mockReturnValue({ items: [entityMock] });
 
       const result = await roleManager.hasLink(
@@ -201,7 +202,12 @@ describe('BackstageRoleManager', () => {
     //  user:default/mike
     //
     it('should return true for hasLink when user:default/mike inherits role:default/somerole from group:default/somegroup', async () => {
-      const entityMock = createGroupEntity('somegroup', undefined, []);
+      const entityMock = createGroupEntity(
+        'somegroup',
+        undefined,
+        [],
+        ['mike'],
+      );
       roleManager.addLink('group:default/somegroup', 'role:default/somerole');
       catalogApiMock.getEntities.mockReturnValue({ items: [entityMock] });
 
@@ -221,7 +227,9 @@ describe('BackstageRoleManager', () => {
     // user:default/mike
     //
     it('should return false for hasLink when user:default/mike does not inherits group:default/somegroup', async () => {
-      const entityMock = createGroupEntity('not-matched-group', undefined, []);
+      const entityMock = createGroupEntity('not-matched-group', undefined, [
+        'mike',
+      ]);
       catalogApiMock.getEntities.mockReturnValue({ items: [entityMock] });
 
       const result = await roleManager.hasLink(
@@ -240,7 +248,9 @@ describe('BackstageRoleManager', () => {
     // user:default/mike                         group:default/somegroup
     //
     it('should return false for hasLink when user:default/mike does not inherits role:default/somerole', async () => {
-      const entityMock = createGroupEntity('not-matched-group', undefined, []);
+      const entityMock = createGroupEntity('not-matched-group', undefined, [
+        'mike',
+      ]);
       roleManager.addLink('group:default/somegroup', 'role:default/somerole');
       catalogApiMock.getEntities.mockReturnValue({ items: [entityMock] });
 
@@ -262,21 +272,13 @@ describe('BackstageRoleManager', () => {
     // user:default/mike
     //
     it('should return true for hasLink, when user:default/mike inherits from group:default/team-a', async () => {
-      const groupMock = createGroupEntity('team-b', 'team-a', []);
+      const groupMock = createGroupEntity('team-b', 'team-a', [], ['mike']);
       const groupParentMock = createGroupEntity('team-a', undefined, [
         'team-b',
       ]);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (hasParent && hasParent[0] === 'group:default/team-b') {
-          return { items: [groupParentMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupMock, groupParentMock] };
       });
 
       const result = await roleManager.hasLink(
@@ -297,21 +299,13 @@ describe('BackstageRoleManager', () => {
     // user:default/mike
     //
     it('should return true for hasLink, when user:default/mike inherits role:default/team-a from group:default/team-a', async () => {
-      const groupMock = createGroupEntity('team-b', 'team-a', []);
+      const groupMock = createGroupEntity('team-b', 'team-a', [], ['mike']);
       const groupParentMock = createGroupEntity('team-a', undefined, [
         'team-b',
       ]);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (hasParent && hasParent[0] === 'group:default/team-b') {
-          return { items: [groupParentMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupMock, groupParentMock] };
       });
 
       roleManager.addLink('group:default/team-a', 'role:default/team-a');
@@ -339,33 +333,12 @@ describe('BackstageRoleManager', () => {
         'team-c',
         'team-d',
       ]);
-      const groupBMock = createGroupEntity('team-b', 'team-a', []);
-      const groupCMock = createGroupEntity('team-c', 'team-a', []);
-      const groupDMock = createGroupEntity('team-d', 'team-a', []);
+      const groupBMock = createGroupEntity('team-b', 'team-a', [], ['mike']);
+      const groupCMock = createGroupEntity('team-c', 'team-a', [], ['tom']);
+      const groupDMock = createGroupEntity('team-d', 'team-a', [], ['john']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupBMock] };
-        }
-        if (hasMember && hasMember[0] === 'user:default/tom') {
-          return { items: [groupCMock] };
-        }
-        if (hasMember && hasMember[0] === 'user:default/john') {
-          return { items: [groupDMock] };
-        }
-
-        const hasParent = arg.filter['relations.parentOf'];
-        if (hasParent && hasParent[0] === 'group:default/team-b') {
-          return { items: [groupAMock] };
-        }
-        if (hasParent && hasParent[0] === 'group:default/team-c') {
-          return { items: [groupAMock] };
-        }
-        if (hasParent && hasParent[0] === 'group:default/team-d') {
-          return { items: [groupAMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
       const result = await roleManager.hasLink(
@@ -391,33 +364,12 @@ describe('BackstageRoleManager', () => {
         'team-c',
         'team-d',
       ]);
-      const groupBMock = createGroupEntity('team-b', 'team-a', []);
-      const groupCMock = createGroupEntity('team-c', 'team-a', []);
-      const groupDMock = createGroupEntity('team-d', 'team-a', []);
+      const groupBMock = createGroupEntity('team-b', 'team-a', [], ['mike']);
+      const groupCMock = createGroupEntity('team-c', 'team-a', [], ['tom']);
+      const groupDMock = createGroupEntity('team-d', 'team-a', [], ['john']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupBMock] };
-        }
-        if (hasMember && hasMember[0] === 'user:default/tom') {
-          return { items: [groupCMock] };
-        }
-        if (hasMember && hasMember[0] === 'user:default/john') {
-          return { items: [groupDMock] };
-        }
-
-        const hasParent = arg.filter['relations.parentOf'];
-        if (hasParent && hasParent[0] === 'group:default/team-b') {
-          return { items: [groupAMock] };
-        }
-        if (hasParent && hasParent[0] === 'group:default/team-c') {
-          return { items: [groupAMock] };
-        }
-        if (hasParent && hasParent[0] === 'group:default/team-d') {
-          return { items: [groupAMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
       roleManager.addLink('group:default/team-b', 'role:default/team-b');
@@ -440,19 +392,11 @@ describe('BackstageRoleManager', () => {
     // user:default/mike
     //
     it('should return false for hasLink, when user:default/mike does not inherits from group:default/team-c', async () => {
-      const groupBMock = createGroupEntity('team-b', 'team-a', []);
+      const groupBMock = createGroupEntity('team-b', 'team-a', ['mike']);
       const groupAMock = createGroupEntity('team-a', undefined, ['team-b']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupBMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (hasParent && hasParent[0] === 'group:default/team-b') {
-          return { items: [groupAMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupAMock, groupBMock] };
       });
 
       const result = await roleManager.hasLink(
@@ -473,19 +417,11 @@ describe('BackstageRoleManager', () => {
     // user:default/mike
     //
     it('should return false for hasLink, when user:default/mike does not inherits role:default/team-c from group:default/team-c', async () => {
-      const groupBMock = createGroupEntity('team-b', 'team-a', []);
+      const groupBMock = createGroupEntity('team-b', 'team-a', ['mike']);
       const groupAMock = createGroupEntity('team-a', undefined, ['team-b']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupBMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (hasParent && hasParent[0] === 'group:default/team-b') {
-          return { items: [groupAMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupAMock, groupBMock] };
       });
 
       roleManager.addLink('group:default/team-c', 'role:default/team-c');
@@ -508,25 +444,13 @@ describe('BackstageRoleManager', () => {
     //                user:default/mike
     //
     it('should return true for hasLink, when user:default/mike inherits group tree with group:default/team-a', async () => {
-      const groupCMock = createGroupEntity('team-c', 'team-a', []);
-      const groupDMock = createGroupEntity('team-d', 'team-b', []);
-      const groupAMock = createGroupEntity('team-a', undefined, ['team-c']);
-      const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
+      const groupCMock = createGroupEntity('team-c', 'team-a', [], ['mike']);
+      const groupDMock = createGroupEntity('team-d', 'team-b', ['mike']);
+      const groupAMock = createGroupEntity('team-a', undefined, [], ['team-c']);
+      const groupBMock = createGroupEntity('team-b', undefined, [], ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupCMock, groupDMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (
-          hasParent &&
-          hasParent[0] === 'group:default/team-c' &&
-          hasParent[1] === 'group:default/team-d'
-        ) {
-          return { items: [groupAMock, groupBMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
       const result = await roleManager.hasLink(
@@ -547,25 +471,13 @@ describe('BackstageRoleManager', () => {
     //       |--------user:default/mike -------------------|
     //
     it('should return true for hasLink, when user:default/mike inherits role:default/team-a group tree with group:default/team-a', async () => {
-      const groupCMock = createGroupEntity('team-c', 'team-a', []);
-      const groupDMock = createGroupEntity('team-d', 'team-b', []);
+      const groupCMock = createGroupEntity('team-c', 'team-a', [], ['mike']);
+      const groupDMock = createGroupEntity('team-d', 'team-b', [], ['mike']);
       const groupAMock = createGroupEntity('team-a', undefined, ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupCMock, groupDMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (
-          hasParent &&
-          hasParent[0] === 'group:default/team-c' &&
-          hasParent[1] === 'group:default/team-d'
-        ) {
-          return { items: [groupAMock, groupBMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
       roleManager.addLink('group:default/team-a', 'role:default/team-a');
@@ -588,25 +500,13 @@ describe('BackstageRoleManager', () => {
     //                user:default/mike
     //
     it('should return false for hasLink, when user:default/mike inherits from group:default/team-e', async () => {
-      const groupCMock = createGroupEntity('team-c', 'team-a', []);
-      const groupDMock = createGroupEntity('team-d', 'team-b', []);
+      const groupCMock = createGroupEntity('team-c', 'team-a', ['mike']);
+      const groupDMock = createGroupEntity('team-d', 'team-b', ['mike']);
       const groupAMock = createGroupEntity('team-a', undefined, ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupCMock, groupDMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (
-          hasParent &&
-          hasParent[0] === 'group:default/team-c' &&
-          hasParent[1] === 'group:default/team-d'
-        ) {
-          return { items: [groupAMock, groupBMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
       const result = await roleManager.hasLink(
@@ -627,25 +527,13 @@ describe('BackstageRoleManager', () => {
     //                user:default/mike
     //
     it('should return false for hasLink, when user:default/mike inherits role:default/team-e from group:default/team-e', async () => {
-      const groupCMock = createGroupEntity('team-c', 'team-a', []);
-      const groupDMock = createGroupEntity('team-d', 'team-b', []);
+      const groupCMock = createGroupEntity('team-c', 'team-a', ['mike']);
+      const groupDMock = createGroupEntity('team-d', 'team-b', ['mike']);
       const groupAMock = createGroupEntity('team-a', undefined, ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupCMock, groupDMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (
-          hasParent &&
-          hasParent[0] === 'group:default/team-c' &&
-          hasParent[1] === 'group:default/team-d'
-        ) {
-          return { items: [groupAMock, groupBMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupAMock, groupBMock, groupCMock, groupDMock] };
       });
 
       roleManager.addLink('group:default/team-e', 'role:default/team-e');
@@ -669,19 +557,11 @@ describe('BackstageRoleManager', () => {
     // user:default/mike
     //
     it('should return false for hasLink, when user:default/mike inherits from group:default/team-a and group:default/team-b, but we have cycle dependency', async () => {
-      const groupBMock = createGroupEntity('team-b', 'team-a', []);
+      const groupBMock = createGroupEntity('team-b', 'team-a', [], ['mike']);
       const groupAMock = createGroupEntity('team-a', 'team-b', ['team-b']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupBMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (hasParent && hasParent[0] === 'group:default/team-b') {
-          return { items: [groupAMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupBMock, groupAMock] };
       });
 
       let result = await roleManager.hasLink(
@@ -715,19 +595,11 @@ describe('BackstageRoleManager', () => {
     // user:default/mike
     //
     it('should return false for hasLink, when user:default/mike inherits role:default/team-b and role:default/team-a from group:default/team-a and group:default/team-b, but we have cycle dependency', async () => {
-      const groupBMock = createGroupEntity('team-b', 'team-a', []);
+      const groupBMock = createGroupEntity('team-b', 'team-a', ['mike']);
       const groupAMock = createGroupEntity('team-a', 'team-b', ['team-b']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupBMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (hasParent && hasParent[0] === 'group:default/team-b') {
-          return { items: [groupAMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupBMock, groupAMock] };
       });
 
       roleManager.addLink('group:default/team-b', 'role:default/team-b');
@@ -767,22 +639,11 @@ describe('BackstageRoleManager', () => {
     //
     it('should return false for hasLink, when user:default/mike inherits from group:default/team-a, group:default/team-b, group:default/team-c, but we have cycle dependency', async () => {
       const groupAMock = createGroupEntity('team-a', 'team-b', ['team-b']);
-      const groupBMock = createGroupEntity('team-b', 'team-a', []);
-      const groupCMock = createGroupEntity('team-c', 'team-b', []);
+      const groupBMock = createGroupEntity('team-b', 'team-a', ['team-c']);
+      const groupCMock = createGroupEntity('team-c', 'team-b', [], ['mike']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupCMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (hasParent && hasParent[0] === 'group:default/team-c') {
-          return { items: [groupBMock] };
-        }
-        if (hasParent && hasParent[0] === 'group:default/team-b') {
-          return { items: [groupAMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupAMock, groupBMock, groupCMock] };
       });
 
       let result = await roleManager.hasLink(
@@ -828,22 +689,11 @@ describe('BackstageRoleManager', () => {
     //
     it('should return false for hasLink, when user:default/mike inherits the roles from group:default/team-a, group:default/team-b, group:default/team-c, but we have cycle dependency', async () => {
       const groupAMock = createGroupEntity('team-a', 'team-b', ['team-b']);
-      const groupBMock = createGroupEntity('team-b', 'team-a', []);
-      const groupCMock = createGroupEntity('team-c', 'team-b', []);
+      const groupBMock = createGroupEntity('team-b', 'team-a', ['team-c']);
+      const groupCMock = createGroupEntity('team-c', 'team-b', ['mike']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupCMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        if (hasParent && hasParent[0] === 'group:default/team-c') {
-          return { items: [groupBMock] };
-        }
-        if (hasParent && hasParent[0] === 'group:default/team-b') {
-          return { items: [groupAMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupAMock, groupBMock, groupCMock] };
       });
 
       roleManager.addLink('group:default/team-a', 'role:default/team-a');
@@ -890,27 +740,13 @@ describe('BackstageRoleManager', () => {
     //               user:default/mike
     //
     it('should return false for hasLink, when user:default/mike inherits group tree with group:default/team-a, but we cycle dependency', async () => {
-      const groupCMock = createGroupEntity('team-c', 'team-a', ['mike']);
-      const groupDMock = createGroupEntity('team-d', 'team-b', ['mike']);
+      const groupCMock = createGroupEntity('team-c', 'team-a', [], ['mike']);
+      const groupDMock = createGroupEntity('team-d', 'team-b', [], ['mike']);
       const groupAMock = createGroupEntity('team-a', 'team-c', ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        // first iteration
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupCMock, groupDMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        // second iteration
-        if (
-          hasParent &&
-          hasParent[0] === 'group:default/team-c' &&
-          hasParent[1] === 'group:default/team-d'
-        ) {
-          return { items: [groupAMock, groupBMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupCMock, groupDMock, groupAMock, groupBMock] };
       });
 
       const result = await roleManager.hasLink(
@@ -935,28 +771,15 @@ describe('BackstageRoleManager', () => {
     //               user:default/mike -------------------|
     //
     it('should return false for hasLink, when user:default/mike inherits role from group tree with group:default/team-a, but we cycle dependency', async () => {
-      const groupCMock = createGroupEntity('team-c', 'team-a', ['mike']);
-      const groupDMock = createGroupEntity('team-d', 'team-b', ['mike']);
+      const groupCMock = createGroupEntity('team-c', 'team-a', [], ['mike']);
+      const groupDMock = createGroupEntity('team-d', 'team-b', [], ['mike']);
       const groupAMock = createGroupEntity('team-a', 'team-c', ['team-c']);
       const groupBMock = createGroupEntity('team-b', undefined, ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-        // first iteration
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupCMock, groupDMock] };
-        }
-        const hasParent = arg.filter['relations.parentOf'];
-        // second iteration
-        if (
-          hasParent &&
-          hasParent[0] === 'group:default/team-c' &&
-          hasParent[1] === 'group:default/team-d'
-        ) {
-          return { items: [groupAMock, groupBMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [groupCMock, groupDMock, groupAMock, groupBMock] };
       });
+
       roleManager.addLink('group:default/team-a', 'role:default/team-a');
       roleManager.addLink('group:default/team-c', 'role:default/team-c');
 
@@ -986,43 +809,32 @@ describe('BackstageRoleManager', () => {
     //               ↓               ↓
     //   user:default/mike    user:default/tom
     //
+    // This test passes now ?
     it('should return false for hasLink for user:default/mike and group:default/team-a(cycle dependency), but should be true for user:default/tom and group:default/team-b', async () => {
       const groupRootMock = createGroupEntity('root', undefined, [
         'team-a',
         'team-b',
       ]);
-      const groupCMock = createGroupEntity('team-c', 'team-a', ['team-a']);
-      const groupDMock = createGroupEntity('team-d', 'team-b', []);
-      const groupAMock = createGroupEntity('team-a', 'root', ['team-c']);
+      const groupCMock = createGroupEntity(
+        'team-c',
+        'team-a',
+        ['team-a'],
+        ['mike'],
+      );
+      const groupDMock = createGroupEntity('team-d', 'team-b', [], ['tom']);
+      const groupAMock = createGroupEntity('team-a', 'team-c', ['team-c']);
       const groupBMock = createGroupEntity('team-b', 'root', ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupCMock] };
-        }
-        if (hasMember && hasMember[0] === 'user:default/tom') {
-          return { items: [groupDMock] };
-        }
-
-        const hasParent = arg.filter['relations.parentOf'];
-
-        if (hasParent && hasParent[0] === 'group:default/team-c') {
-          return { items: [groupAMock] };
-        }
-
-        if (hasParent && hasParent[0] === 'group:default/team-d') {
-          return { items: [groupBMock] };
-        }
-
-        if (
-          (hasParent && hasParent[0] === 'group:default/team-b') ||
-          hasParent[0] === 'group:default/team-a'
-        ) {
-          return { items: [groupRootMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return {
+          items: [
+            groupRootMock,
+            groupCMock,
+            groupDMock,
+            groupAMock,
+            groupBMock,
+          ],
+        };
       });
 
       let result = await roleManager.hasLink(
@@ -1056,44 +868,32 @@ describe('BackstageRoleManager', () => {
     // group:default/team-c                         group:default/team-d
     //               ↓                                        ↓
     //   user:default/mike                           user:default/tom
-    //
+    // This test passes now ?
     it('should return false for hasLink for user:default/mike and role:default/team-a(cycle dependency), but should be true for user:default/tom and role:default/team-b', async () => {
       const groupRootMock = createGroupEntity('root', undefined, [
         'team-a',
         'team-b',
       ]);
-      const groupCMock = createGroupEntity('team-c', 'team-a', ['team-a']);
-      const groupDMock = createGroupEntity('team-d', 'team-b', []);
-      const groupAMock = createGroupEntity('team-a', 'root', ['team-c']);
+      const groupCMock = createGroupEntity(
+        'team-c',
+        'team-a',
+        ['team-a'],
+        ['mike'],
+      );
+      const groupDMock = createGroupEntity('team-d', 'team-b', [], ['tom']);
+      const groupAMock = createGroupEntity('team-a', 'team-c', ['team-c']);
       const groupBMock = createGroupEntity('team-b', 'root', ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-
-        if (hasMember && hasMember[0] === 'user:default/mike') {
-          return { items: [groupCMock] };
-        }
-        if (hasMember && hasMember[0] === 'user:default/tom') {
-          return { items: [groupDMock] };
-        }
-
-        const hasParent = arg.filter['relations.parentOf'];
-
-        if (hasParent && hasParent[0] === 'group:default/team-c') {
-          return { items: [groupAMock] };
-        }
-
-        if (hasParent && hasParent[0] === 'group:default/team-d') {
-          return { items: [groupBMock] };
-        }
-
-        if (
-          (hasParent && hasParent[0] === 'group:default/team-b') ||
-          hasParent[0] === 'group:default/team-a'
-        ) {
-          return { items: [groupRootMock] };
-        }
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return {
+          items: [
+            groupRootMock,
+            groupCMock,
+            groupDMock,
+            groupAMock,
+            groupBMock,
+          ],
+        };
       });
 
       roleManager.addLink('group:default/team-a', 'role:default/team-a');
@@ -1154,20 +954,12 @@ describe('BackstageRoleManager', () => {
     });
 
     it('getRoles returns role for user inherited from group', async () => {
-      const teamAGroup = createGroupEntity('team-a', undefined, [
-        'user:default/test',
-      ]);
+      const teamAGroup = createGroupEntity('team-a', undefined, [], ['test']);
 
       roleManager.addLink('group:default/team-a', 'role:default/rbac_admin');
 
-      catalogApiMock.getEntities.mockImplementation((arg: any) => {
-        const hasMember = arg.filter['relations.hasMember'];
-
-        if (hasMember && hasMember[0] === 'user:default/test') {
-          return { items: [teamAGroup] };
-        }
-
-        return { items: [] };
+      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+        return { items: [teamAGroup] };
       });
 
       let roles = await roleManager.getRoles('user:default/test');
@@ -1188,6 +980,7 @@ describe('BackstageRoleManager', () => {
     name: string,
     parent?: string,
     children?: string[],
+    members?: string[],
   ): Entity {
     const entity: Entity = {
       apiVersion: 'v1',
@@ -1201,6 +994,10 @@ describe('BackstageRoleManager', () => {
 
     if (children) {
       entity.spec!.children = children;
+    }
+
+    if (members) {
+      entity.spec!.members = members;
     }
 
     if (parent) {

--- a/plugins/rbac-backend/src/role-manager/role-manager.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.test.ts
@@ -113,12 +113,7 @@ describe('BackstageRoleManager', () => {
           filter: {
             kind: 'Group',
           },
-          fields: [
-            'metadata.name',
-            'metadata.namespace',
-            'spec.parent',
-            'spec.members',
-          ],
+          fields: ['metadata.name', 'metadata.namespace', 'spec.parent'],
         },
         { token: 'some-token' },
       );
@@ -141,12 +136,7 @@ describe('BackstageRoleManager', () => {
           filter: {
             kind: 'Group',
           },
-          fields: [
-            'metadata.name',
-            'metadata.namespace',
-            'spec.parent',
-            'spec.members',
-          ],
+          fields: ['metadata.name', 'metadata.namespace', 'spec.parent'],
         },
         { token: 'some-token' },
       );
@@ -642,7 +632,11 @@ describe('BackstageRoleManager', () => {
       const groupBMock = createGroupEntity('team-b', 'team-a', ['team-c']);
       const groupCMock = createGroupEntity('team-c', 'team-b', [], ['mike']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock] };
+        }
         return { items: [groupAMock, groupBMock, groupCMock] };
       });
 
@@ -692,7 +686,11 @@ describe('BackstageRoleManager', () => {
       const groupBMock = createGroupEntity('team-b', 'team-a', ['team-c']);
       const groupCMock = createGroupEntity('team-c', 'team-b', ['mike']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock] };
+        }
         return { items: [groupAMock, groupBMock, groupCMock] };
       });
 
@@ -825,7 +823,13 @@ describe('BackstageRoleManager', () => {
       const groupAMock = createGroupEntity('team-a', 'team-c', ['team-c']);
       const groupBMock = createGroupEntity('team-b', 'root', ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock] };
+        } else if (hasMember && hasMember === 'user:default/tom') {
+          return { items: [groupDMock] };
+        }
         return {
           items: [
             groupRootMock,
@@ -884,7 +888,13 @@ describe('BackstageRoleManager', () => {
       const groupAMock = createGroupEntity('team-a', 'team-c', ['team-c']);
       const groupBMock = createGroupEntity('team-b', 'root', ['team-d']);
 
-      catalogApiMock.getEntities.mockImplementation((_arg: any) => {
+      catalogApiMock.getEntities.mockImplementation((arg: any) => {
+        const hasMember = arg.filter['relations.hasMember'];
+        if (hasMember && hasMember === 'user:default/mike') {
+          return { items: [groupCMock] };
+        } else if (hasMember && hasMember === 'user:default/tom') {
+          return { items: [groupDMock] };
+        }
         return {
           items: [
             groupRootMock,

--- a/plugins/rbac-backend/src/role-manager/role-manager.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.test.ts
@@ -876,12 +876,7 @@ describe('BackstageRoleManager', () => {
         'team-f',
         'team-g',
       ]);
-      const groupGMock = createGroupEntity(
-        'team-g',
-        'team-e',
-        ['team-d'],
-        ['mike'],
-      );
+      const groupGMock = createGroupEntity('team-g', 'team-e', [], ['mike']);
 
       catalogApiMock.getEntities.mockImplementation((arg: any) => {
         const hasMember = arg.filter['relations.hasMember'];
@@ -922,7 +917,7 @@ describe('BackstageRoleManager', () => {
       expect(test).toBeFalsy();
     });
 
-    // user:default/mike should inherits role from group:default/team-f, and we have a complex graph
+    // user:default/mike should inherits role from group:default/team-e, and we have a complex graph
     // So return true on call hasLink.
     //
     //     Hierarchy:
@@ -951,12 +946,7 @@ describe('BackstageRoleManager', () => {
         'team-f',
         'team-g',
       ]);
-      const groupGMock = createGroupEntity(
-        'team-g',
-        'team-e',
-        ['team-d'],
-        ['mike'],
-      );
+      const groupGMock = createGroupEntity('team-g', 'team-e', [], ['mike']);
 
       catalogApiMock.getEntities.mockImplementation((arg: any) => {
         const hasMember = arg.filter['relations.hasMember'];

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -20,11 +20,11 @@ import { DataBaseConditionalStorage } from '../database/conditional-storage';
 import { migrate } from '../database/migration';
 import { DataBasePolicyMetadataStorage } from '../database/policy-metadata-storage';
 import { DataBaseRoleMetadataStorage } from '../database/role-metadata';
+import { BackstageRoleManager } from '../role-manager/role-manager';
 import { EnforcerDelegate } from './enforcer-delegate';
 import { MODEL } from './permission-model';
 import { RBACPermissionPolicy } from './permission-policy';
 import { PolicesServer } from './policies-rest-api';
-import { BackstageRoleManager } from './role-manager';
 
 export class PolicyBuilder {
   public static async build(


### PR DESCRIPTION
## Description

This PR aims to reduce the number of times we make a call to the catalog while building the group hierarchy graph for a user. In our original approach, we would find that for each call to the authorize endpoint, we would retrieve the number of roles that the RBAC plugin is aware of, multiplied by the hierarchy level of the user. So, in the case of 52 roles and a user nested under four groups, we would end up with 52 * 4 = 208 catalog calls.

In the update, I chose to make a single call to retrieve all of the groups at once and then build the graph based on the retrieved information. This now means that for every authorize endpoint, we only make a call to the catalog the same number of times as the number of roles that the RBAC plugin is aware of.

Another aim of this PR is to separate some of the code from the BackstageRoleManager. Originally, we had the Role, which stored all of the roles that the RBAC plugin is aware of, and the AncestorSearchMemo, which was used to build the graph. I opted to move these into their own files to hopefully make maintenance easier.