### PR TITLE
fix: text filtering in Notifications

### DIFF
--- a/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
@@ -137,6 +137,9 @@ export const NotificationsTable = ({
   const compactColumns = React.useMemo(
     (): TableColumn<Notification>[] => [
       {
+        customFilterAndSearch: () =>
+          true /* Keep it on backend due to pagination. If recent flickering is an issue, implement search here as well. */,
+
         // Compact content
         render: (notification: Notification) => {
           return (


### PR DESCRIPTION
The filtering used to be done twice - by both the BE and the FE. Since we stopped using a regular table, the FE filtering did not find match and so filtered-out all the messages.

With this fix, just the BE performs the filter.

Fixes: [FLPATH-1067](https://issues.redhat.com//browse/FLPATH-1067)