### PR TITLE
feat(rbac): query the catalog database when building graph

### DIFF
--- a/plugins/rbac-backend/src/file-permissions/csv.test.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv.test.ts
@@ -112,9 +112,15 @@ async function createEnforcer(
   log: Logger,
   tokenManager: TokenManager,
 ): Promise<Enforcer> {
+  const catalogDBClient = Knex.knex({ client: MockClient });
   const enf = await newEnforcer(theModel, adapter);
 
-  const rm = new BackstageRoleManager(catalogApi, log, tokenManager);
+  const rm = new BackstageRoleManager(
+    catalogApi,
+    log,
+    tokenManager,
+    catalogDBClient,
+  );
   enf.setRoleManager(rm);
   enf.enableAutoBuildRoleLinks(false);
   await enf.buildRoleLinks();

--- a/plugins/rbac-backend/src/role-manager/ancestor-search-memo.test.ts
+++ b/plugins/rbac-backend/src/role-manager/ancestor-search-memo.test.ts
@@ -1,0 +1,277 @@
+import { Entity } from '@backstage/catalog-model';
+
+import * as Knex from 'knex';
+import { createTracker, MockClient, Tracker } from 'knex-mock-client';
+
+import { AncestorSearchMemo, Relation } from './ancestor-search-memo';
+
+describe('ancestor-search-memo', () => {
+  const userRelations = [
+    {
+      source_entity_ref: 'user:default/adam',
+      target_entity_ref: 'group:default/team-a',
+    },
+  ];
+
+  const allRelations = [
+    {
+      source_entity_ref: 'user:default/adam',
+      target_entity_ref: 'group:default/team-a',
+    },
+    {
+      source_entity_ref: 'group:default/team-a',
+      target_entity_ref: 'group:default/team-b',
+    },
+    {
+      source_entity_ref: 'group:default/team-b',
+      target_entity_ref: 'group:default/team-c',
+    },
+    {
+      source_entity_ref: 'user:default/george',
+      target_entity_ref: 'group:default/team-d',
+    },
+    {
+      source_entity_ref: 'group:default/team-d',
+      target_entity_ref: 'group:default/team-e',
+    },
+    {
+      source_entity_ref: 'group:default/team-e',
+      target_entity_ref: 'group:default/team-f',
+    },
+  ];
+
+  const testGroups = [
+    createGroupEntity(
+      'group:default/team-a',
+      'group:default/team-b',
+      [],
+      ['adam'],
+    ),
+    createGroupEntity('group:default/team-b', 'group:default/team-c', [], []),
+    createGroupEntity('group:default/team-c', '', [], []),
+    createGroupEntity(
+      'group:default/team-d',
+      'group:default/team-e',
+      [],
+      ['george'],
+    ),
+    createGroupEntity('group:default/team-e', 'group:default/team-f', [], []),
+    createGroupEntity('group:default/team-f', '', [], []),
+  ];
+
+  const catalogApiMock: any = {
+    getEntities: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ items: testGroups })),
+  };
+
+  const catalogDBClient = Knex.knex({ client: MockClient });
+
+  const tokenManagerMock = {
+    getToken: jest.fn().mockImplementation(async () => {
+      return Promise.resolve({ token: 'some-token' });
+    }),
+    authenticate: jest.fn().mockImplementation(),
+  };
+
+  const asm = new AncestorSearchMemo(
+    'user:default/adam',
+    tokenManagerMock,
+    catalogApiMock,
+    catalogDBClient,
+  );
+
+  describe('getAllGroups and getAllRelations', () => {
+    let tracker: Tracker;
+
+    beforeAll(() => {
+      tracker = createTracker(catalogDBClient);
+    });
+
+    afterEach(() => {
+      tracker.reset();
+    });
+
+    it('should return all relations', async () => {
+      tracker.on
+        .select(
+          /select "source_entity_ref", "target_entity_ref" from "relations" where "type" = ?/,
+        )
+        .response(allRelations);
+      const allRelationsTest = await asm.getAllRelations();
+      expect(allRelationsTest).toEqual(allRelations);
+    });
+
+    it('should return all groups', async () => {
+      const allGroupsTest = await asm.getAllGroups();
+      // @ts-ignore
+      expect(allGroupsTest).toEqual(testGroups);
+    });
+
+    it('should fail to return anything when there is an error getting all relations', async () => {
+      const allRelationsTest = await asm.getAllRelations();
+      expect(allRelationsTest).toEqual([]);
+    });
+  });
+
+  describe('getUserGroups and getUserRelations', () => {
+    let tracker: Tracker;
+
+    beforeAll(() => {
+      tracker = createTracker(catalogDBClient);
+    });
+
+    afterEach(() => {
+      tracker.reset();
+    });
+
+    it('should return all user relations', async () => {
+      tracker.on
+        .select(
+          /select "source_entity_ref", "target_entity_ref" from "relations" where "type" = ?/,
+        )
+        .response(userRelations);
+      const relations = await asm.getUserRelations();
+
+      expect(relations).toEqual(userRelations);
+    });
+
+    it('should return all user groups', async () => {
+      tracker.on
+        .select(
+          /select "source_entity_ref", "target_entity_ref" from "relations" where "type" = ?/,
+        )
+        .response(userRelations);
+      const relations = await asm.getUserRelations();
+
+      expect(relations).toEqual(userRelations);
+    });
+
+    it('should fail to return anything when there is an error getting user relations', async () => {
+      const relations = await asm.getUserRelations();
+
+      expect(relations).toEqual([]);
+    });
+  });
+
+  describe('traverseRelations', () => {
+    let tracker: Tracker;
+
+    beforeAll(() => {
+      tracker = createTracker(catalogDBClient);
+    });
+
+    afterEach(() => {
+      tracker.reset();
+    });
+
+    // user:default/adam -> group:default/team-a -> group:default/team-b -> group:default/team-c
+    it('should build a graph for a particular user', async () => {
+      tracker.on
+        .select(
+          /select "source_entity_ref", "target_entity_ref" from "relations" where "type" = ?/,
+        )
+        .response(userRelations);
+      const userRelationsTest = await asm.getUserRelations();
+
+      tracker.reset();
+      tracker.on
+        .select(
+          /select "source_entity_ref", "target_entity_ref" from "relations" where "type" = ?/,
+        )
+        .response(allRelations);
+      const allRelationsTest = await asm.getAllRelations();
+
+      userRelationsTest.forEach(relation =>
+        asm.traverseRelations(
+          asm,
+          relation as Relation,
+          allRelationsTest as Relation[],
+        ),
+      );
+
+      expect(asm.hasEntityRef('user:default/adam')).toBeTruthy();
+      expect(asm.hasEntityRef('group:default/team-a')).toBeTruthy();
+      expect(asm.hasEntityRef('group:default/team-b')).toBeTruthy();
+      expect(asm.hasEntityRef('group:default/team-c')).toBeTruthy();
+      expect(asm.hasEntityRef('group:default/team-d')).toBeFalsy();
+    });
+  });
+
+  describe('buildUserGraph', () => {
+    let tracker: Tracker;
+
+    const asmUserGraph = new AncestorSearchMemo(
+      'user:default/adam',
+      tokenManagerMock,
+      catalogApiMock,
+      catalogDBClient,
+    );
+
+    const asmDBSpy = jest
+      .spyOn(asmUserGraph, 'doesRelationTableExist')
+      .mockImplementation(() => Promise.resolve(true));
+
+    beforeAll(() => {
+      tracker = createTracker(catalogDBClient);
+    });
+
+    afterEach(() => {
+      tracker.reset();
+    });
+
+    // user:default/adam -> group:default/team-a -> group:default/team-b -> group:default/team-c
+    it('should build the user graph using relations table', async () => {
+      tracker.on
+        .select(
+          /select "source_entity_ref", "target_entity_ref" from "relations" where "type" = ?/,
+        )
+        .response(userRelations);
+      tracker.reset();
+      tracker.on
+        .select(
+          /select "source_entity_ref", "target_entity_ref" from "relations" where "type" = ?/,
+        )
+        .response(allRelations);
+      await asmUserGraph.buildUserGraph(asmUserGraph);
+
+      expect(asmDBSpy).toHaveBeenCalled();
+      expect(asm.hasEntityRef('user:default/adam')).toBeTruthy();
+      expect(asm.hasEntityRef('group:default/team-a')).toBeTruthy();
+      expect(asm.hasEntityRef('group:default/team-b')).toBeTruthy();
+      expect(asm.hasEntityRef('group:default/team-c')).toBeTruthy();
+      expect(asm.hasEntityRef('group:default/team-d')).toBeFalsy();
+    });
+  });
+
+  function createGroupEntity(
+    name: string,
+    parent?: string,
+    children?: string[],
+    members?: string[],
+  ): Entity {
+    const entity: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name,
+        namespace: 'default',
+      },
+      spec: {},
+    };
+
+    if (children) {
+      entity.spec!.children = children;
+    }
+
+    if (members) {
+      entity.spec!.members = members;
+    }
+
+    if (parent) {
+      entity.spec!.parent = parent;
+    }
+
+    return entity;
+  }
+});

--- a/plugins/rbac-backend/src/role-manager/role-list.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-list.test.ts
@@ -1,10 +1,16 @@
 import { RoleList } from './role-list';
 
 describe('RoleList', () => {
-  const roleList = new RoleList('user:default/adam');
-  const newRole = new RoleList('role:default/test');
-  const extraRole = new RoleList('role:default/extra');
-  roleList.addRole(extraRole);
+  let roleList: RoleList;
+  let newRole: RoleList;
+  let extraRole: RoleList;
+
+  beforeEach(() => {
+    roleList = new RoleList('user:default/adam');
+    newRole = new RoleList('role:default/test');
+    extraRole = new RoleList('role:default/extra');
+    roleList.addRole(extraRole);
+  });
 
   describe('addRole', () => {
     it('should add a role', () => {
@@ -19,11 +25,18 @@ describe('RoleList', () => {
 
       expect(roleList.hasRole('role:default/test', 1)).toEqual(true);
       expect(roleList.hasRole('role:default/does-not-exist', 1)).toEqual(false);
+      expect(roleList.getRoles().length).toEqual(2);
+
+      roleList.addRole(newRole);
+
+      expect(roleList.getRoles().length).toEqual(2);
     });
   });
 
   describe('getRoles', () => {
     it('should return all roles', () => {
+      roleList.addRole(newRole);
+
       const allRoles = roleList.getRoles();
       expect(allRoles).toEqual([extraRole, newRole]);
     });
@@ -31,6 +44,10 @@ describe('RoleList', () => {
 
   describe('deleteRole', () => {
     it('should remove a role', () => {
+      roleList.addRole(newRole);
+
+      expect(roleList.hasRole('role:default/test', 1)).toEqual(true);
+
       roleList.deleteRole(newRole);
 
       expect(roleList.hasRole('role:default/test', 1)).toEqual(false);

--- a/plugins/rbac-backend/src/role-manager/role-list.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-list.test.ts
@@ -1,0 +1,40 @@
+import { RoleList } from './role-list';
+
+describe('RoleList', () => {
+  const roleList = new RoleList('user:default/adam');
+  const newRole = new RoleList('role:default/test');
+  const extraRole = new RoleList('role:default/extra');
+  roleList.addRole(extraRole);
+
+  describe('addRole', () => {
+    it('should add a role', () => {
+      roleList.addRole(newRole);
+
+      expect(roleList.hasRole('role:default/test', 1)).toEqual(true);
+      expect(roleList.hasRole('role:default/does-not-exist', 1)).toEqual(false);
+    });
+
+    it('should not add a duplicate of an existing role', () => {
+      roleList.addRole(newRole);
+
+      expect(roleList.hasRole('role:default/test', 1)).toEqual(true);
+      expect(roleList.hasRole('role:default/does-not-exist', 1)).toEqual(false);
+    });
+  });
+
+  describe('getRoles', () => {
+    it('should return all roles', () => {
+      const allRoles = roleList.getRoles();
+      expect(allRoles).toEqual([extraRole, newRole]);
+    });
+  });
+
+  describe('deleteRole', () => {
+    it('should remove a role', () => {
+      roleList.deleteRole(newRole);
+
+      expect(roleList.hasRole('role:default/test', 1)).toEqual(false);
+      expect(roleList.hasRole('role:default/does-not-exist', 1)).toEqual(false);
+    });
+  });
+});

--- a/plugins/rbac-backend/src/role-manager/role-manager.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.test.ts
@@ -613,7 +613,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-b',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
 
       result = await roleManager.hasLink(
@@ -622,7 +622,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
     });
 
@@ -658,7 +658,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-b',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
 
       result = await roleManager.hasLink(
@@ -667,7 +667,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
     });
 
@@ -703,7 +703,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-c',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
 
       result = await roleManager.hasLink(
@@ -712,7 +712,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-b',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
 
       result = await roleManager.hasLink(
@@ -721,7 +721,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
     });
 
@@ -761,7 +761,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-c',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
 
       result = await roleManager.hasLink(
@@ -770,7 +770,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-b',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
 
       result = await roleManager.hasLink(
@@ -779,7 +779,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
     });
 
@@ -814,7 +814,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-c"]]',
       );
     });
 
@@ -852,7 +852,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-c"]]',
       );
     });
 
@@ -916,7 +916,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-e',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-c"]]',
       );
 
       const test = await roleManager.hasLink(
@@ -1043,7 +1043,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-c"]]',
       );
 
       result = await roleManager.hasLink(
@@ -1111,7 +1111,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-c"]]',
       );
 
       result = await roleManager.hasLink(

--- a/plugins/rbac-backend/src/role-manager/role-manager.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.test.ts
@@ -2,11 +2,15 @@ import { TokenManager } from '@backstage/backend-common';
 import { CatalogApi } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 
+import * as Knex from 'knex';
+import { MockClient } from 'knex-mock-client';
 import { Logger } from 'winston';
 
 import { BackstageRoleManager } from '../role-manager/role-manager';
 
 describe('BackstageRoleManager', () => {
+  const catalogDBClient = Knex.knex({ client: MockClient });
+
   const catalogApiMock: any = {
     getEntities: jest
       .fn()
@@ -31,6 +35,7 @@ describe('BackstageRoleManager', () => {
       catalogApiMock as CatalogApi,
       loggerMock as Logger,
       tokenManagerMock as TokenManager,
+      catalogDBClient,
     );
   });
 
@@ -71,6 +76,10 @@ describe('BackstageRoleManager', () => {
   });
 
   describe('hasLink tests', () => {
+    afterEach(() => {
+      (loggerMock.warn as jest.Mock).mockReset();
+    });
+
     it('should throw an error for unsupported domain', async () => {
       await expect(
         roleManager.hasLink(
@@ -649,7 +658,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-b',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-b',
       );
 
       result = await roleManager.hasLink(
@@ -658,7 +667,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-a',
       );
     });
 
@@ -752,7 +761,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-c',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-c',
       );
 
       result = await roleManager.hasLink(
@@ -761,7 +770,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-b',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-b',
       );
 
       result = await roleManager.hasLink(
@@ -770,7 +779,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-a',
       );
     });
 
@@ -843,7 +852,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-a',
       );
     });
 
@@ -907,7 +916,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-e',
       );
 
       const test = await roleManager.hasLink(
@@ -1102,7 +1111,7 @@ describe('BackstageRoleManager', () => {
       );
       expect(result).toBeFalsy();
       expect(loggerMock.warn).toHaveBeenCalledWith(
-        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: group:default/team-a',
+        'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-c"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: role:default/team-a',
       );
 
       result = await roleManager.hasLink(

--- a/plugins/rbac-backend/src/role-manager/role-manager.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.ts
@@ -109,7 +109,9 @@ export class BackstageRoleManager implements RoleManager {
       this.log.warn(
         `Detected cycle dependencies in the Group graph: ${JSON.stringify(
           cycles,
-        )}. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for group: ${name2}`,
+        )}. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: ${JSON.stringify(
+          cycles,
+        )}`,
       );
 
       return false;

--- a/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -108,9 +108,15 @@ describe('EnforcerDelegate', () => {
       dbManagerMock,
     ).createAdapter();
 
+    const catalogDBClient = Knex.knex({ client: MockClient });
     const enf = await newEnforcer(theModel, sqliteInMemoryAdapter);
 
-    const rm = new BackstageRoleManager(catalogApi, logger, tokenManagerMock);
+    const rm = new BackstageRoleManager(
+      catalogApi,
+      logger,
+      tokenManagerMock,
+      catalogDBClient,
+    );
     enf.setRoleManager(rm);
     enf.enableAutoBuildRoleLinks(false);
     await enf.buildRoleLinks();

--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -123,9 +123,15 @@ async function createEnforcer(
   logger: Logger,
   tokenManager: TokenManager,
 ): Promise<Enforcer> {
+  const catalogDBClient = Knex.knex({ client: MockClient });
   const enf = await newEnforcer(theModel, adapter);
 
-  const rm = new BackstageRoleManager(catalogApi, logger, tokenManager);
+  const rm = new BackstageRoleManager(
+    catalogApi,
+    logger,
+    tokenManager,
+    catalogDBClient,
+  );
   enf.setRoleManager(rm);
   enf.enableAutoBuildRoleLinks(false);
   await enf.buildRoleLinks();

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -52,10 +52,14 @@ export class PolicyBuilder {
     enf.enableAutoSave(true);
 
     const catalogClient = new CatalogClient({ discoveryApi: env.discovery });
+    const catalogDBClient = await DatabaseManager.fromConfig(env.config)
+      .forPlugin('catalog')
+      .getClient();
     const rm = new BackstageRoleManager(
       catalogClient,
       env.logger,
       env.tokenManager,
+      catalogDBClient,
     );
     enf.setRoleManager(rm);
     enf.enableAutoBuildRoleLinks(false);


### PR DESCRIPTION
## Description

As part of the work to increase the performance of the RBAC backend plugin, this PR further reduces the number of catalog api calls to zero by instead attempting to query the catalog database table 'relations'. This relations table contains all of the relations between two entities within the catalog. We can query this table to retrieve relations of 'memberOf' for a specified user and 'childOf' for groups that have parents. We can then begin to build the graph using this minimum amount of information.

Went in and fixed the broken tests to now work. Also, fixed an issue with the logger mock within the `role-manager.test.ts` not being reset after each test. Now, the correct log statements will show up ensuring that we have accurate tests. Also, renamed `enforcer.delegate.test.ts` to `enforcer-delegate.test.ts` to match the format of other test file names.

Added additional tests to cover the new methods added to the `AncestorSearchMemo` as well as added some missing tests for `RoleList`. In `ancestor-search-memo.test.ts`, I opted for a simple graph when testing `traverseRelations` and `buildUserGraph`. My reasoning for this is because the logic for `traverseRelations` is very similar to `traverseGroups` where we already have some fairly in depth graphs for testing. The only difference as of right now is that the `traverseRelations` graph will start with the user whereas the `traverseGroups` graph will start with the groups that the user is associated with.

EX traverse relations -
```
         -> group-a -> group-c
user -> |
         -> group-b -> goup-d
```

EX traverse groups - 
```
group-a -> group-c

group-b -> goup-d
```