### PR TITLE
fix(rbac): remove admin metadata, when all admins removed from config

### DIFF
--- a/plugins/rbac-backend/src/helper.test.ts
+++ b/plugins/rbac-backend/src/helper.test.ts
@@ -90,7 +90,7 @@ describe('helper.ts', () => {
       expect(mockEnforcerDelegate.removeGroupingPolicy).toHaveBeenCalledWith(
         ['user:default/admin', roleName],
         source,
-        true,
+        false,
       );
     });
 

--- a/plugins/rbac-backend/src/helper.ts
+++ b/plugins/rbac-backend/src/helper.ts
@@ -35,7 +35,7 @@ export async function removeTheDifference(
 
   for (const missingRole of missing) {
     const role = [missingRole, roleName];
-    await enf.removeGroupingPolicy(role, source, true);
+    await enf.removeGroupingPolicy(role, source, false);
   }
 }
 

--- a/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -390,7 +390,6 @@ export class EnforcerDelegate {
     const trx = externalTrx ?? (await this.knex.transaction());
     try {
       for (const policy of policies) {
-        const roleEntity = policy[1];
         await this.checkIfPolicyModifiable(
           policy,
           source,

--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -431,7 +431,12 @@ describe('RBACPermissionPolicy Tests', () => {
 
       expect(await enf.getAllRoles()).toEqual(allEnfRoles);
 
-      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
+      const nonAdminPolicies = (await enf.getPolicy()).filter(
+        (policy: string[]) => {
+          return policy[0] !== 'role:default/rbac_admin';
+        },
+      );
+      expect(nonAdminPolicies).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(
@@ -495,7 +500,10 @@ describe('RBACPermissionPolicy Tests', () => {
 
       expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
+      const nonAdminPolicies = (await enf.getPolicy()).filter((p: string[]) => {
+        return p[0] !== 'role:default/rbac_admin';
+      });
+      expect(nonAdminPolicies).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(
@@ -586,7 +594,12 @@ describe('RBACPermissionPolicy Tests', () => {
 
       expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
+      const nonAdminPolicies = (await enf.getPolicy()).filter(
+        (policy: string[]) => {
+          return policy[0] !== 'role:default/rbac_admin';
+        },
+      );
+      expect(nonAdminPolicies).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(
@@ -667,7 +680,12 @@ describe('RBACPermissionPolicy Tests', () => {
 
       expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
+      const nonAdminPolicies = (await enf.getPolicy()).filter(
+        (policy: string[]) => {
+          return policy[0] !== 'role:default/rbac_admin';
+        },
+      );
+      expect(nonAdminPolicies).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(
@@ -731,7 +749,12 @@ describe('RBACPermissionPolicy Tests', () => {
 
       expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
+      const nonAdminPolicies = (await enf.getPolicy()).filter(
+        (policy: string[]) => {
+          return policy[0] !== 'role:default/rbac_admin';
+        },
+      );
+      expect(nonAdminPolicies).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(
@@ -810,7 +833,12 @@ describe('RBACPermissionPolicy Tests', () => {
 
       expect(await enf.getGroupingPolicy()).toEqual(allEnfGroupPolicies);
 
-      expect(await enf.getPolicy()).toEqual(allEnfPolicies);
+      const nonAdminPolicies = (await enf.getPolicy()).filter(
+        (policy: string[]) => {
+          return policy[0] !== 'role:default/rbac_admin';
+        },
+      );
+      expect(nonAdminPolicies).toEqual(allEnfPolicies);
 
       // policy metadata should to be removed
       expect(policyMetadataStorage.removePolicyMetadata).toHaveBeenCalledTimes(

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -185,9 +185,12 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     );
     await setAdminPermissions(enforcerDelegate);
 
-    if (!adminUsers || adminUsers.length === 0) {
+    if (
+      (!adminUsers || adminUsers.length === 0) &&
+      (!superUsers || superUsers.length === 0)
+    ) {
       logger.warn(
-        'There are no admins configured for the RBAC-backend plugin.',
+        'There are no admins or super admins configured for the RBAC-backend plugin.',
       );
     }
 

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -177,17 +177,17 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       }
     }
 
-    if (adminUsers && adminUsers.length > 0) {
-      await useAdminsFromConfig(
-        adminUsers,
-        enforcerDelegate,
-        roleMetadataStorage,
-        knex,
-      );
-      await setAdminPermissions(enforcerDelegate);
-    } else {
+    await useAdminsFromConfig(
+      adminUsers || [],
+      enforcerDelegate,
+      roleMetadataStorage,
+      knex,
+    );
+    await setAdminPermissions(enforcerDelegate);
+
+    if (!adminUsers || adminUsers.length === 0) {
       logger.warn(
-        'There are no admins configured for the RBAC-backend plugin. The plugin may not work properly.',
+        'There are no admins configured for the RBAC-backend plugin.',
       );
     }
 

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -127,6 +127,8 @@ const mockEnforcer: Partial<EnforcerDelegate> = {
   updatePolicies: jest.fn().mockImplementation(),
 
   updateGroupingPolicies: jest.fn().mockImplementation(),
+
+  addOrUpdateGroupingPolicies: jest.fn().mockImplementation(),
 };
 
 const roleMetadataStorageMock: RoleMetadataStorage = {


### PR DESCRIPTION
# What does this pull request do

1) remove admin metadata, when all admins removed from config
2) remove role metadata, when it really unused
3) change log message, when admin or super-admin list is absent

### What issue is referenced in this pull request?

https://issues.redhat.com/browse/RHIDP-1506
