### PR TITLE
fix(orchestrator): handle nullable start/state properties of process instance

### DIFF
--- a/plugins/orchestrator-backend/src/service/DataIndexService.ts
+++ b/plugins/orchestrator-backend/src/service/DataIndexService.ts
@@ -49,6 +49,10 @@ export class DataIndexService {
       .mutation(ProcessInstanceAbortMutationDocument, { id: workflowId })
       .toPromise();
 
+    this.logger.debug(
+      `Abort workflow instance result: ${JSON.stringify(result)}`,
+    );
+
     if (result.error) {
       this.logger.error(
         `Error aborting workflow instance ${workflowId}: ${result.error}`,
@@ -66,6 +70,10 @@ export class DataIndexService {
     const graphQlQuery = `{ ProcessDefinitions ( where: {id: {equal: "${definitionId}" } } ) { id, name, version, type, endpoint, serviceUrl, source } }`;
 
     const result = await this.client.query(graphQlQuery, {});
+
+    this.logger.debug(
+      `Get workflow definition result: ${JSON.stringify(result)}`,
+    );
 
     if (result.error) {
       this.logger.error(`Error fetching workflow definition ${result.error}`);
@@ -99,6 +107,10 @@ export class DataIndexService {
     this.logger.info(`getWorkflowDefinitions() called:  ${this.dataIndexUrl}`);
     const result = await this.client.query(QUERY, {});
 
+    this.logger.debug(
+      `Get workflow definitions result: ${JSON.stringify(result)}`,
+    );
+
     if (result.error) {
       this.logger.error(
         `Error fetching data index swf results ${result.error}`,
@@ -113,14 +125,18 @@ export class DataIndexService {
     const graphQlQuery =
       '{ ProcessInstances ( orderBy: { start: ASC }, where: {processId: {isNull: false} } ) { id, processName, processId, businessKey, state, start, end, nodes { id }, variables, parentProcessInstance {id, processName, businessKey} } }';
 
-    const response = await this.client.query(graphQlQuery, {});
+    const result = await this.client.query(graphQlQuery, {});
 
-    if (response.error) {
-      this.logger.error(`Error when fetching instances: ${response.error}`);
-      throw response.error;
+    this.logger.debug(
+      `Fetch process instances result: ${JSON.stringify(result)}`,
+    );
+
+    if (result.error) {
+      this.logger.error(`Error when fetching instances: ${result.error}`);
+      throw result.error;
     }
 
-    const processInstancesSrc = response.data
+    const processInstancesSrc = result.data
       .ProcessInstances as ProcessInstance[];
 
     const processInstances = await Promise.all(
@@ -153,17 +169,18 @@ export class DataIndexService {
   ): Promise<string | undefined> {
     const graphQlQuery = `{ ProcessDefinitions ( where: {id: {equal: "${workflowId}" } } ) { id, source } }`;
 
-    const response = await this.client.query(graphQlQuery, {});
+    const result = await this.client.query(graphQlQuery, {});
 
-    if (response.error) {
-      this.logger.error(
-        `Error when fetching workflow source: ${response.error}`,
-      );
+    this.logger.debug(
+      `Fetch workflow source result: ${JSON.stringify(result)}`,
+    );
+
+    if (result.error) {
+      this.logger.error(`Error when fetching workflow source: ${result.error}`);
       return undefined;
     }
 
-    const processDefinitions = response.data
-      .ProcessDefinitions as WorkflowInfo[];
+    const processDefinitions = result.data.ProcessDefinitions as WorkflowInfo[];
 
     if (processDefinitions.length === 0) {
       this.logger.info(`No workflow source found for ${workflowId}`);
@@ -182,6 +199,10 @@ export class DataIndexService {
 
     const result = await this.client.query(graphQlQuery, {});
 
+    this.logger.debug(
+      `Fetch workflow instances result: ${JSON.stringify(result)}`,
+    );
+
     if (result.error) {
       this.logger.error(
         `Error when fetching workflow instances: ${result.error}`,
@@ -199,6 +220,10 @@ export class DataIndexService {
 
     const result = await this.client.query(graphQlQuery, {});
 
+    this.logger.debug(
+      `Fetch process instance jobs result: ${JSON.stringify(result)}`,
+    );
+
     if (result.error) {
       this.logger.error(`Error when fetching jobs instances: ${result.error}`);
       throw result.error;
@@ -213,6 +238,10 @@ export class DataIndexService {
     const graphQlQuery = `{ ProcessInstances (where: { id: {equal: "${instanceId}" } } ) { variables } }`;
 
     const result = await this.client.query(graphQlQuery, {});
+
+    this.logger.debug(
+      `Fetch process instance variables result: ${JSON.stringify(result)}`,
+    );
 
     if (result.error) {
       this.logger.error(
@@ -236,6 +265,10 @@ export class DataIndexService {
     const graphQlQuery = `{ ProcessInstances (where: { id: {equal: "${instanceId}" } } ) { id, processName, processId, serviceUrl, businessKey, state, start, end, nodes { id, nodeId, definitionId, type, name, enter, exit }, variables, parentProcessInstance {id, processName, businessKey}, error { nodeDefinitionId, message} } }`;
 
     const result = await this.client.query(graphQlQuery, {});
+
+    this.logger.debug(
+      `Fetch process instance result: ${JSON.stringify(result)}`,
+    );
 
     if (result.error) {
       this.logger.error(

--- a/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.ts
+++ b/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.ts
@@ -102,7 +102,7 @@ export function mapWorkflowCategoryDTO(
 }
 
 export function getProcessInstancesDTOFromString(
-  state: string,
+  state?: string,
 ): ProcessInstanceStatusDTO {
   switch (state) {
     case ProcessInstanceState.Active.valueOf():
@@ -115,6 +115,8 @@ export function getProcessInstancesDTOFromString(
       return 'Aborted';
     case ProcessInstanceState.Suspended.valueOf():
       return 'Suspended';
+    case ProcessInstanceState.Pending.valueOf():
+      return 'Pending';
     default:
       throw new Error(
         'state is not one of the values of type ProcessInstanceStatusDTO',

--- a/plugins/orchestrator-common/src/auto-generated/api/models/schema.ts
+++ b/plugins/orchestrator-common/src/auto-generated/api/models/schema.ts
@@ -142,7 +142,8 @@ export interface components {
       | 'Error'
       | 'Completed'
       | 'Aborted'
-      | 'Suspended';
+      | 'Suspended'
+      | 'Pending';
     WorkflowRunStatusDTO: {
       key?: string;
       value?: string;

--- a/plugins/orchestrator-common/src/models.ts
+++ b/plugins/orchestrator-common/src/models.ts
@@ -6,6 +6,7 @@ export enum ProcessInstanceState {
   Aborted = 'ABORTED',
   Suspended = 'SUSPENDED',
   Error = 'ERROR',
+  Pending = 'PENDING',
 }
 
 export type ProcessInstanceStateValues = Uppercase<
@@ -60,13 +61,13 @@ export interface ProcessInstance {
   rootProcessInstanceId?: string;
   rootProcessId?: string;
   roles?: string[];
-  state: ProcessInstanceStateValues;
+  state?: ProcessInstanceStateValues;
   endpoint: string;
   serviceUrl?: string;
   nodes: NodeInstance[];
   milestones?: Milestone[];
   variables?: ProcessInstanceVariables | string;
-  start: Date;
+  start?: Date;
   end?: Date;
   parentProcessInstance?: ProcessInstance;
   childProcessInstances?: ProcessInstance[];

--- a/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
@@ -103,7 +103,9 @@ export const WorkflowInstancePage = ({
     fetchInstance,
     SHORT_REFRESH_INTERVAL,
     (curValue: AssessedProcessInstance | undefined) =>
-      !!curValue && curValue.instance.state === 'ACTIVE',
+      !!curValue &&
+      (curValue.instance.state === 'ACTIVE' ||
+        curValue.instance.state === 'PENDING'),
   );
 
   const canAbort = React.useMemo(

--- a/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
@@ -26,13 +26,14 @@ export const mapProcessInstanceToDetails = (
   instance: ProcessInstance,
 ): WorkflowRunDetail => {
   const name = instance.processName || instance.processId;
-  const start = moment(instance.start);
+  const start = instance.start ? moment(instance.start) : undefined;
   let duration: string = VALUE_UNAVAILABLE;
-  if (instance.end) {
+  if (start && instance.end) {
     const end = moment(instance.end);
     duration = moment.duration(start.diff(end)).humanize();
   }
 
+  const started = start?.toDate().toLocaleString() ?? VALUE_UNAVAILABLE;
   const variables = parseWorkflowVariables(instance?.variables);
   const nextWorkflowSuggestions: WorkflowRunDetail['nextWorkflowSuggestions'] =
     // @ts-ignore
@@ -42,7 +43,7 @@ export const mapProcessInstanceToDetails = (
     id: instance.id,
     name,
     workflowId: instance.processId,
-    started: start.toDate().toLocaleString(),
+    started,
     duration,
     category: instance.category,
     status: instance.state,

--- a/plugins/orchestrator/src/components/WorkflowInstanceStatusIndicator.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstanceStatusIndicator.tsx
@@ -4,15 +4,20 @@ import DotIcon from '@material-ui/icons/FiberManualRecord';
 
 import { ProcessInstanceStateValues } from '@janus-idp/backstage-plugin-orchestrator-common';
 
+import { VALUE_UNAVAILABLE } from '../constants';
 import { useWorkflowInstanceStateColors } from '../hooks/useWorkflowInstanceStatusColors';
 import { capitalize } from '../utils/StringUtils';
 
 export const WorkflowInstanceStatusIndicator = ({
   status,
 }: {
-  status: ProcessInstanceStateValues;
+  status?: ProcessInstanceStateValues;
 }) => {
   const iconColor = useWorkflowInstanceStateColors(status);
+
+  if (!status) {
+    return VALUE_UNAVAILABLE;
+  }
 
   return (
     <>

--- a/plugins/orchestrator/src/components/WorkflowProgressNode.tsx
+++ b/plugins/orchestrator/src/components/WorkflowProgressNode.tsx
@@ -14,7 +14,7 @@ import { Paragraph } from './Paragraph';
 import { WorkflowProgressNodeModel } from './WorkflowProgressNodeModel';
 
 const WorkflowProgressNodeIcon: React.FC<{
-  status: WorkflowProgressNodeModel['status'];
+  status?: WorkflowProgressNodeModel['status'];
   error?: WorkflowProgressNodeModel['error'];
 }> = ({ status, error }) => {
   const color = useWorkflowInstanceStateColors(status);
@@ -56,6 +56,13 @@ const WorkflowProgressNodeIcon: React.FC<{
       return (
         <Tooltip title="Suspended">
           <PauseCircleIcon className={color} />
+        </Tooltip>
+      );
+    }
+    case 'PENDING': {
+      return (
+        <Tooltip title="Pending">
+          <HourglassTopIcon className={color} />
         </Tooltip>
       );
     }

--- a/plugins/orchestrator/src/components/WorkflowProgressNodeModel.ts
+++ b/plugins/orchestrator/src/components/WorkflowProgressNodeModel.ts
@@ -7,13 +7,13 @@ import {
 import { isNonNullable } from '../utils/TypeGuards';
 
 export type WorkflowProgressNodeModel = NodeInstance & {
-  status: ProcessInstanceStateValues;
+  status?: ProcessInstanceStateValues;
   error?: ProcessInstanceError;
 };
 
 export const fromNodeInstanceToWorkflowProgressNodeModel =
   (
-    workflowStatus: ProcessInstanceStateValues,
+    workflowStatus?: ProcessInstanceStateValues,
     workflowError?: ProcessInstanceError,
   ) =>
   (
@@ -41,7 +41,11 @@ export const fromNodeInstanceToWorkflowProgressNodeModel =
       model.status = 'ACTIVE';
     }
 
-    if (isLastNode && ['ABORTED', 'SUSPENDED'].includes(workflowStatus)) {
+    if (
+      workflowStatus &&
+      isLastNode &&
+      ['ABORTED', 'SUSPENDED'].includes(workflowStatus)
+    ) {
       model.status = workflowStatus;
     }
 

--- a/plugins/orchestrator/src/components/WorkflowRunDetail.ts
+++ b/plugins/orchestrator/src/components/WorkflowRunDetail.ts
@@ -7,7 +7,7 @@ export type WorkflowRunDetail = {
   id: string;
   name: string;
   workflowId: string;
-  status: string;
+  status?: string;
   started: string;
   duration: string;
   category?: string;

--- a/plugins/orchestrator/src/hooks/useWorkflowInstanceStatusColors.ts
+++ b/plugins/orchestrator/src/hooks/useWorkflowInstanceStatusColors.ts
@@ -6,7 +6,7 @@ import {
 } from '@janus-idp/backstage-plugin-orchestrator-common';
 
 export const useWorkflowInstanceStateColors = (
-  value: ProcessInstanceStateValues,
+  value?: ProcessInstanceStateValues,
 ) => {
   const useStyles = makeStyles(
     theme =>
@@ -26,9 +26,12 @@ export const useWorkflowInstanceStateColors = (
         [ProcessInstanceState.Error]: {
           color: theme.palette.error.main,
         },
+        [ProcessInstanceState.Pending]: {
+          color: theme.palette.grey[500],
+        },
       }) as const,
   );
 
   const styles = useStyles();
-  return styles[value];
+  return value ? styles[value] : undefined;
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/FLPATH-1035

- Add debug logs for SonataFlow responses
- Remove unused `SonataFlow#fetchWorkflows` method
- Handle null values for `start` and `state` properties (ProcessInstance)
- Handle `PENDING` state (ProcessInstance)