### PR TITLE
fix(orchestrator): workflowId parameter wrongly parsed in getWorkflowOverviewById (v2)

### DIFF
--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -348,10 +348,9 @@ function setupInternalRoutes(
   // v2
   api.register(
     'getWorkflowOverviewById',
-    async (_c, req: express.Request, res: express.Response, next) => {
-      const {
-        params: { workflowId },
-      } = req;
+    async (c, _req: express.Request, res: express.Response, next) => {
+      const workflowId = c.request.params.workflowId as string;
+
       await V2.getWorkflowOverviewById(services.sonataFlowService, workflowId)
         .then(result => res.json(result))
         .catch(next);


### PR DESCRIPTION
The `workflowId` param isn't parsed properly.
The endpoint always returns 500 error.

Fix [FLPATH-1052](https://issues.redhat.com/browse/FLPATH-1052)