### PR TITLE
fix(orchestrator): handle api endpoint failure

### DIFF
--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -147,6 +147,21 @@ function initOpenAPIBackend(): OpenAPIBackend {
       verbose: true,
       addUsedSchema: false,
     },
+    handlers: {
+      validationFail: async (
+        c,
+        _req: express.Request,
+        res: express.Response,
+      ) => {
+        console.log('validationFail', c.operation);
+        res.status(400).json({ err: c.validation.errors });
+      },
+      notFound: async (_c, req: express.Request, res: express.Response) => {
+        res.status(404).json({ err: `${req.path} path not found` });
+      },
+      notImplemented: async (_c, req: express.Request, res: express.Response) =>
+        res.status(500).json({ err: `${req.path} not implemented` }),
+    },
   });
 }
 


### PR DESCRIPTION
Return an error when a nonexistent or not implemented endpoint is invoked. 
A validation failure handler is provided too.
This prevents backstage crash.

Current behavior: 

```zsh
» curl -X GET  http://localhost:7007/api/orchestrator/foo && echo && curl -X GET  http://localhost:7007/api/orchestrator/bar     

{"err":"/foo path not found"}
{"err":"/bar path not found"}
```