### PR TITLE
fix(orchestrator): implementation of getWorkflowById (v2)

### DIFF
--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -198,8 +198,11 @@ function setupInternalRoutes(
       });
   });
 
-  router.get('/workflows', async (_, res) => {
-    await V1.getWorkflows(services.sonataFlowService, services.dataIndexService)
+  router.get('/workflows/:workflowId', async (req, res) => {
+    const {
+      params: { workflowId },
+    } = req;
+    await V1.getWorkflowById(services.sonataFlowService, workflowId)
       .then(result => res.status(200).json(result))
       .catch(error => {
         res.status(500).send(error.message || 'Internal Server Error');
@@ -207,8 +210,10 @@ function setupInternalRoutes(
   });
 
   // v2
-  api.register('getWorkflows', async (_c, _req, res, next) => {
-    await V2.getWorkflows(services.sonataFlowService, services.dataIndexService)
+  api.register('getWorkflowById', async (c, _req, res, next) => {
+    const workflowId = c.request.params.workflowId as string;
+
+    await V2.getWorkflowById(services.sonataFlowService, workflowId)
       .then(result => res.json(result))
       .catch(error => {
         res.status(500).send(error.message || 'Internal Server Error');

--- a/plugins/orchestrator-common/src/auto-generated/api/definition.ts
+++ b/plugins/orchestrator-common/src/auto-generated/api/definition.ts
@@ -174,6 +174,45 @@ const OPENAPI = `
         }
       }
     },
+    "/v2/workflows/{workflowId}": {
+      "get": {
+        "operationId": "getWorkflowById",
+        "description": "Get a workflow by ID",
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "description": "ID of the workflow to execute",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDTO"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error workflow by id",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/workflows/instances": {
       "get": {
         "operationId": "getInstances",

--- a/plugins/orchestrator-common/src/auto-generated/api/models/schema.ts
+++ b/plugins/orchestrator-common/src/auto-generated/api/models/schema.ts
@@ -18,6 +18,10 @@ export interface paths {
     /** Create or update a workflow */
     post: operations['createWorkflow'];
   };
+  '/v2/workflows/{workflowId}': {
+    /** @description Get a workflow by ID */
+    get: operations['getWorkflowById'];
+  };
   '/v2/workflows/instances': {
     /**
      * Get instances
@@ -294,6 +298,29 @@ export interface operations {
         };
       };
       /** @description Error creating workflow */
+      500: {
+        content: {
+          'text/plain': string;
+        };
+      };
+    };
+  };
+  /** @description Get a workflow by ID */
+  getWorkflowById: {
+    parameters: {
+      path: {
+        /** @description ID of the workflow to execute */
+        workflowId: string;
+      };
+    };
+    responses: {
+      /** @description Success */
+      200: {
+        content: {
+          'application/json': components['schemas']['WorkflowDTO'];
+        };
+      };
+      /** @description Error workflow by id */
       500: {
         content: {
           'text/plain': string;

--- a/plugins/orchestrator-common/src/auto-generated/docs/index.adoc/index.adoc
+++ b/plugins/orchestrator-common/src/auto-generated/docs/index.adoc/index.adoc
@@ -481,6 +481,94 @@ ifdef::internal-generation[]
 endif::internal-generation[]
 
 
+[.getWorkflowById]
+==== getWorkflowById
+
+`GET /v2/workflows/{workflowId}`
+
+
+
+===== Description
+
+Get a workflow by ID
+
+
+// markup not found, no include::{specDir}v2/workflows/\{workflowId\}/GET/spec.adoc[opts=optional]
+
+
+
+===== Parameters
+
+====== Path Parameters
+
+[cols="2,3,1,1,1"]
+|===
+|Name| Description| Required| Default| Pattern
+
+| workflowId
+| ID of the workflow to execute 
+| X
+| null
+| 
+
+|===
+
+
+
+
+
+
+===== Return Type
+
+<<WorkflowDTO>>
+
+
+===== Content Type
+
+* application/json
+* text/plain
+
+===== Responses
+
+.HTTP Response Codes
+[cols="2,3,1"]
+|===
+| Code | Message | Datatype
+
+
+| 200
+| Success
+|  <<WorkflowDTO>>
+
+
+| 500
+| Error workflow by id
+|  <<String>>
+
+|===
+
+===== Samples
+
+
+// markup not found, no include::{snippetDir}v2/workflows/\{workflowId\}/GET/http-request.adoc[opts=optional]
+
+
+// markup not found, no include::{snippetDir}v2/workflows/\{workflowId\}/GET/http-response.adoc[opts=optional]
+
+
+
+// file not found, no * wiremock data link :v2/workflows/{workflowId}/GET/GET.json[]
+
+
+ifdef::internal-generation[]
+===== Implementation
+
+// markup not found, no include::{specDir}v2/workflows/\{workflowId\}/GET/implementation.adoc[opts=optional]
+
+
+endif::internal-generation[]
+
+
 [.getWorkflowOverviewById]
 ==== getWorkflowOverviewById
 

--- a/plugins/orchestrator-common/src/openapi/openapi.yaml
+++ b/plugins/orchestrator-common/src/openapi/openapi.yaml
@@ -105,6 +105,30 @@ paths:
             text/plain:
               schema:
                 type: string
+  /v2/workflows/{workflowId}:
+    get:
+      operationId: getWorkflowById
+      description: Get a workflow by ID
+      parameters:
+        - name: workflowId
+          in: path
+          description: ID of the workflow to execute
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkflowDTO'
+        '500':
+          description: Error workflow by id
+          content:
+            text/plain:
+              schema:
+                type: string
   /v2/workflows/instances:
     get:
       operationId: getInstances


### PR DESCRIPTION
By mistake the PR that added the new openapi v2 endpoints broke the `/workflows/:workflowId` v1 route.
In addition, the v2 endpoint wasn't properly added due to a wrong rebase.