### PR TITLE
fix(orchestrator): walk around the state field is empty issue when fetch instance

### DIFF
--- a/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
@@ -105,7 +105,8 @@ export const WorkflowInstancePage = ({
     (curValue: AssessedProcessInstance | undefined) =>
       !!curValue &&
       (curValue.instance.state === 'ACTIVE' ||
-        curValue.instance.state === 'PENDING'),
+        curValue.instance.state === 'PENDING' ||
+        curValue.instance.hasOwnProperty('state')),
   );
 
   const canAbort = React.useMemo(


### PR DESCRIPTION
Jira: [https://issues.redhat.com/browse/FLPATH-1060](https://issues.redhat.com/browse/FLPATH-1060)

When run workflow the `state` field of the `instance` object could be `null`, but actually it should not be. We walk around it in this fix.