### PR TITLE
fix(rbac): improve error handling in retrieving permission metadata.

### DIFF
--- a/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
@@ -60,8 +60,8 @@ describe('plugin-endpoint', () => {
       const collector = new PluginPermissionMetadataCollector(
         mockPluginEndpointDiscovery,
         backendPluginIDsProviderMock,
-        config,
         logger,
+        config,
       );
       const policiesMetadata = await collector.getPluginPolicies();
 
@@ -79,8 +79,8 @@ describe('plugin-endpoint', () => {
       const collector = new PluginPermissionMetadataCollector(
         mockPluginEndpointDiscovery,
         backendPluginIDsProviderMock,
-        config,
         logger,
+        config,
       );
       const policiesMetadata = await collector.getPluginPolicies();
 
@@ -109,8 +109,8 @@ describe('plugin-endpoint', () => {
       const collector = new PluginPermissionMetadataCollector(
         mockPluginEndpointDiscovery,
         backendPluginIDsProviderMock,
-        config,
         logger,
+        config,
       );
       const policiesMetadata = await collector.getPluginPolicies();
 
@@ -148,8 +148,8 @@ describe('plugin-endpoint', () => {
       const collector = new PluginPermissionMetadataCollector(
         mockPluginEndpointDiscovery,
         backendPluginIDsProviderMock,
-        config,
         logger,
+        config,
       );
       const policiesMetadata = await collector.getPluginPolicies();
 
@@ -163,7 +163,7 @@ describe('plugin-endpoint', () => {
       ]);
     });
 
-    it('should throw error when it is not possible to retrieve permission metadata for known endpoint', async () => {
+    it('should log error when it is not possible to retrieve permission metadata for known endpoint', async () => {
       backendPluginIDsProviderMock.getPluginIds.mockReturnValue([
         'permission',
         'catalog',
@@ -184,15 +184,68 @@ describe('plugin-endpoint', () => {
         '{"permissions":[{"type":"resource","name":"policy.entity.read","attributes":{"action":"read"}}]}',
       );
 
+      const errorSpy = jest.spyOn(logger, 'error').mockClear();
       const collector = new PluginPermissionMetadataCollector(
         mockPluginEndpointDiscovery,
         backendPluginIDsProviderMock,
-        config,
         logger,
+        config,
       );
-      await expect(collector.getPluginPolicies()).rejects.toThrow(
-        'Unexpected error',
+
+      const policiesMetadata = await collector.getPluginPolicies();
+
+      expect(policiesMetadata.length).toEqual(1);
+      expect(policiesMetadata[0].pluginId).toEqual('permission');
+      expect(policiesMetadata[0].policies).toEqual([
+        {
+          permission: 'policy.entity.read',
+          policy: 'read',
+        },
+      ]);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Failed to retrieve permission metadata for catalog. Error: Unexpected error',
       );
+    });
+
+    it('should not log error caused by non json permission metadata for known endpoint', async () => {
+      backendPluginIDsProviderMock.getPluginIds.mockReturnValue([
+        'permission',
+        'catalog',
+      ]);
+
+      mockUrlReaderService.readUrl = jest
+        .fn()
+        .mockImplementation(async (_wellKnownURL: string) => {
+          return mockReadUrlResponse;
+        });
+      bufferMock.toString
+        .mockReturnValueOnce(
+          '{"permissions":[{"type":"resource","name":"policy.entity.read","attributes":{"action":"read"}}]}',
+        )
+        .mockReturnValueOnce('non json data');
+
+      const errorSpy = jest.spyOn(logger, 'error').mockClear();
+
+      const collector = new PluginPermissionMetadataCollector(
+        mockPluginEndpointDiscovery,
+        backendPluginIDsProviderMock,
+        logger,
+        config,
+      );
+      const policiesMetadata = await collector.getPluginPolicies();
+
+      expect(policiesMetadata.length).toEqual(1);
+      expect(policiesMetadata[0].pluginId).toEqual('permission');
+      expect(policiesMetadata[0].policies).toEqual([
+        {
+          permission: 'policy.entity.read',
+          policy: 'read',
+        },
+      ]);
+
+      // workaround for https://issues.redhat.com/browse/RHIDP-1456
+      expect(errorSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -203,8 +256,8 @@ describe('plugin-endpoint', () => {
       const collector = new PluginPermissionMetadataCollector(
         mockPluginEndpointDiscovery,
         backendPluginIDsProviderMock,
-        config,
         logger,
+        config,
       );
       const conditionRulesMetadata = await collector.getPluginConditionRules();
 
@@ -222,8 +275,8 @@ describe('plugin-endpoint', () => {
       const collector = new PluginPermissionMetadataCollector(
         mockPluginEndpointDiscovery,
         backendPluginIDsProviderMock,
-        config,
         logger,
+        config,
       );
       const conditionRulesMetadata = await collector.getPluginConditionRules();
 

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -100,8 +100,8 @@ export class PolicesServer {
     const pluginPermMetaData = new PluginPermissionMetadataCollector(
       this.discovery,
       this.pluginIdProvider,
-      this.config,
       this.logger,
+      this.config,
     );
 
     router.use(permissionsIntegrationRouter);


### PR DESCRIPTION
### What does this pull request do

Log errors when requesting rbac-backend permission metadata instead of propagating them. Ignore errors caused by non-JSON responses during permission metadata retrieval.

### What are the issues referenced in the pull request?

Fixes: https://issues.redhat.com/browse/RHIDP-1453
Workaround for: https://issues.redhat.com/browse/RHIDP-1456