### PR TITLE
fix(rbac): allow for super users to have allow all access

### DIFF
--- a/plugins/rbac-backend/README.md
+++ b/plugins/rbac-backend/README.md
@@ -95,7 +95,7 @@ NOTE: If you are using Red Hat Developer Hub backend plugin is pre-installed and
 
 ### Configure policy admins
 
-The RBAC plugin empowers you to manage permission policies for users and groups with a designated group of individuals known as policy administrators. These administrators are granted access to the RBAC plugin's REST API and user interface.
+The RBAC plugin empowers you to manage permission policies for users and groups with a designated group of individuals known as policy administrators. These administrators are granted access to the RBAC plugin's REST API and user interface as well as the ability to read from the catalog.
 
 You can specify the policy administrators in your application configuration as follows:
 
@@ -109,7 +109,21 @@ permission:
         - name: group:default/admins
 ```
 
-For more information on the available API endpoints, refer to the [API documentation](./docs/apis.md).
+The RBAC plugin also enables you to grant users the title of 'super user,' which provides them with unrestricted access throughout the Backstage instance.
+
+You can specify the super users in your application configuration as follows:
+
+```YAML
+permission:
+  enabled: true
+  rbac:
+    admin:
+      superUsers:
+        - name: user:default/alice
+        - name: user:default/mike
+```
+
+For more information on the available API endpoints accessible to the policy administrators, refer to the [API documentation](./docs/apis.md).
 
 ### Configuring policies via file
 

--- a/plugins/rbac-backend/config.d.ts
+++ b/plugins/rbac-backend/config.d.ts
@@ -8,7 +8,7 @@ export interface Config {
        */
       policyFileReload?: boolean;
       /**
-       * Optional configuration for admins, can declare individual users and / or groups
+       * Optional configuration for admins
        * @visibility frontend
        */
       admin?: {
@@ -17,6 +17,16 @@ export interface Config {
          * @visibility frontend
          */
         users?: Array<{
+          /**
+           * @visibility frontend
+           */
+          name: string;
+        }>;
+        /**
+         * The list of super users that will have allow all access, should be a list of only users
+         * @visibility frontend
+         */
+        superUsers?: Array<{
           /**
            * @visibility frontend
            */


### PR DESCRIPTION
## Description

Adds a 'super user' configuration value that grants users allow all access to their backstage instance. In this approach, I settled for creating an additional config value to capture the individuals who would be labeled super users within a backstage instance. This way we still preserve the integrity of the rbac admin role and have the ability to have users that will allow all priveliges.

Also, updated the documentation with the additional config value. Added an additional test for reloading the CSV file that was missed previously. This test checks if a user that originally was granted an allow for a particular permission, looses said allow result when removed from the csv file. 

## Fixes

- Fixes: #999 
