### PR TITLE
fix(rbac): fixed autocomplete text input behavior on clear

### DIFF
--- a/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
+++ b/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
@@ -84,11 +84,14 @@ export const AddMembersForm = ({
         onChange={(_e, value: SelectedMember) => {
           setSelectedMember(value);
           if (value) {
+            setSearch(value.label);
             setFieldValue('selectedMembers', [...selectedMembers, value]);
           }
         }}
         inputValue={search}
-        onInputChange={(_e, newSearch: string) => setSearch(newSearch)}
+        onInputChange={(_e, newSearch: string, reason) =>
+          reason === 'input' && setSearch(newSearch)
+        }
         getOptionDisabled={(option: SelectedMember) =>
           !!selectedMembers.find(
             (sm: SelectedMember) => sm.etag === option.etag,


### PR DESCRIPTION
For [RHIDP-1395](https://issues.redhat.com/browse/RHIDP-1395): [RBAC] Unable to clear Autocomplete text field on the add members section in the role form.

Screen recording:

https://github.com/janus-idp/backstage-plugins/assets/26255262/5d0322ce-28b9-40e3-ac1d-30372f792ef7

