### PR TITLE
docs(rbac): update to the rbac documentation

### DIFF
--- a/plugins/rbac-backend/README.md
+++ b/plugins/rbac-backend/README.md
@@ -16,6 +16,24 @@ To effectively utilize the RBAC plugin, you must have the Backstage permission f
 
 You need to [set up the permission framework in Backstage](https://backstage.io/docs/permissions/getting-started/).Since this plugin provides a dynamic policy that replaces the traditional one, there's no need to create a policy manually. Please note that one of the requirements for permission framework is enabling the [service-to-service authentication](https://backstage.io/docs/auth/service-to-service-auth/#setup). Ensure that you complete these authentication setup steps as well.
 
+### Identity resolver
+
+The permission framework, and consequently, this RBAC plugin, rely on the concept of group membership. To ensure smooth operation, please follow the [Sign-in identities and resolvers](https://backstage.io/docs/auth/identity-resolver/) documentation. It's crucial that when populating groups, you include any groups that you plan to assign permissions to.
+
+## Installation
+
+To integrate the RBAC plugin into your Backstage instance, follow these steps.
+
+### Installing the plugin
+
+Add the RBAC plugin packages as dependencies by running the following command.
+
+```SHELL
+yarn workspace backend add @janus-idp/backstage-plugin-rbac-backend
+```
+
+**NOTE**: If you are using Red Hat Developer Hub backend plugin is pre-installed and you do not need this step.
+
 ### Configuring the Backend
 
 To connect the RBAC framework to your backend use the `PolicyBuilder` class in your backend permissions plugin (typically `packages/backend/src/plugins/permissions.ts`) as follows:
@@ -75,24 +93,6 @@ async function main() {
 }
 ```
 
-### Identity resolver
-
-The permission framework, and consequently, this RBAC plugin, rely on the concept of group membership. To ensure smooth operation, please follow the [Sign-in identities and resolvers](https://backstage.io/docs/auth/identity-resolver/) documentation. It's crucial that when populating groups, you include any groups that you plan to assign permissions to.
-
-## Installation
-
-To integrate the RBAC plugin into your Backstage instance, follow these steps.
-
-### Installing the plugin
-
-Add the RBAC plugin packages as dependencies by running the following command.
-
-```SHELL
-yarn workspace backend add @janus-idp/backstage-plugin-rbac-backend
-```
-
-NOTE: If you are using Red Hat Developer Hub backend plugin is pre-installed and you do not need this step.
-
 ### Configure policy admins
 
 The RBAC plugin empowers you to manage permission policies for users and groups with a designated group of individuals known as policy administrators. These administrators are granted access to the RBAC plugin's REST API and user interface as well as the ability to read from the catalog.
@@ -142,9 +142,7 @@ g, group:default/team_b, role:default/team_b
 
 ---
 
-**NOTE**
-
-When you add a role in the permission policies configuration file, ensure that the role is associated with at least one permission policy with the `allow` effect.
+**NOTE**: When you add a role in the permission policies configuration file, ensure that the role is associated with at least one permission policy with the `allow` effect.
 
 ---
 

--- a/plugins/rbac-backend/docs/apis.md
+++ b/plugins/rbac-backend/docs/apis.md
@@ -16,7 +16,7 @@ Each endpoint also requires an Authorization header with the Bearer token that w
 
 GET </api/permission/roles>
 
-lists all roles.
+Lists all roles.
 
 Returns:
 
@@ -24,11 +24,19 @@ Returns:
 [
   {
     "memberReferences": ["user:default/adam"],
-    "name": "role:default/guests"
+    "name": "role:default/rbac_admin",
+    "metadata": {
+      "source": "configuration",
+      "description": null
+    }
   },
   {
     "memberReferences": ["group:default/janus-authors", "user:default/matt"],
-    "name": "role:default/test"
+    "name": "role:default/test",
+    "metadata": {
+      "source": "csv-file",
+      "description": null
+    }
   }
 ]
 ```
@@ -54,7 +62,11 @@ Returns:
 [
   {
     "memberReferences": ["group:default/janus-authors", "user:default/matt"],
-    "name": "role:default/test"
+    "name": "role:default/test",
+    "metadata": {
+      "source": "csv-file",
+      "description": null
+    }
   }
 ]
 ```
@@ -69,17 +81,21 @@ Creates a new role.
 
 Request Parameters:
 
-| Parameter name   | Description                                                      | Type   |
-| ---------------- | ---------------------------------------------------------------- | ------ |
-| memberReferences | users / groups to be added to the role `<kind>:<default>/<name>` | Array  |
-| name             | name of the role                                                 | String |
+| Parameter name       | Description                                                      | Type   |
+| -------------------- | ---------------------------------------------------------------- | ------ |
+| memberReferences     | users / groups to be added to the role `<kind>:<default>/<name>` | Array  |
+| name                 | name of the role                                                 | String |
+| metadata.description | description of the role                                          | String |
 
 body:
 
 ```json
 {
   "memberReferences": ["group:default/test"],
-  "name": "role:default/test_admin"
+  "name": "role:default/test_admin",
+  "metadata": {
+    "description": "This is a test admin role"
+  }
 }
 ```
 
@@ -104,10 +120,11 @@ Request Parameters:
 
 Request Parameters for oldRole and newRole:
 
-| Parameter name   | Description                                                      | Type   |
-| ---------------- | ---------------------------------------------------------------- | ------ |
-| memberReferences | users / groups to be added to the role `<kind>:<default>/<name>` | Array  |
-| name             | name of the role                                                 | String |
+| Parameter name       | Description                                                      | Type   |
+| -------------------- | ---------------------------------------------------------------- | ------ |
+| memberReferences     | users / groups to be added to the role `<kind>:<default>/<name>` | Array  |
+| name                 | name of the role                                                 | String |
+| metadata.description | description of the role                                          | String |
 
 body:
 
@@ -115,11 +132,17 @@ body:
 {
   "oldRole": {
     "memberReferences": ["group:default/test"],
-    "name": "role:default/test_admin"
+    "name": "role:default/test_admin",
+    "metadata": {
+      "description": "This is a test admin role"
+    }
   },
   "newRole": {
     "memberReferences": ["group:default/test", "user:default/test2"],
-    "name": "role:default/test_admin"
+    "name": "role:default/test_admin",
+    "metadata": {
+      "description": "This is a test admin role with a group and user"
+    }
   }
 }
 ```
@@ -150,7 +173,10 @@ before:
 ```json
 {
   "memberReferences": ["group:default/test, user:default/test2"],
-  "name": "role:default/test_admin"
+  "name": "role:default/test_admin",
+  "metadata": {
+    "description": "This is a test admin role with a group and user"
+  }
 }
 ```
 
@@ -159,7 +185,10 @@ after:
 ```json
 {
   "memberReferences": ["group:default/test"],
-  "name": "role:default/test_admin"
+  "name": "role:default/test_admin",
+  "metadata": {
+    "description": "This is a test admin role with a group and user"
+  }
 }
 ```
 
@@ -190,7 +219,7 @@ Returns a status code of 204 upon success.
 
 GET </api/permission/policies>
 
-lists all permission polices.
+Lists all permission polices.
 
 Returns:
 
@@ -200,13 +229,19 @@ Returns:
     "entityReference": "role:default/test",
     "permission": "catalog-entity",
     "policy": "read",
-    "effect": "allow"
+    "effect": "allow",
+    "metadata": {
+      "source": "csv-file"
+    }
   },
   {
     "entityReference": "role:default/test",
     "permission": "catalog.entity.create",
     "policy": "create",
-    "effect": "allow"
+    "effect": "allow",
+    "metadata": {
+      "source": "csv-file"
+    }
   },
   ...
 ]
@@ -235,13 +270,19 @@ Returns:
     "entityReference": "role:default/test",
     "permission": "catalog-entity",
     "policy": "read",
-    "effect": "allow"
+    "effect": "allow",
+    "metadata": {
+      "source": "csv-file"
+    }
   },
   {
     "entityReference": "role:default/test",
     "permission": "catalog.entity.create",
     "policy": "create",
-    "effect": "allow"
+    "effect": "allow",
+    "metadata": {
+      "source": "csv-file"
+    }
   }
 ]
 ```
@@ -252,7 +293,7 @@ Returns:
 
 POST </api/permission/policies>
 
-Creates a permission policy for a specified entity.
+Creates one or more permission policies for a specified entity.
 
 Request parameters:
 
@@ -266,12 +307,14 @@ Request parameters:
 body:
 
 ```json
-{
-  "entityReference": "role:default/test",
-  "permission": "catalog-entity",
-  "policy": "read",
-  "effect": "allow"
-}
+[
+  {
+    "entityReference": "role:default/test",
+    "permission": "catalog-entity",
+    "policy": "delete",
+    "effect": "allow"
+  }
+]
 ```
 
 Returns a status code of 201 upon success.
@@ -283,7 +326,7 @@ Returns a status code of 201 upon success.
 PUT </api/permission/policies/:kind/:namespace/:name>
 ex. <http://localhost:7007/api/permission/policies/role/default/test>
 
-Updates a permission policy for a specified entity.
+Updates one or more permission policies for a specified entity.
 
 Request parameters:
 
@@ -305,16 +348,30 @@ body:
 
 ```json
 {
-  "oldPolicy": {
-    "permission": "catalog-entity",
-    "policy": "read",
-    "effect": "deny"
-  },
-  "newPolicy": {
-    "permission": "policy-entity",
-    "policy": "read",
-    "effect": "allow"
-  }
+  "oldPolicy": [
+    {
+      "permission": "catalog-entity",
+      "policy": "read",
+      "effect": "allow"
+    },
+    {
+      "permission": "catalog.entity.create",
+      "policy": "create",
+      "effect": "allow"
+    }
+  ],
+  "newPolicy": [
+    {
+      "permission": "catalog-entity",
+      "policy": "read",
+      "effect": "deny"
+    },
+    {
+      "permission": "policy-entity",
+      "policy": "create",
+      "effect": "allow"
+    }
+  ]
 }
 ```
 
@@ -350,7 +407,7 @@ Returns a status code of 204 upon success.
 
 GET </api/permission/plugins/policies>
 
-lists all plugin permission policies from plugins installed in your Backstage instance.
+Lists all plugin permission policies from plugins installed in your Backstage instance.
 
 Returns:
 
@@ -420,7 +477,9 @@ The structure of the condition JSON object is as follows:
 
 ### GET </plugins/condition-rules>
 
-GET </plugins/condition-rules> provides condition parameters schemas.
+GET </plugins/condition-rules>
+
+Provides condition parameters schemas.
 
 ```json
 [

--- a/plugins/rbac-backend/docs/permissions.md
+++ b/plugins/rbac-backend/docs/permissions.md
@@ -4,16 +4,17 @@ Note: The requirements section primarily pertains to the frontend and may not be
 
 When defining a permission for the RBAC Backend plugin to consume, follow these guidelines:
 
-Permission policies defined using the name of the permission will have higher priority over permission policies that are defined using the resource type.
-Example:
+- Permission policies defined using the name of the permission will have higher priority over permission policies that are defined using the resource type.
 
-```
-p, role:default/myrole, catalog-entity, read, allow
-p, role:default/myrole, catalog.entity.read, read, deny
-g, user:default/myuser, role:default/myrole
-```
+  - Example:
 
-Where 'myuser' will have a deny for reading catalog entities, because the permission name takes priority over the permission resource type.
+    ```CSV
+    p, role:default/myrole, catalog-entity, read, allow
+    p, role:default/myrole, catalog.entity.read, read, deny
+    g, user:default/myuser, role:default/myrole
+    ```
+
+  Where 'myuser' will have a deny for reading catalog entities, because the permission name takes priority over the permission resource type.
 
 - If the permission does not have a policy associated with it, use the keyword `use` in its place.
   - Example: `p, role:default/test, kubernetes.proxy, use, allow`


### PR DESCRIPTION
## Description

Updates the documentation for the RBAC plugin. We have had a number of updates to the plugin and this PR should help to get the documentation caught back up to these updates. 

Added the ability to create and update multiple permission policies, added the `metadata.description` parameter, moved some steps around in the README for a better step by step guide, and minor formatting to the permission policies guide. 