### PR TITLE
fix(orchestrator): refactor 500 response to use ErrorResponse object

### DIFF
--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -154,7 +154,9 @@ function setupInternalRoutes(
     await V1.getWorkflowsOverview(services.sonataFlowService)
       .then(result => res.status(200).json(result))
       .catch(error => {
-        res.status(500).send(error.message || 'Internal Server Error');
+        res
+          .status(500)
+          .json({ message: error.message || 'internal server error' });
       });
   });
 
@@ -165,7 +167,9 @@ function setupInternalRoutes(
       await V2.getWorkflowsOverview(services.sonataFlowService)
         .then(result => res.json(result))
         .catch(error => {
-          res.status(500).send(error.message || 'internal Server Error');
+          res
+            .status(500)
+            .json({ message: error.message || 'internal server error' });
           next();
         });
     },
@@ -175,7 +179,9 @@ function setupInternalRoutes(
     await V1.getWorkflows(services.sonataFlowService, services.dataIndexService)
       .then(result => res.status(200).json(result))
       .catch(error => {
-        res.status(500).send(error.message || 'internal Server Error');
+        res
+          .status(500)
+          .json({ message: error.message || 'internal server error' });
       });
   });
 
@@ -184,7 +190,9 @@ function setupInternalRoutes(
     await V2.getWorkflows(services.sonataFlowService, services.dataIndexService)
       .then(result => res.json(result))
       .catch(error => {
-        res.status(500).send(error.message || 'internal Server Error');
+        res
+          .status(500)
+          .json({ message: error.message || 'internal server error' });
         next();
       });
   });
@@ -196,7 +204,9 @@ function setupInternalRoutes(
     await V1.getWorkflowById(services.sonataFlowService, workflowId)
       .then(result => res.status(200).json(result))
       .catch(error => {
-        res.status(500).send(error.message || 'Internal Server Error');
+        res
+          .status(500)
+          .json({ message: error.message || 'internal server error' });
       });
   });
 
@@ -207,7 +217,9 @@ function setupInternalRoutes(
     await V2.getWorkflowById(services.sonataFlowService, workflowId)
       .then(result => res.json(result))
       .catch(error => {
-        res.status(500).send(error.message || 'Internal Server Error');
+        res
+          .status(500)
+          .json({ message: error.message || 'internal server error' });
         next();
       });
   });
@@ -220,7 +232,9 @@ function setupInternalRoutes(
     await V1.abortWorkflow(services.dataIndexService, workflowId)
       .then(result => res.status(200).json(result.data))
       .catch(error => {
-        res.status(500).send(error.message || 'Internal Server Error');
+        res
+          .status(500)
+          .json({ message: error.message || 'internal server error' });
       });
   });
 
@@ -230,7 +244,9 @@ function setupInternalRoutes(
     await V2.abortWorkflow(services.dataIndexService, workflowId)
       .then(result => res.json(result))
       .catch(error => {
-        res.status(500).send(error.message || 'Internal Server Error');
+        res
+          .status(500)
+          .json({ message: error.message || 'internal server error' });
         next();
       });
   });
@@ -251,7 +267,9 @@ function setupInternalRoutes(
     )
       .then((result: any) => res.status(200).json(result))
       .catch((error: { message: any }) => {
-        res.status(500).send(error.message || 'Internal Server Error');
+        res
+          .status(500)
+          .json({ message: error.message || 'internal server error' });
       });
   });
 
@@ -275,7 +293,9 @@ function setupInternalRoutes(
       )
         .then(result => res.status(200).json(result))
         .catch((error: { message: string }) => {
-          res.status(500).send(error.message || 'Internal Server Error');
+          res
+            .status(500)
+            .json({ message: error.message || 'internal server error' });
         });
     },
   );
@@ -300,7 +320,9 @@ function setupInternalRoutes(
       )
         .then(result => res.status(200).json(result))
         .catch((error: { message: string }) => {
-          res.status(500).send(error.message || 'Internal Server Error');
+          res
+            .status(500)
+            .json({ message: error.message || 'internal server error' });
         });
     },
   );
@@ -331,7 +353,9 @@ function setupInternalRoutes(
     await V1.getInstances(services.dataIndexService)
       .then(result => res.status(200).json(result))
       .catch(error => {
-        res.status(500).send(error.message || 'internal Server Error');
+        res
+          .status(500)
+          .json({ message: error.message || 'internal server error' });
       });
   });
 
@@ -362,7 +386,9 @@ function setupInternalRoutes(
     )
       .then(result => res.status(200).json(result))
       .catch(error => {
-        res.status(500).send(error.message || 'Internal Server Error');
+        res
+          .status(500)
+          .json({ message: error.message || 'internal server error' });
       });
   });
 
@@ -382,7 +408,9 @@ function setupInternalRoutes(
       )
         .then(result => res.status(200).json(result))
         .catch(error => {
-          res.status(500).send(error.message || 'Internal Server Error');
+          res
+            .status(500)
+            .json({ message: error.message || 'internal server error' });
           next();
         });
     },
@@ -515,7 +543,9 @@ function setupInternalRoutes(
       await V2.getWorkflowResults(services.dataIndexService, instanceId)
         .then(result => res.status(200).json(result))
         .catch((error: { message: string }) => {
-          res.status(500).send(error.message || 'Internal Server Error');
+          res
+            .status(500)
+            .json({ message: error.message || 'internal server error' });
         });
     },
   );
@@ -527,7 +557,9 @@ function setupInternalRoutes(
       await V2.getWorkflowStatuses()
         .then(result => res.status(200).json(result))
         .catch((error: { message: string }) => {
-          res.status(500).send(error.message || 'Internal Server Error');
+          res
+            .status(500)
+            .json({ message: error.message || 'internal server error' });
         });
     },
   );

--- a/plugins/orchestrator-common/package.json
+++ b/plugins/orchestrator-common/package.json
@@ -35,7 +35,8 @@
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
-    "openapi": "./scripts/openapi.sh"
+    "openapi": "./scripts/openapi.sh",
+    "openapi:prettier:fix": "prettier --ignore-unknown --write ./src/auto-generated"
   },
   "dependencies": {
     "@backstage/types": "^1.1.1",

--- a/plugins/orchestrator-common/scripts/openapi.sh
+++ b/plugins/orchestrator-common/scripts/openapi.sh
@@ -14,3 +14,4 @@ echo '`' >> ${FILE}
 echo "export const openApiDocument = JSON.parse(OPENAPI);" >> ${FILE}
 
 rm ./src/openapi/openapi.json
+yarn openapi:prettier:fix

--- a/plugins/orchestrator-common/src/auto-generated/api/definition.ts
+++ b/plugins/orchestrator-common/src/auto-generated/api/definition.ts
@@ -35,9 +35,9 @@ const OPENAPI = `
           "500": {
             "description": "Error fetching workflow overviews",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -74,9 +74,9 @@ const OPENAPI = `
           "500": {
             "description": "Error fetching workflow overview",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -102,9 +102,9 @@ const OPENAPI = `
           "500": {
             "description": "Error fetching workflow list",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -141,9 +141,9 @@ const OPENAPI = `
           "500": {
             "description": "Error workflow by id",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -170,9 +170,9 @@ const OPENAPI = `
           "500": {
             "description": "Error fetching instances",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -209,9 +209,9 @@ const OPENAPI = `
           "500": {
             "description": "Error fetching instance",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -248,9 +248,9 @@ const OPENAPI = `
           "500": {
             "description": "Error getting workflow results",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -280,9 +280,9 @@ const OPENAPI = `
           "500": {
             "description": "Error fetching workflow statuses",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -329,9 +329,9 @@ const OPENAPI = `
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -369,9 +369,9 @@ const OPENAPI = `
           "500": {
             "description": "Error aborting workflow",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -382,6 +382,24 @@ const OPENAPI = `
   },
   "components": {
     "schemas": {
+      "ErrorResponse": {
+        "description": "The ErrorResponse object represents a common structure for handling errors in API responses. It includes essential information about the error, such as the error message and additional optional details.",
+        "type": "object",
+        "properties": {
+          "message": {
+            "description": "A string providing a concise and human-readable description of the encountered error. This field is required in the ErrorResponse object.",
+            "type": "string",
+            "default": "internal server error"
+          },
+          "additionalInfo": {
+            "description": "An optional field that can contain additional information or context about the error. It provides flexibility for including extra details based on specific error scenarios.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
       "WorkflowOverviewListResultDTO": {
         "type": "object",
         "properties": {

--- a/plugins/orchestrator-common/src/auto-generated/api/models/schema.ts
+++ b/plugins/orchestrator-common/src/auto-generated/api/models/schema.ts
@@ -59,6 +59,16 @@ export type webhooks = Record<string, never>;
 
 export interface components {
   schemas: {
+    /** @description The ErrorResponse object represents a common structure for handling errors in API responses. It includes essential information about the error, such as the error message and additional optional details. */
+    ErrorResponse: {
+      /**
+       * @description A string providing a concise and human-readable description of the encountered error. This field is required in the ErrorResponse object.
+       * @default internal server error
+       */
+      message: string;
+      /** @description An optional field that can contain additional information or context about the error. It provides flexibility for including extra details based on specific error scenarios. */
+      additionalInfo?: string;
+    };
     WorkflowOverviewListResultDTO: {
       overviews?: components['schemas']['WorkflowOverviewDTO'][];
       paginationInfo?: components['schemas']['PaginationInfoDTO'];
@@ -210,7 +220,7 @@ export interface operations {
       /** @description Error fetching workflow overviews */
       500: {
         content: {
-          'text/plain': string;
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
     };
@@ -233,7 +243,7 @@ export interface operations {
       /** @description Error fetching workflow overview */
       500: {
         content: {
-          'text/plain': string;
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
     };
@@ -250,7 +260,7 @@ export interface operations {
       /** @description Error fetching workflow list */
       500: {
         content: {
-          'text/plain': string;
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
     };
@@ -273,7 +283,7 @@ export interface operations {
       /** @description Error workflow by id */
       500: {
         content: {
-          'text/plain': string;
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
     };
@@ -293,7 +303,7 @@ export interface operations {
       /** @description Error fetching instances */
       500: {
         content: {
-          'text/plain': string;
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
     };
@@ -316,7 +326,7 @@ export interface operations {
       /** @description Error fetching instance */
       500: {
         content: {
-          'text/plain': string;
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
     };
@@ -339,7 +349,7 @@ export interface operations {
       /** @description Error getting workflow results */
       500: {
         content: {
-          'text/plain': string;
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
     };
@@ -359,7 +369,7 @@ export interface operations {
       /** @description Error fetching workflow statuses */
       500: {
         content: {
-          'text/plain': string;
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
     };
@@ -387,7 +397,7 @@ export interface operations {
       /** @description Internal Server Error */
       500: {
         content: {
-          'text/plain': string;
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
     };
@@ -413,7 +423,7 @@ export interface operations {
       /** @description Error aborting workflow */
       500: {
         content: {
-          'text/plain': string;
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
     };

--- a/plugins/orchestrator-common/src/auto-generated/docs/index.adoc/index.adoc
+++ b/plugins/orchestrator-common/src/auto-generated/docs/index.adoc/index.adoc
@@ -74,6 +74,7 @@ Aborts a workflow instance identified by the provided workflowId.
 ===== Content Type
 
 * text/plain
+* application/json
 
 ===== Responses
 
@@ -90,7 +91,7 @@ Aborts a workflow instance identified by the provided workflowId.
 
 | 500
 | Error aborting workflow
-|  <<String>>
+|  <<ErrorResponse>>
 
 |===
 
@@ -174,7 +175,6 @@ Execute a workflow
 ===== Content Type
 
 * application/json
-* text/plain
 
 ===== Responses
 
@@ -191,7 +191,7 @@ Execute a workflow
 
 | 500
 | Internal Server Error
-|  <<String>>
+|  <<ErrorResponse>>
 
 |===
 
@@ -262,7 +262,6 @@ Get Workflow Instance by ID
 ===== Content Type
 
 * application/json
-* text/plain
 
 ===== Responses
 
@@ -279,7 +278,7 @@ Get Workflow Instance by ID
 
 | 500
 | Error fetching instance
-|  <<String>>
+|  <<ErrorResponse>>
 
 |===
 
@@ -337,7 +336,6 @@ array[<<ProcessInstanceDTO>>]
 ===== Content Type
 
 * application/json
-* text/plain
 
 ===== Responses
 
@@ -354,7 +352,7 @@ array[<<ProcessInstanceDTO>>]
 
 | 500
 | Error fetching instances
-|  <<String>>
+|  <<ErrorResponse>>
 
 |===
 
@@ -425,7 +423,6 @@ Get a workflow by ID
 ===== Content Type
 
 * application/json
-* text/plain
 
 ===== Responses
 
@@ -442,7 +439,7 @@ Get a workflow by ID
 
 | 500
 | Error workflow by id
-|  <<String>>
+|  <<ErrorResponse>>
 
 |===
 
@@ -513,7 +510,6 @@ Get a workflow overview by ID
 ===== Content Type
 
 * application/json
-* text/plain
 
 ===== Responses
 
@@ -530,7 +526,7 @@ Get a workflow overview by ID
 
 | 500
 | Error fetching workflow overview
-|  <<String>>
+|  <<ErrorResponse>>
 
 |===
 
@@ -601,7 +597,6 @@ Get workflow results
 ===== Content Type
 
 * application/json
-* text/plain
 
 ===== Responses
 
@@ -618,7 +613,7 @@ Get workflow results
 
 | 500
 | Error getting workflow results
-|  <<String>>
+|  <<ErrorResponse>>
 
 |===
 
@@ -676,7 +671,6 @@ array[<<WorkflowRunStatusDTO>>]
 ===== Content Type
 
 * application/json
-* text/plain
 
 ===== Responses
 
@@ -693,7 +687,7 @@ array[<<WorkflowRunStatusDTO>>]
 
 | 500
 | Error fetching workflow statuses
-|  <<String>>
+|  <<ErrorResponse>>
 
 |===
 
@@ -751,7 +745,6 @@ Get a list of workflow
 ===== Content Type
 
 * application/json
-* text/plain
 
 ===== Responses
 
@@ -768,7 +761,7 @@ Get a list of workflow
 
 | 500
 | Error fetching workflow list
-|  <<String>>
+|  <<ErrorResponse>>
 
 |===
 
@@ -826,7 +819,6 @@ Get a list of workflow overviews
 ===== Content Type
 
 * application/json
-* text/plain
 
 ===== Responses
 
@@ -843,7 +835,7 @@ Get a list of workflow overviews
 
 | 500
 | Error fetching workflow overviews
-|  <<String>>
+|  <<ErrorResponse>>
 
 |===
 
@@ -893,6 +885,31 @@ endif::internal-generation[]
 | 
 | ProcessInstanceDTO 
 | 
+|  
+
+|===
+
+
+[#ErrorResponse]
+=== _ErrorResponse_ 
+
+The ErrorResponse object represents a common structure for handling errors in API responses. It includes essential information about the error, such as the error message and additional optional details.
+
+[.fields-ErrorResponse]
+[cols="2,1,2,4,1"]
+|===
+| Field Name| Required| Type| Description| Format
+
+| message
+| X
+| String 
+| A string providing a concise and human-readable description of the encountered error. This field is required in the ErrorResponse object.
+|  
+
+| additionalInfo
+| 
+| String 
+| An optional field that can contain additional information or context about the error. It provides flexibility for including extra details based on specific error scenarios.
 |  
 
 |===

--- a/plugins/orchestrator-common/src/openapi/openapi.yaml
+++ b/plugins/orchestrator-common/src/openapi/openapi.yaml
@@ -23,9 +23,9 @@ paths:
         '500':
           description: Error fetching workflow overviews
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
   /v2/workflows/{workflowId}/overview:
     get:
       operationId: getWorkflowOverviewById
@@ -47,9 +47,9 @@ paths:
         '500':
           description: Error fetching workflow overview
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
   /v2/workflows:
     get:
       operationId: getWorkflows
@@ -64,9 +64,9 @@ paths:
         '500':
           description: Error fetching workflow list
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
   /v2/workflows/{workflowId}:
     get:
       operationId: getWorkflowById
@@ -88,9 +88,9 @@ paths:
         '500':
           description: Error workflow by id
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
   /v2/workflows/instances:
     get:
       operationId: getInstances
@@ -106,9 +106,9 @@ paths:
         '500':
           description: Error fetching instances
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
   /v2/workflows/instances/{instanceId}:
     get:
       summary: Get Workflow Instance by ID
@@ -130,9 +130,9 @@ paths:
         '500':
           description: Error fetching instance
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
   /v2/workflows/instances/{instanceId}/results:
     get:
       summary: Get workflow results
@@ -154,9 +154,9 @@ paths:
         '500':
           description: Error getting workflow results
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
   /v2/workflows/instances/statuses:
     get:
       operationId: getWorkflowStatuses
@@ -174,9 +174,9 @@ paths:
         '500':
           description: Error fetching workflow statuses
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
   /v2/workflows/{workflowId}/execute:
     post:
       summary: Execute a workflow
@@ -204,9 +204,9 @@ paths:
         '500':
           description: Internal Server Error
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
   /v2/workflows/{workflowId}/abort:
     delete:
       summary: Abort a workflow instance
@@ -229,11 +229,30 @@ paths:
         '500':
           description: Error aborting workflow
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
+    ErrorResponse:
+      description:
+        The ErrorResponse object represents a common structure for handling errors in API responses.
+        It includes essential information about the error, such as the error message and additional optional details.
+      type: object
+      properties:
+        message:
+          description:
+            A string providing a concise and human-readable description of the encountered error.
+            This field is required in the ErrorResponse object.
+          type: string
+          default: internal server error
+        additionalInfo:
+          description:
+            An optional field that can contain additional information or context about the error.
+            It provides flexibility for including extra details based on specific error scenarios.
+          type: string
+      required:
+        - message
     WorkflowOverviewListResultDTO:
       type: object
       properties:

--- a/plugins/orchestrator-common/src/openapi/types.ts
+++ b/plugins/orchestrator-common/src/openapi/types.ts
@@ -1,5 +1,6 @@
 import { components } from '../auto-generated/api/models/schema';
 
+export type ErrorResponse = components['schemas']['ErrorResponse'];
 export type WorkflowOverviewListResultDTO =
   components['schemas']['WorkflowOverviewListResultDTO'];
 export type WorkflowOverviewDTO = components['schemas']['WorkflowOverviewDTO'];


### PR DESCRIPTION
https://issues.redhat.com/browse/FLPATH-1024

* Apply Prettier to auto-generated OpenAPI files during the generation phase to ensure consistent formatting.
* Refactor all v2 endpoint 500 responses to utilize the `ErrorResponse` object, enhancing readability and maintainability by replacing text/plain responses.
