### PR TITLE
fix(orchestrator): remove date-time format from spec

### DIFF
--- a/plugins/orchestrator-common/src/auto-generated/api/definition.ts
+++ b/plugins/orchestrator-common/src/auto-generated/api/definition.ts
@@ -641,8 +641,7 @@ const OPENAPI = `
             "$ref": "#/components/schemas/ProcessInstanceStatusDTO"
           },
           "started": {
-            "type": "string",
-            "format": "date-time"
+            "type": "string"
           },
           "duration": {
             "type": "string"
@@ -786,12 +785,10 @@ const OPENAPI = `
           },
           "enter": {
             "type": "string",
-            "format": "date-time",
             "description": "Date when the node was entered"
           },
           "exit": {
             "type": "string",
-            "format": "date-time",
             "description": "Date when the node was exited (optional)"
           },
           "definitionId": {

--- a/plugins/orchestrator-common/src/auto-generated/api/models/schema.ts
+++ b/plugins/orchestrator-common/src/auto-generated/api/models/schema.ts
@@ -117,7 +117,6 @@ export interface components {
       name?: string;
       workflow?: string;
       status?: components['schemas']['ProcessInstanceStatusDTO'];
-      /** Format: date-time */
       started?: string;
       duration?: string;
       category?: components['schemas']['WorkflowCategoryDTO'];
@@ -176,15 +175,9 @@ export interface components {
       name?: string;
       /** @description Node type */
       type?: string;
-      /**
-       * Format: date-time
-       * @description Date when the node was entered
-       */
+      /** @description Date when the node was entered */
       enter?: string;
-      /**
-       * Format: date-time
-       * @description Date when the node was exited (optional)
-       */
+      /** @description Date when the node was exited (optional) */
       exit?: string;
       /** @description Definition ID */
       definitionId?: string;

--- a/plugins/orchestrator-common/src/auto-generated/docs/index.adoc/index.adoc
+++ b/plugins/orchestrator-common/src/auto-generated/docs/index.adoc/index.adoc
@@ -1192,15 +1192,15 @@ endif::internal-generation[]
 
 | enter
 | 
-| Date 
+| String 
 | Date when the node was entered
-| date-time 
+|  
 
 | exit
 | 
-| Date 
+| String 
 | Date when the node was exited (optional)
-| date-time 
+|  
 
 | definitionId
 | 
@@ -1284,9 +1284,9 @@ endif::internal-generation[]
 
 | started
 | 
-| Date 
+| String 
 | 
-| date-time 
+|  
 
 | duration
 | 
@@ -1589,13 +1589,13 @@ Category of the workflow
 | 
 | oas_any_type_not_mapped 
 | Date when the node was entered
-| date-time 
+|  
 
 | exit
 | 
 | oas_any_type_not_mapped 
 | Date when the node was exited (optional)
-| date-time 
+|  
 
 | definitionId
 | 

--- a/plugins/orchestrator-common/src/openapi/openapi.yaml
+++ b/plugins/orchestrator-common/src/openapi/openapi.yaml
@@ -409,7 +409,6 @@ components:
           $ref: '#/components/schemas/ProcessInstanceStatusDTO'
         started:
           type: string
-          format: date-time
         duration:
           type: string
         category:
@@ -504,11 +503,9 @@ components:
           description: Node type
         enter:
           type: string
-          format: date-time
           description: Date when the node was entered
         exit:
           type: string
-          format: date-time
           description: Date when the node was exited (optional)
         definitionId:
           type: string


### PR DESCRIPTION
The values of date-time fields don't refect the RFC format. Use only string.

Fix [FLPATH-1051](https://issues.redhat.com/browse/FLPATH-1051)