### PR TITLE
fix(rbac): check source before throwing duplicate warning

### DIFF
--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -100,7 +100,19 @@ const policyMetadataStorageMock: PolicyMetadataStorage = {
         return [];
       },
     ),
-  findPolicyMetadata: jest.fn().mockImplementation(),
+  findPolicyMetadata: jest
+    .fn()
+    .mockImplementation(
+      async (
+        _policy: string[],
+        _trx: Knex.Knex.Transaction,
+      ): Promise<PermissionPolicyMetadata> => {
+        const test: PermissionPolicyMetadata = {
+          source: 'csv-file',
+        };
+        return test;
+      },
+    ),
   createPolicyMetadata: jest.fn().mockImplementation(),
   removePolicyMetadata: jest.fn().mockImplementation(),
 };

--- a/plugins/rbac-backend/src/service/policies-validation.ts
+++ b/plugins/rbac-backend/src/service/policies-validation.ts
@@ -154,7 +154,7 @@ async function validateGroupingPolicy(
   const metadata = await roleMetadataStorage.findRoleMetadata(parent);
   if (metadata && metadata.source !== source && metadata.source !== 'legacy') {
     return new Error(
-      `You could not add user or group to the role created with source ${metadata.source}`,
+      `Group policy is invalid: ${groupPolicy}. You could not add user or group to the role created with source ${metadata.source}`,
     );
   }
   return undefined;
@@ -176,9 +176,12 @@ export async function validateAllPredefinedPolicies(
     }
 
     if (await enforcer.hasPolicy(...policy)) {
-      return new Error(
-        `Duplicate policy: ${policy} found in the file ${preDefinedPoliciesFile}`,
-      );
+      const source = (await enforcer.getMetadata(policy)).source;
+      if (source !== 'csv-file') {
+        return new Error(
+          `Duplicate policy: ${policy} found in the file ${preDefinedPoliciesFile}, originates from source: ${source}`,
+        );
+      }
     }
   }
 
@@ -194,9 +197,12 @@ export async function validateAllPredefinedPolicies(
     }
 
     if (await enforcer.hasGroupingPolicy(...groupPolicy)) {
-      return new Error(
-        `Duplicate role: ${groupPolicy} found in the file ${preDefinedPoliciesFile}`,
-      );
+      const source = (await enforcer.getMetadata(groupPolicy)).source;
+      if (source !== 'csv-file') {
+        return new Error(
+          `Duplicate role: ${groupPolicy} found in the file ${preDefinedPoliciesFile}, originates from source: ${source}`,
+        );
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
## Description

Fixes the duplication warning being thrown unnecessarily whenever there is a policy present in the CSV file and the database. This issue was happening because we were not checking the origin of the duplication warning whenever we were loading in the app-config at the start of an instance. The updates to this PR aims to fix it so that we check the source also before throwing the warning. 

Updated the tests as well to match the duplication fix.