### PR TITLE
fix(orchestrator): improvements to backend services

### DIFF
--- a/plugins/orchestrator-backend/src/service/Helper.ts
+++ b/plugins/orchestrator-backend/src/service/Helper.ts
@@ -5,6 +5,24 @@ import { Logger } from 'winston';
 
 import os from 'os';
 
+export async function retryAsyncFunction<T>(args: {
+  asyncFunc: () => Promise<T | undefined>;
+  retries: number;
+  delayMs: number;
+}): Promise<T> {
+  let result: T | undefined;
+  for (let i = 0; i < args.retries; i++) {
+    result = await args.asyncFunc();
+    if (result !== undefined) {
+      return result;
+    }
+    await new Promise(resolve => setTimeout(resolve, args.delayMs));
+  }
+  throw new Error(
+    `Exceeded maximum number of retries for function ${args.asyncFunc.name}`,
+  );
+}
+
 export async function getWorkingDirectory(
   config: Config,
   logger: Logger,

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -98,10 +98,11 @@ export class SonataFlowService {
     workflowId: string,
   ): Promise<string | undefined> {
     try {
-      const endpoint =
-        (await this.dataIndex.getWorkflowDefinition(workflowId)).serviceUrl ??
-        '';
-      const urlToFetch = `${endpoint}/management/processes/${workflowId}/sources`;
+      const definition = await this.dataIndex.getWorkflowDefinition(workflowId);
+      if (!definition?.serviceUrl) {
+        return undefined;
+      }
+      const urlToFetch = `${definition.serviceUrl}/management/processes/${workflowId}/sources`;
       const response = await executeWithRetry(() => fetch(urlToFetch));
 
       if (response.ok) {

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -431,9 +431,17 @@ function setupInternalRoutes(
 
     const workflowDefinition =
       await services.dataIndexService.getWorkflowDefinition(workflowId);
+
+    if (!workflowDefinition) {
+      res.status(500).send(`Couldn't fetch workflow definition ${workflowId}`);
+      return;
+    }
     const serviceUrl = workflowDefinition.serviceUrl;
     if (!serviceUrl) {
-      throw new Error(`ServiceUrl is not defined for workflow ${workflowId}`);
+      res
+        .status(500)
+        .send(`Service URL is not defined for workflow ${workflowId}`);
+      return;
     }
 
     // workflow source


### PR DESCRIPTION
- Some places in the services assume the response array is non-empty or the response object is not undefined, which could not be the case. So I've changed these parts to a more defensive code.
- When executing a workflow, I've added a call to fetch the instance details just to make sure the data is available. 

Please note that none of these improvements is changing the current behavior.