### PR TITLE
fix(rbac): use sqlite with in memory config for db disabled option

### DIFF
--- a/plugins/rbac-backend/model/rbac-policy.csv
+++ b/plugins/rbac-backend/model/rbac-policy.csv
@@ -1,7 +1,0 @@
-
-
-p, role:default/guests, catalog-entity, read, deny
-p, role:default/guests, catalog.entity.create, use, deny
-
-g, user:default/guest, role:default/guests
-

--- a/plugins/rbac-backend/package.json
+++ b/plugins/rbac-backend/package.json
@@ -60,7 +60,6 @@
   "files": [
     "dist",
     "config.d.ts",
-    "model",
     "migrations"
   ],
   "repository": "github:janus-idp/backstage-plugins",

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -1,22 +1,15 @@
 import {
   DatabaseManager,
   PluginEndpointDiscovery,
-  resolvePackagePath,
   TokenManager,
 } from '@backstage/backend-common';
-import { DatabaseService } from '@backstage/backend-plugin-api';
 import { CatalogClient } from '@backstage/catalog-client';
 import { Config, ConfigReader } from '@backstage/config';
 import { IdentityApi } from '@backstage/plugin-auth-node';
 import { RouterOptions } from '@backstage/plugin-permission-backend';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 
-import {
-  FileAdapter,
-  newEnforcer,
-  newModelFromString,
-  StringAdapter,
-} from 'casbin';
+import { newEnforcer, newModelFromString } from 'casbin';
 import { Router } from 'express';
 import { Logger } from 'winston';
 


### PR DESCRIPTION
# What does this pull request do

Use SQLite with in-memory config for the disabled database option. Earlier, we used the file adapter for this mode, but our code didn't save content to the file. So, in fact, the RBAC backend was working with in-memory mode without persisting any data. Also, the file location was absolutely wrong and bad - the node_modules located with the plugin binary. So, the easiest way to achieve the same functionality with zero support effort is to use SQLite3 with in-memory config.

# What issue is referenced in this pull request?

https://issues.redhat.com/browse/RHIDP-1244



