### PR TITLE
fix(orchestrator): warn "unknown format X ignored in schema at path Y"

### DIFF
--- a/plugins/orchestrator-backend/dist-dynamic/package.json
+++ b/plugins/orchestrator-backend/dist-dynamic/package.json
@@ -63,6 +63,7 @@
     "winston": "^3.11.0",
     "yn": "^5.0.0",
     "moment": "^2.29.4",
+    "ajv-formats": "^2.1.1",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {},

--- a/plugins/orchestrator-backend/package.json
+++ b/plugins/orchestrator-backend/package.json
@@ -86,7 +86,8 @@
     "openapi-types": "^12.1.3",
     "winston": "^3.11.0",
     "yn": "^5.0.0",
-    "moment": "^2.29.4"
+    "moment": "^2.29.4",
+    "ajv-formats": "^2.1.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.25.2",

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -3,6 +3,7 @@ import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { ScmIntegrations } from '@backstage/integration';
 import { JsonObject, JsonValue } from '@backstage/types';
 
+import { fullFormats } from 'ajv-formats/dist/formats';
 import express from 'express';
 import Router from 'express-promise-router';
 import { OpenAPIBackend, Request } from 'openapi-backend';
@@ -146,6 +147,7 @@ function initOpenAPIBackend(): OpenAPIBackend {
       strictSchema: false,
       verbose: true,
       addUsedSchema: false,
+      formats: fullFormats, // open issue: https://github.com/openapistack/openapi-backend/issues/280
     },
     handlers: {
       validationFail: async (


### PR DESCRIPTION
During backstage startup there are warnings like:
 `unknown format "date-time" ignored in schema at path "#/oneOf/0/properties/ended"`
 due to a bug in [OpenAPIBackend issue](https://github.com/openapistack/openapi-backend/issues/280).

Resolves [FLPATH-1045](https://issues.redhat.com/browse/FLPATH-1045)

Based on Yaron Dayagi <ydayagi@redhat.com> [work](https://github.com/janus-idp/backstage-plugins/blob/903c7f37a1cf138ac96ef3f631f951866c2014fa/plugins/notifications-backend/src/service/router.ts#L45-L52) in notification plugin.