### PR TITLE
fix(ocm): prevent error when ManagedCluster.status doesn't contain a 'clusterClaims' field

### DIFF
--- a/plugins/ocm-backend/src/helpers/parser.test.ts
+++ b/plugins/ocm-backend/src/helpers/parser.test.ts
@@ -57,6 +57,18 @@ describe('getClaim', () => {
 
     expect(result).toEqual('');
   });
+
+  it('should return empty string when clusterClaims is undefined', () => {
+    const cluster: any = {
+      status: {
+        clusterClaims: undefined,
+      },
+    };
+
+    const result = getClaim(cluster, 'any');
+
+    expect(result).toEqual('');
+  });
 });
 
 describe('parseResources', () => {

--- a/plugins/ocm-backend/src/helpers/parser.ts
+++ b/plugins/ocm-backend/src/helpers/parser.ts
@@ -31,7 +31,7 @@ export const getClaim = (
   cluster: { status?: { clusterClaims: ClusterClaim[] } },
   claimName: string,
 ): string =>
-  cluster.status?.clusterClaims.find(value => value.name === claimName)
+  cluster.status?.clusterClaims?.find(value => value.name === claimName)
     ?.value || '';
 
 export const parseClusterStatus = (mc: ManagedCluster): ClusterStatus => {


### PR DESCRIPTION
Error:
When a ManagerCluster API response lacks the `status.clusterClaims` then the error `Cannot read properties of undefined (reading 'find')` is displayed on the UI.

Fix: Just make sure that `clusterClaims` is checked before calling `find` ;