### PR TITLE
fix(rbac): rework condition policies to bound them to RBAC roles

### DIFF
--- a/plugins/rbac-backend/docs/apis.md
+++ b/plugins/rbac-backend/docs/apis.md
@@ -732,7 +732,7 @@ To utilize this condition to the RBAC REST api you need to wrap it with more inf
 
 ### POST condition
 
-POST </api/permission/conditions>
+POST </api/permission/roles/conditions>
 
 Creates a new condition.
 
@@ -769,7 +769,7 @@ Returns a status code of 201 and json with id upon success:
 
 ### PUT condition
 
-PUT </permission/conditions/:id>
+PUT </permission/roles/conditions/:id>
 
 Update conditions by id.
 
@@ -811,7 +811,7 @@ Returns a status code of 200 upon success.
 
 ### Get condition by id
 
-GET </api/permission/conditions/:id>
+GET </api/permission/roles/conditions/:id>
 
 Returns condition by id:
 
@@ -850,7 +850,7 @@ Returns a status code of 200 upon success.
 
 ### GET conditions
 
-GET </api/permission/conditions>
+GET </api/permission/roles/conditions>
 
 Returns lists all conditions:
 
@@ -891,7 +891,7 @@ Returns a status code of 200 upon success.
 
 ### DELETE condition by id
 
-DELETE </api/permission/conditions/:id>
+DELETE </api/permission/roles/conditions/:id>
 
 Deletes condition by id.
 

--- a/plugins/rbac-backend/migrations/20240308134410_migrations.js
+++ b/plugins/rbac-backend/migrations/20240308134410_migrations.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  const policyConditionsExist = await knex.schema.hasTable('policy-conditions');
+
+  if (policyConditionsExist) {
+    // We drop policy condition table, because we decided to rework this feature
+    // and bound policy condition to the role
+    await knex.schema.dropTable('policy-conditions');
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(_knex) {};

--- a/plugins/rbac-backend/migrations/20240308134941_migrations.js
+++ b/plugins/rbac-backend/migrations/20240308134941_migrations.js
@@ -11,7 +11,7 @@ exports.up = async function up(knex) {
     table.string('result');
     table.string('pluginId');
     table.string('resourceType');
-    table.string('actions');
+    table.string('permissions');
     // Conditions is potentially long json.
     // In the future maybe we can use `json` or `jsonb` type instead of `text`:
     // table.json('conditions') or table.jsonb('conditions').

--- a/plugins/rbac-backend/migrations/20240308134941_migrations.js
+++ b/plugins/rbac-backend/migrations/20240308134941_migrations.js
@@ -11,6 +11,7 @@ exports.up = async function up(knex) {
     table.string('result');
     table.string('pluginId');
     table.string('resourceType');
+    table.string('actions');
     // Conditions is potentially long json.
     // In the future maybe we can use `json` or `jsonb` type instead of `text`:
     // table.json('conditions') or table.jsonb('conditions').

--- a/plugins/rbac-backend/migrations/20240308134941_migrations.js
+++ b/plugins/rbac-backend/migrations/20240308134941_migrations.js
@@ -1,0 +1,32 @@
+/**
+ * up - runs migration.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('role-condition-policies', table => {
+    table.increments('id').primary();
+    table.string('roleEntityRef');
+    table.string('result');
+    table.string('pluginId');
+    table.string('resourceType');
+    // Conditions is potentially long json.
+    // In the future maybe we can use `json` or `jsonb` type instead of `text`:
+    // table.json('conditions') or table.jsonb('conditions').
+    // But let's start with text type.
+    // Data type "text" can be unlimited by size for Postgres.
+    // Also postgres has a lot of build in features for this data type.
+    table.text('conditionsJson');
+  });
+};
+
+/**
+ * down - reverts(undo) migration.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.dropTable('policy-conditions');
+};

--- a/plugins/rbac-backend/src/database/conditional-storage.ts
+++ b/plugins/rbac-backend/src/database/conditional-storage.ts
@@ -189,12 +189,11 @@ export class DataBaseConditionalStorage implements ConditionalStorage {
           perm => perm.name,
         );
         if (conditionPermNames.includes(permission.name)) {
-          // todo maybe bug here...
           throw new ConflictError(
-            `Found condition with conflicted action '${JSON.stringify(
+            `Found condition with conflicted permission '${JSON.stringify(
               permission,
             )}'. Role could have multiple ` +
-              `conditions for the same resource type '${conditionalDecision.resourceType}', but with different action sets.`,
+              `conditions for the same resource type '${conditionalDecision.resourceType}', but with different permission name sets.`,
           );
         }
       }

--- a/plugins/rbac-backend/src/database/conditional-storage.ts
+++ b/plugins/rbac-backend/src/database/conditional-storage.ts
@@ -8,9 +8,9 @@ import {
   RoleConditionalPolicyDecision,
 } from '@janus-idp/backstage-plugin-rbac-common';
 
-const CONDITIONAL_TABLE = 'role-condition-policies';
+export const CONDITIONAL_TABLE = 'role-condition-policies';
 
-interface ConditionalPolicyDecisionDAO {
+export interface ConditionalPolicyDecisionDAO {
   result: AuthorizeResult.CONDITIONAL;
   id?: number;
   roleEntityRef: string;
@@ -90,13 +90,9 @@ export class DataBaseConditionalStorage implements ConditionalStorage {
     );
     if (condition) {
       throw new ConflictError(
-        `A condition with resource type ${
-          condition.resourceType
-        } and actions ${JSON.stringify(
-          condition.actions,
-        )} has already been stored for role ${
-          conditionalDecision.roleEntityRef
-        }`,
+        `A condition with resource type '${condition.resourceType}'` +
+          ` and actions '${JSON.stringify(condition.actions)}'` +
+          ` has already been stored for role '${conditionalDecision.roleEntityRef}'`,
       );
     }
 

--- a/plugins/rbac-backend/src/database/conditional.storage.test.ts
+++ b/plugins/rbac-backend/src/database/conditional.storage.test.ts
@@ -251,7 +251,7 @@ describe('DataBaseConditionalStorage', () => {
           await db.createCondition(condition1);
         }).rejects.toThrow(
           `A condition with resource type 'catalog-entity'` +
-            ` and permission names '[\"catalog.entity.read\"]'` +
+            ` and permission names '["catalog.entity.read"]'` +
             ` has already been stored for role 'role:default/test'`,
         );
       },
@@ -438,7 +438,7 @@ describe('DataBaseConditionalStorage', () => {
         await expect(async () => {
           await db.updateCondition(1, updateCondition);
         }).rejects.toThrow(
-          `Found condition with conflicted action '{\"name\":\"catalog.entity.delete\",\"action\":\"delete\"}'. Role could have multiple ` +
+          `Found condition with conflicted action '{"name":"catalog.entity.delete","action":"delete"}'. Role could have multiple ` +
             `conditions for the same resource type 'catalog-entity', but with different action sets.`,
         );
       },

--- a/plugins/rbac-backend/src/database/conditional.storage.test.ts
+++ b/plugins/rbac-backend/src/database/conditional.storage.test.ts
@@ -438,8 +438,8 @@ describe('DataBaseConditionalStorage', () => {
         await expect(async () => {
           await db.updateCondition(1, updateCondition);
         }).rejects.toThrow(
-          `Found condition with conflicted action '{"name":"catalog.entity.delete","action":"delete"}'. Role could have multiple ` +
-            `conditions for the same resource type 'catalog-entity', but with different action sets.`,
+          `Found condition with conflicted permission '{"name":"catalog.entity.delete","action":"delete"}'. Role could have multiple ` +
+            `conditions for the same resource type 'catalog-entity', but with different permission name sets.`,
         );
       },
     );

--- a/plugins/rbac-backend/src/database/conditional.storage.test.ts
+++ b/plugins/rbac-backend/src/database/conditional.storage.test.ts
@@ -1,0 +1,436 @@
+import { PluginDatabaseManager } from '@backstage/backend-common';
+import { TestDatabaseId, TestDatabases } from '@backstage/backend-test-utils';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+
+import * as Knex from 'knex';
+import { createTracker, MockClient } from 'knex-mock-client';
+
+import { RoleConditionalPolicyDecision } from '@janus-idp/backstage-plugin-rbac-common';
+
+import {
+  CONDITIONAL_TABLE,
+  ConditionalPolicyDecisionDAO,
+  DataBaseConditionalStorage,
+} from './conditional-storage';
+import { migrate } from './migration';
+
+jest.setTimeout(60000);
+
+describe('DataBaseConditionalStorage', () => {
+  const databases = TestDatabases.create({
+    ids: ['POSTGRES_13', 'SQLITE_3'],
+  });
+
+  const conditionDao1: ConditionalPolicyDecisionDAO = {
+    pluginId: 'catalog',
+    resourceType: 'catalog-entity',
+    actions: '["read"]',
+    roleEntityRef: 'role:default/test',
+    result: AuthorizeResult.CONDITIONAL,
+    conditionsJson:
+      `{` +
+      `"rule":"IS_ENTITY_OWNER",` +
+      `"resourceType":"catalog-entity",` +
+      `"params":{"claims":["group:default/test-group"]}` +
+      `}`,
+  };
+  const conditionDao2: ConditionalPolicyDecisionDAO = {
+    pluginId: 'test',
+    resourceType: 'test-entity',
+    actions: '["delete"]',
+    roleEntityRef: 'role:default/test-2',
+    result: AuthorizeResult.CONDITIONAL,
+    conditionsJson:
+      `{` +
+      `"rule": "IS_ENTITY_OWNER",` +
+      `"resourceType": "test-entity",` +
+      `"params": {"claims": ["group:default/test-group"]}` +
+      `}`,
+  };
+  const condition1: RoleConditionalPolicyDecision = {
+    id: 1,
+    pluginId: 'catalog',
+    resourceType: 'catalog-entity',
+    actions: ['read'],
+    roleEntityRef: 'role:default/test',
+    result: AuthorizeResult.CONDITIONAL,
+    conditions: {
+      rule: 'IS_ENTITY_OWNER',
+      resourceType: 'catalog-entity',
+      params: {
+        claims: ['group:default/test-group'],
+      },
+    },
+  };
+  const condition2: RoleConditionalPolicyDecision = {
+    id: 2,
+    pluginId: 'test',
+    resourceType: 'test-entity',
+    actions: ['delete'],
+    roleEntityRef: 'role:default/test-2',
+    result: AuthorizeResult.CONDITIONAL,
+    conditions: {
+      rule: 'IS_ENTITY_OWNER',
+      resourceType: 'test-entity',
+      params: {
+        claims: ['group:default/test-group'],
+      },
+    },
+  };
+
+  async function createDatabase(databaseId: TestDatabaseId) {
+    const knex = await databases.init(databaseId);
+    const databaseManagerMock: PluginDatabaseManager = {
+      getClient: jest.fn(() => {
+        return Promise.resolve(knex);
+      }),
+      migrations: { skip: false },
+    };
+
+    await migrate(databaseManagerMock);
+    return {
+      knex,
+      db: new DataBaseConditionalStorage(knex),
+    };
+  }
+
+  describe('filterConditions', () => {
+    it.each(databases.eachSupportedId())(
+      'should return all conditions',
+      async databaseId => {
+        const { knex, db } = await createDatabase(databaseId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao2,
+        );
+
+        const conditions = await db.filterConditions();
+        expect(conditions.length).toEqual(2);
+
+        expect(conditions[0]).toEqual(condition1);
+        expect(conditions[1]).toEqual(condition2);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return condition by roleEntityRef',
+      async databaseId => {
+        const { knex, db } = await createDatabase(databaseId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao2,
+        );
+
+        const conditions = await db.filterConditions(`role:default/test`);
+        expect(conditions.length).toEqual(1);
+
+        expect(conditions[0]).toEqual(condition1);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return condition by pluginId',
+      async databaseId => {
+        const { knex, db } = await createDatabase(databaseId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao2,
+        );
+
+        const conditions = await db.filterConditions(undefined, 'catalog');
+        expect(conditions.length).toEqual(1);
+
+        expect(conditions[0]).toEqual(condition1);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return condition by pluginId',
+      async databaseId => {
+        const { knex, db } = await createDatabase(databaseId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao2,
+        );
+
+        const conditions = await db.filterConditions(
+          undefined,
+          undefined,
+          'catalog-entity',
+        );
+        expect(conditions.length).toEqual(1);
+
+        expect(conditions[0]).toEqual(condition1);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return condition by action',
+      async databaseId => {
+        const { knex, db } = await createDatabase(databaseId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao2,
+        );
+
+        const conditions = await db.filterConditions(
+          undefined,
+          undefined,
+          undefined,
+          ['read'],
+        );
+        expect(conditions.length).toEqual(1);
+
+        expect(conditions[0]).toEqual(condition1);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return condition by all arguments',
+      async databaseId => {
+        const { knex, db } = await createDatabase(databaseId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao2,
+        );
+
+        const conditions = await db.filterConditions(
+          'role:default/test',
+          'catalog',
+          'catalog-entity',
+          ['read'],
+        );
+        expect(conditions.length).toEqual(1);
+
+        expect(conditions[0]).toEqual(condition1);
+      },
+    );
+  });
+
+  describe('createCondition', () => {
+    it.each(databases.eachSupportedId())(
+      'should successfully create new policy metadata',
+      async databasesId => {
+        const { knex, db } = await createDatabase(databasesId);
+
+        const id = await db.createCondition(condition1);
+
+        const condition = await knex<ConditionalPolicyDecisionDAO>(
+          CONDITIONAL_TABLE,
+        ).where('id', id);
+        expect(condition.length).toEqual(1);
+        expect(condition[0]).toEqual({
+          id: 1,
+          ...conditionDao1,
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should throw conflict error',
+      async databasesId => {
+        const { knex, db } = await createDatabase(databasesId);
+
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+
+        await expect(async () => {
+          await db.createCondition(condition1);
+        }).rejects.toThrow(
+          `A condition with resource type 'catalog-entity'` +
+            ` and actions '["read"]'` +
+            ` has already been stored for role 'role:default/test'`,
+        );
+      },
+    );
+
+    it('should throw failed to create metadata error, because inserted result is undefined', async () => {
+      const knex = Knex.knex({ client: MockClient });
+      const tracker = createTracker(knex);
+      tracker.on.select(CONDITIONAL_TABLE).response(undefined);
+      tracker.on.insert(CONDITIONAL_TABLE).response(undefined);
+
+      const db = new DataBaseConditionalStorage(knex);
+
+      await expect(async () => {
+        await db.createCondition(condition1);
+      }).rejects.toThrow(`Failed to create the condition.`);
+    });
+  });
+
+  describe('findUniqueCondition', () => {
+    it.each(databases.eachSupportedId())(
+      'should find condition',
+      async databasesId => {
+        const { knex, db } = await createDatabase(databasesId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+
+        const condition = await db.findUniqueCondition(
+          'role:default/test',
+          'catalog-entity',
+          ['read'],
+        );
+
+        expect(condition).toEqual(condition1);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should not find condition',
+      async databasesId => {
+        const { db } = await createDatabase(databasesId);
+
+        const condition = await db.findUniqueCondition(
+          'role:default/test',
+          'catalog-entity',
+          ['read'],
+        );
+
+        expect(condition).toBeUndefined();
+      },
+    );
+  });
+
+  describe('getCondition', () => {
+    it.each(databases.eachSupportedId())(
+      'should return condition by id',
+      async databasesId => {
+        const { knex, db } = await createDatabase(databasesId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+
+        const condition = await db.getCondition(1);
+
+        expect(condition).toEqual(condition1);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should not find condition',
+      async databasesId => {
+        const { db } = await createDatabase(databasesId);
+
+        const condition = await db.getCondition(1);
+
+        expect(condition).toBeUndefined();
+      },
+    );
+  });
+
+  describe('deleteCondition', () => {
+    it.each(databases.eachSupportedId())(
+      'should delete condition by id',
+      async databasesId => {
+        const { knex, db } = await createDatabase(databasesId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+
+        await db.deleteCondition(1);
+
+        const conditions = await knex
+          .table(CONDITIONAL_TABLE)
+          .select<ConditionalPolicyDecisionDAO[]>();
+        expect(conditions.length).toEqual(0);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should not find condition',
+      async databasesId => {
+        const { db } = await createDatabase(databasesId);
+
+        await expect(async () => {
+          await db.deleteCondition(1);
+        }).rejects.toThrow('Condition with id 1 was not found');
+      },
+    );
+  });
+
+  describe('updateCondition', () => {
+    it.each(databases.eachSupportedId())(
+      'should update condition',
+      async databasesId => {
+        const { knex, db } = await createDatabase(databasesId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+
+        const updateCondition: RoleConditionalPolicyDecision = {
+          ...condition1,
+          actions: ['read', 'delete'],
+        };
+        await db.updateCondition(1, updateCondition);
+
+        const condition = await knex
+          .table(CONDITIONAL_TABLE)
+          .select<ConditionalPolicyDecisionDAO[]>()
+          .where('id', 1);
+        expect(condition).toEqual([
+          {
+            ...conditionDao1,
+            actions: '["read","delete"]',
+            id: 1,
+          },
+        ]);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should fail to update condition, because condition not found',
+      async databasesId => {
+        const { db } = await createDatabase(databasesId);
+
+        const updateCondition: RoleConditionalPolicyDecision = {
+          ...condition1,
+          actions: ['read', 'delete'],
+        };
+        await expect(async () => {
+          await db.updateCondition(1, updateCondition);
+        }).rejects.toThrow('Condition with id 1 was not found');
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should fail to update condition, because condition not found',
+      async databasesId => {
+        const { knex, db } = await createDatabase(databasesId);
+
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert({
+          ...conditionDao1,
+          actions: '["delete"]',
+        });
+
+        const updateCondition: RoleConditionalPolicyDecision = {
+          ...condition1,
+          actions: ['read', 'delete'],
+        };
+        await expect(async () => {
+          await db.updateCondition(1, updateCondition);
+        }).rejects.toThrow(
+          `Found condition with conflicted action 'delete'. Role could have multiple ` +
+            `conditions for the same resource type 'catalog-entity', but with different action sets.`,
+        );
+      },
+    );
+  });
+});

--- a/plugins/rbac-backend/src/helper.test.ts
+++ b/plugins/rbac-backend/src/helper.test.ts
@@ -1,6 +1,7 @@
 import { RoleMetadataDao } from './database/role-metadata';
 import {
   deepSortedEqual,
+  isPermissionAction,
   metadataStringToPolicy,
   policiesToString,
   policyToString,
@@ -24,6 +25,7 @@ describe('helper.ts', () => {
       expect(policyToString(policy)).toEqual(expectedString);
     });
   });
+
   describe('policiesToString', () => {
     it('should convert one permission policy to string', () => {
       const policies = [
@@ -245,6 +247,30 @@ describe('helper.ts', () => {
         source: 'rest',
       };
       expect(deepSortedEqual(obj1, obj2)).toBe(false);
+    });
+  });
+
+  describe('isPermissionAction', () => {
+    it('should return true', () => {
+      let result = isPermissionAction('create');
+      expect(result).toBeTruthy();
+
+      result = isPermissionAction('read');
+      expect(result).toBeTruthy();
+
+      result = isPermissionAction('update');
+      expect(result).toBeTruthy();
+
+      result = isPermissionAction('delete');
+      expect(result).toBeTruthy();
+
+      result = isPermissionAction('use');
+      expect(result).toBeTruthy();
+    });
+
+    it('should return false', () => {
+      const result = isPermissionAction('unknown');
+      expect(result).toBeFalsy();
     });
   });
 });

--- a/plugins/rbac-backend/src/helper.ts
+++ b/plugins/rbac-backend/src/helper.ts
@@ -1,6 +1,7 @@
 import { difference, isEqual, sortBy, toPairs } from 'lodash';
 
 import {
+  PermissionAction,
   RoleBasedPolicy,
   Source,
 } from '@janus-idp/backstage-plugin-rbac-common';
@@ -52,4 +53,10 @@ export function deepSortedEqual(
   const sortedObj2 = sortBy(toPairs(obj2), ([key]) => key);
 
   return isEqual(sortedObj1, sortedObj2);
+}
+
+export function isPermissionAction(action: string): action is PermissionAction {
+  return ['create', 'read', 'update', 'delete', 'use'].includes(
+    action as PermissionAction,
+  );
 }

--- a/plugins/rbac-backend/src/service/condition-validation.ts
+++ b/plugins/rbac-backend/src/service/condition-validation.ts
@@ -1,0 +1,87 @@
+import {
+  PermissionCondition,
+  PermissionCriteria,
+  PermissionRuleParams,
+} from '@backstage/plugin-permission-common';
+
+import { RoleConditionalPolicyDecision } from '@janus-idp/backstage-plugin-rbac-common';
+
+export function validateRoleCondition(
+  condition: RoleConditionalPolicyDecision,
+) {
+  if (!condition.roleEntityRef) {
+    throw new Error(`'roleEntityRef' must be specified in the role condition`);
+  }
+  if (!condition.result) {
+    throw new Error(`'result' must be specified in the role condition`);
+  }
+  if (!condition.pluginId) {
+    throw new Error(`'pluginId' must be specified in the role condition`);
+  }
+  if (!condition.resourceType) {
+    throw new Error(`'resourceType' must be specified in the role condition`);
+  }
+  if (!condition.conditions) {
+    throw new Error(`'conditions' must be specified in the role condition`);
+  }
+  if (condition.conditions) {
+    validatePermissionCondition(
+      condition.conditions,
+      'roleCondition.conditions',
+    );
+  }
+  console.log('ok');
+}
+
+function validatePermissionCondition(
+  conditionOrCriteria: PermissionCriteria<
+    PermissionCondition<string, PermissionRuleParams>
+  >,
+  jsonPathLocator: string,
+) {
+  if ('not' in conditionOrCriteria) {
+    validatePermissionCondition(
+      conditionOrCriteria.not,
+      `${jsonPathLocator}.not`,
+    );
+    return;
+  }
+  if ('allOf' in conditionOrCriteria) {
+    if (
+      !Array.isArray(conditionOrCriteria.allOf) ||
+      conditionOrCriteria.allOf.length === 0
+    ) {
+      throw new Error(
+        `${jsonPathLocator}.allOf criteria must be non empty array`,
+      );
+    }
+    for (const [index, elem] of conditionOrCriteria.allOf.entries()) {
+      validatePermissionCondition(elem, `${jsonPathLocator}.allOf[${index}]`);
+    }
+    return;
+  }
+  if ('anyOf' in conditionOrCriteria) {
+    if (
+      !Array.isArray(conditionOrCriteria.anyOf) ||
+      conditionOrCriteria.anyOf.length === 0
+    ) {
+      throw new Error(
+        `${jsonPathLocator}.anyOf criteria must be non empty array`,
+      );
+    }
+    for (const [index, elem] of conditionOrCriteria.anyOf.entries()) {
+      validatePermissionCondition(elem, `${jsonPathLocator}.anyOf[${index}]`);
+    }
+    return;
+  }
+  if (!('resourceType' in conditionOrCriteria)) {
+    throw new Error(
+      `'resourceType' must be specified in the ${jsonPathLocator}.condition`,
+    );
+  }
+  if (!('rule' in conditionOrCriteria)) {
+    throw new Error(
+      `'rule' must be specified in the ${jsonPathLocator}.condition`,
+    );
+  }
+}

--- a/plugins/rbac-backend/src/service/condition-validation.ts
+++ b/plugins/rbac-backend/src/service/condition-validation.ts
@@ -4,10 +4,15 @@ import {
   PermissionRuleParams,
 } from '@backstage/plugin-permission-common';
 
-import { RoleConditionalPolicyDecision } from '@janus-idp/backstage-plugin-rbac-common';
+import {
+  PermissionAction,
+  RoleConditionalPolicyDecision,
+} from '@janus-idp/backstage-plugin-rbac-common';
+
+import { isPermissionAction } from '../helper';
 
 export function validateRoleCondition(
-  condition: RoleConditionalPolicyDecision,
+  condition: RoleConditionalPolicyDecision<PermissionAction>,
 ) {
   if (!condition.roleEntityRef) {
     throw new Error(`'roleEntityRef' must be specified in the role condition`);
@@ -21,6 +26,24 @@ export function validateRoleCondition(
   if (!condition.resourceType) {
     throw new Error(`'resourceType' must be specified in the role condition`);
   }
+
+  if (
+    !condition.permissionMapping ||
+    condition.permissionMapping.length === 0
+  ) {
+    throw new Error(
+      `'permissionMapping' must be non empty array in the role condition`,
+    );
+  }
+  const nonActionValue = condition.permissionMapping.find(
+    action => !isPermissionAction(action),
+  );
+  if (nonActionValue) {
+    throw new Error(
+      `'permissionMapping' array contains non action value: '${nonActionValue}'`,
+    );
+  }
+
   if (!condition.conditions) {
     throw new Error(`'conditions' must be specified in the role condition`);
   }
@@ -30,7 +53,6 @@ export function validateRoleCondition(
       'roleCondition.conditions',
     );
   }
-  console.log('ok');
 }
 
 function validatePermissionCondition(

--- a/plugins/rbac-backend/src/service/condition.validation.test.ts
+++ b/plugins/rbac-backend/src/service/condition.validation.test.ts
@@ -402,10 +402,12 @@ describe('condition-validation', () => {
 
       it('should validate role-condition.conditions.anyOf without errors', () => {
         const condition: RoleConditionalPolicyDecision = {
+          id: 1,
           pluginId: 'catalog',
           resourceType: 'catalog-entity',
           roleEntityRef: 'role:default/test',
           result: AuthorizeResult.CONDITIONAL,
+          actions: ['read'],
           conditions: {
             anyOf: [
               {
@@ -579,10 +581,12 @@ describe('condition-validation', () => {
 
       it('should success validation role-condition.conditions.allOf', () => {
         const condition: RoleConditionalPolicyDecision = {
+          id: 1,
           pluginId: 'catalog',
           resourceType: 'catalog-entity',
           roleEntityRef: 'role:default/test',
           result: AuthorizeResult.CONDITIONAL,
+          actions: ['read'],
           conditions: {
             allOf: [
               {

--- a/plugins/rbac-backend/src/service/condition.validation.test.ts
+++ b/plugins/rbac-backend/src/service/condition.validation.test.ts
@@ -407,7 +407,7 @@ describe('condition-validation', () => {
           resourceType: 'catalog-entity',
           roleEntityRef: 'role:default/test',
           result: AuthorizeResult.CONDITIONAL,
-          actions: ['read'],
+          permissions: [{ name: 'catalog.entity-read', action: 'read' }],
           conditions: {
             anyOf: [
               {
@@ -586,7 +586,7 @@ describe('condition-validation', () => {
           resourceType: 'catalog-entity',
           roleEntityRef: 'role:default/test',
           result: AuthorizeResult.CONDITIONAL,
-          actions: ['read'],
+          permissions: [{ name: 'catalog.entity.read', action: 'read' }],
           conditions: {
             allOf: [
               {

--- a/plugins/rbac-backend/src/service/condition.validation.test.ts
+++ b/plugins/rbac-backend/src/service/condition.validation.test.ts
@@ -1,0 +1,613 @@
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+
+import { RoleConditionalPolicyDecision } from '@janus-idp/backstage-plugin-rbac-common';
+
+import { validateRoleCondition } from './condition-validation';
+
+describe('condition-validation', () => {
+  describe('validateCondition', () => {
+    describe('validation common fields', () => {
+      it('should fail validation role condition without pluginId', () => {
+        const condition: any = {
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            anyOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'pluginId' must be specified in the role condition`,
+        );
+      });
+
+      it('should fail validation role condition without resourceType', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            anyOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'resourceType' must be specified in the role condition`,
+        );
+      });
+
+      it('should fail validation role condition without role entity reference', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            anyOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'roleEntityRef' must be specified in the role condition`,
+        );
+      });
+
+      it('should fail validation role condition without result', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          conditions: {
+            anyOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'result' must be specified in the role condition`,
+        );
+      });
+
+      it('should fail validation role condition without conditions', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'conditions' must be specified in the role condition`,
+        );
+      });
+    });
+
+    describe('validate simple condition', () => {
+      it('should fail validation role-condition.conditions without rule', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['user:default/logarifm', 'group:default/team-a'],
+            },
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'rule' must be specified in the roleCondition.conditions.condition`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions without resourceType', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            rule: 'IS_ENTITY_OWNER',
+            params: {
+              claims: ['user:default/logarifm', 'group:default/team-a'],
+            },
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'resourceType' must be specified in the roleCondition.conditions.condition`,
+        );
+      });
+
+      it('should validate role-condition.conditions without errors', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            rule: 'IS_ENTITY_OWNER',
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['user:default/logarifm', 'group:default/team-a'],
+            },
+          },
+        };
+        let unexpectedErr;
+        try {
+          validateRoleCondition(condition);
+        } catch (err) {
+          unexpectedErr = err;
+        }
+        expect(unexpectedErr).toBeUndefined();
+      });
+    });
+
+    describe('validate "not" criteria', () => {
+      it('should fail validation role-condition.conditions.not without rule', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            not: {
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'rule' must be specified in the roleCondition.conditions.not.condition`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.not without resourceType', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            not: {
+              rule: 'IS_ENTITY_OWNER',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'resourceType' must be specified in the roleCondition.conditions.not.condition`,
+        );
+      });
+
+      it('should validate role-condition.conditions.not without errors', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            not: {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+          },
+        };
+        let unexpectedErr;
+        try {
+          validateRoleCondition(condition);
+        } catch (err) {
+          unexpectedErr = err;
+        }
+        expect(unexpectedErr).toBeUndefined();
+      });
+    });
+
+    describe('validate anyOf criteria', () => {
+      it('should fail validation role-condition.conditions.anyOf with an empty array value', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            anyOf: [],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `roleCondition.conditions.anyOf criteria must be non empty array`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.anyOf with non array value', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            anyOf: {
+              rule: 'IS_ENTITY_OWNER',
+              params: {
+                claims: ['group:default/team-a'],
+              },
+            },
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `roleCondition.conditions.anyOf criteria must be non empty array`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.anyOf without resourceType in the first param', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            anyOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'resourceType' must be specified in the roleCondition.conditions.anyOf[0].condition`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.anyOf without resourceType in the second param', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            anyOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'resourceType' must be specified in the roleCondition.conditions.anyOf[1].condition`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.anyOf without rule in the first param', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            anyOf: [
+              {
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'rule' must be specified in the roleCondition.conditions.anyOf[0].condition`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.anyOf without rule in the second param', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            anyOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'rule' must be specified in the roleCondition.conditions.anyOf[1].condition`,
+        );
+      });
+
+      it('should validate role-condition.conditions.anyOf without errors', () => {
+        const condition: RoleConditionalPolicyDecision = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            anyOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        let unexpectedErr;
+        try {
+          validateRoleCondition(condition);
+        } catch (err) {
+          unexpectedErr = err;
+        }
+        expect(unexpectedErr).toBeUndefined();
+      });
+    });
+
+    describe('validate allOf criteria', () => {
+      it('should fail validation role-condition.conditions.allOf with an empty array value', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            allOf: [],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `roleCondition.conditions.allOf criteria must be non empty array`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.allOf with non array value', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            allOf: {
+              rule: 'IS_ENTITY_OWNER',
+              params: {
+                claims: ['group:default/team-a'],
+              },
+            },
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `roleCondition.conditions.allOf criteria must be non empty array`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.allOf without resourceType in the first param', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            allOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'resourceType' must be specified in the roleCondition.conditions.allOf[0].condition`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.allOf without resourceType in the second param', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            allOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'resourceType' must be specified in the roleCondition.conditions.allOf[1].condition`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.allOf without rule in the first param', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            allOf: [
+              {
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'rule' must be specified in the roleCondition.conditions.allOf[0].condition`,
+        );
+      });
+
+      it('should fail validation role-condition.conditions.allOf without rule in the second param', () => {
+        const condition: any = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            allOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        expect(() => validateRoleCondition(condition)).toThrow(
+          `'rule' must be specified in the roleCondition.conditions.allOf[1].condition`,
+        );
+      });
+
+      it('should success validation role-condition.conditions.allOf', () => {
+        const condition: RoleConditionalPolicyDecision = {
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          roleEntityRef: 'role:default/test',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
+            allOf: [
+              {
+                rule: 'IS_ENTITY_OWNER',
+                resourceType: 'catalog-entity',
+                params: {
+                  claims: ['user:default/logarifm', 'group:default/team-a'],
+                },
+              },
+              {
+                rule: 'IS_ENTITY_KIND',
+                resourceType: 'catalog-entity',
+                params: { kinds: ['Group'] },
+              },
+            ],
+          },
+        };
+        let unexpectedErr;
+        try {
+          validateRoleCondition(condition);
+        } catch (err) {
+          unexpectedErr = err;
+        }
+        expect(unexpectedErr).toBeUndefined();
+      });
+    });
+  });
+});

--- a/plugins/rbac-backend/src/service/condition.validation.test.ts
+++ b/plugins/rbac-backend/src/service/condition.validation.test.ts
@@ -5,613 +5,611 @@ import { RoleConditionalPolicyDecision } from '@janus-idp/backstage-plugin-rbac-
 import { validateRoleCondition } from './condition-validation';
 
 describe('condition-validation', () => {
-  describe('validateCondition', () => {
-    describe('validation common fields', () => {
-      it('should fail validation role condition without pluginId', () => {
-        const condition: any = {
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            anyOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'pluginId' must be specified in the role condition`,
-        );
-      });
-
-      it('should fail validation role condition without resourceType', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            anyOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'resourceType' must be specified in the role condition`,
-        );
-      });
-
-      it('should fail validation role condition without role entity reference', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            anyOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'roleEntityRef' must be specified in the role condition`,
-        );
-      });
-
-      it('should fail validation role condition without result', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          conditions: {
-            anyOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'result' must be specified in the role condition`,
-        );
-      });
-
-      it('should fail validation role condition without conditions', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'conditions' must be specified in the role condition`,
-        );
-      });
-    });
-
-    describe('validate simple condition', () => {
-      it('should fail validation role-condition.conditions without rule', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            resourceType: 'catalog-entity',
-            params: {
-              claims: ['user:default/logarifm', 'group:default/team-a'],
-            },
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'rule' must be specified in the roleCondition.conditions.condition`,
-        );
-      });
-
-      it('should fail validation role-condition.conditions without resourceType', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            rule: 'IS_ENTITY_OWNER',
-            params: {
-              claims: ['user:default/logarifm', 'group:default/team-a'],
-            },
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'resourceType' must be specified in the roleCondition.conditions.condition`,
-        );
-      });
-
-      it('should validate role-condition.conditions without errors', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            rule: 'IS_ENTITY_OWNER',
-            resourceType: 'catalog-entity',
-            params: {
-              claims: ['user:default/logarifm', 'group:default/team-a'],
-            },
-          },
-        };
-        let unexpectedErr;
-        try {
-          validateRoleCondition(condition);
-        } catch (err) {
-          unexpectedErr = err;
-        }
-        expect(unexpectedErr).toBeUndefined();
-      });
-    });
-
-    describe('validate "not" criteria', () => {
-      it('should fail validation role-condition.conditions.not without rule', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            not: {
-              resourceType: 'catalog-entity',
-              params: {
-                claims: ['user:default/logarifm', 'group:default/team-a'],
-              },
-            },
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'rule' must be specified in the roleCondition.conditions.not.condition`,
-        );
-      });
-
-      it('should fail validation role-condition.conditions.not without resourceType', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            not: {
-              rule: 'IS_ENTITY_OWNER',
-              params: {
-                claims: ['user:default/logarifm', 'group:default/team-a'],
-              },
-            },
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'resourceType' must be specified in the roleCondition.conditions.not.condition`,
-        );
-      });
-
-      it('should validate role-condition.conditions.not without errors', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            not: {
+  describe('validation common fields', () => {
+    it('should fail validation role condition without pluginId', () => {
+      const condition: any = {
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          anyOf: [
+            {
               rule: 'IS_ENTITY_OWNER',
               resourceType: 'catalog-entity',
               params: {
                 claims: ['user:default/logarifm', 'group:default/team-a'],
               },
             },
-          },
-        };
-        let unexpectedErr;
-        try {
-          validateRoleCondition(condition);
-        } catch (err) {
-          unexpectedErr = err;
-        }
-        expect(unexpectedErr).toBeUndefined();
-      });
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'pluginId' must be specified in the role condition`,
+      );
     });
 
-    describe('validate anyOf criteria', () => {
-      it('should fail validation role-condition.conditions.anyOf with an empty array value', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            anyOf: [],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `roleCondition.conditions.anyOf criteria must be non empty array`,
-        );
-      });
-
-      it('should fail validation role-condition.conditions.anyOf with non array value', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            anyOf: {
+    it('should fail validation role condition without resourceType', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          anyOf: [
+            {
               rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
               params: {
-                claims: ['group:default/team-a'],
+                claims: ['user:default/logarifm', 'group:default/team-a'],
               },
             },
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `roleCondition.conditions.anyOf criteria must be non empty array`,
-        );
-      });
-
-      it('should fail validation role-condition.conditions.anyOf without resourceType in the first param', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            anyOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'resourceType' must be specified in the roleCondition.conditions.anyOf[0].condition`,
-        );
-      });
-
-      it('should fail validation role-condition.conditions.anyOf without resourceType in the second param', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            anyOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'resourceType' must be specified in the roleCondition.conditions.anyOf[1].condition`,
-        );
-      });
-
-      it('should fail validation role-condition.conditions.anyOf without rule in the first param', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            anyOf: [
-              {
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'rule' must be specified in the roleCondition.conditions.anyOf[0].condition`,
-        );
-      });
-
-      it('should fail validation role-condition.conditions.anyOf without rule in the second param', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            anyOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'rule' must be specified in the roleCondition.conditions.anyOf[1].condition`,
-        );
-      });
-
-      it('should validate role-condition.conditions.anyOf without errors', () => {
-        const condition: RoleConditionalPolicyDecision = {
-          id: 1,
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          permissions: [{ name: 'catalog.entity-read', action: 'read' }],
-          conditions: {
-            anyOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        let unexpectedErr;
-        try {
-          validateRoleCondition(condition);
-        } catch (err) {
-          unexpectedErr = err;
-        }
-        expect(unexpectedErr).toBeUndefined();
-      });
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'resourceType' must be specified in the role condition`,
+      );
     });
 
-    describe('validate allOf criteria', () => {
-      it('should fail validation role-condition.conditions.allOf with an empty array value', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            allOf: [],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `roleCondition.conditions.allOf criteria must be non empty array`,
-        );
-      });
-
-      it('should fail validation role-condition.conditions.allOf with non array value', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            allOf: {
+    it('should fail validation role condition without role entity reference', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          anyOf: [
+            {
               rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
               params: {
-                claims: ['group:default/team-a'],
+                claims: ['user:default/logarifm', 'group:default/team-a'],
               },
             },
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `roleCondition.conditions.allOf criteria must be non empty array`,
-        );
-      });
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'roleEntityRef' must be specified in the role condition`,
+      );
+    });
 
-      it('should fail validation role-condition.conditions.allOf without resourceType in the first param', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            allOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
+    it('should fail validation role condition without result', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        conditions: {
+          anyOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
               },
-              {
-                rule: 'IS_ENTITY_KIND',
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'resourceType' must be specified in the roleCondition.conditions.allOf[0].condition`,
-        );
-      });
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'result' must be specified in the role condition`,
+      );
+    });
 
-      it('should fail validation role-condition.conditions.allOf without resourceType in the second param', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            allOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                params: { kinds: ['Group'] },
-              },
-            ],
-          },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'resourceType' must be specified in the roleCondition.conditions.allOf[1].condition`,
-        );
-      });
+    it('should fail validation role condition without conditions', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'conditions' must be specified in the role condition`,
+      );
+    });
+  });
 
-      it('should fail validation role-condition.conditions.allOf without rule in the first param', () => {
-        const condition: any = {
-          pluginId: 'catalog',
+  describe('validate simple condition', () => {
+    it('should fail validation role-condition.conditions without rule', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
           resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            allOf: [
-              {
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
+          params: {
+            claims: ['user:default/logarifm', 'group:default/team-a'],
           },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'rule' must be specified in the roleCondition.conditions.allOf[0].condition`,
-        );
-      });
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'rule' must be specified in the roleCondition.conditions.condition`,
+      );
+    });
 
-      it('should fail validation role-condition.conditions.allOf without rule in the second param', () => {
-        const condition: any = {
-          pluginId: 'catalog',
-          resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          conditions: {
-            allOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
+    it('should fail validation role-condition.conditions without resourceType', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          rule: 'IS_ENTITY_OWNER',
+          params: {
+            claims: ['user:default/logarifm', 'group:default/team-a'],
           },
-        };
-        expect(() => validateRoleCondition(condition)).toThrow(
-          `'rule' must be specified in the roleCondition.conditions.allOf[1].condition`,
-        );
-      });
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'resourceType' must be specified in the roleCondition.conditions.condition`,
+      );
+    });
 
-      it('should success validation role-condition.conditions.allOf', () => {
-        const condition: RoleConditionalPolicyDecision = {
-          id: 1,
-          pluginId: 'catalog',
+    it('should validate role-condition.conditions without errors', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          rule: 'IS_ENTITY_OWNER',
           resourceType: 'catalog-entity',
-          roleEntityRef: 'role:default/test',
-          result: AuthorizeResult.CONDITIONAL,
-          permissions: [{ name: 'catalog.entity.read', action: 'read' }],
-          conditions: {
-            allOf: [
-              {
-                rule: 'IS_ENTITY_OWNER',
-                resourceType: 'catalog-entity',
-                params: {
-                  claims: ['user:default/logarifm', 'group:default/team-a'],
-                },
-              },
-              {
-                rule: 'IS_ENTITY_KIND',
-                resourceType: 'catalog-entity',
-                params: { kinds: ['Group'] },
-              },
-            ],
+          params: {
+            claims: ['user:default/logarifm', 'group:default/team-a'],
           },
-        };
-        let unexpectedErr;
-        try {
-          validateRoleCondition(condition);
-        } catch (err) {
-          unexpectedErr = err;
-        }
-        expect(unexpectedErr).toBeUndefined();
-      });
+        },
+      };
+      let unexpectedErr;
+      try {
+        validateRoleCondition(condition);
+      } catch (err) {
+        unexpectedErr = err;
+      }
+      expect(unexpectedErr).toBeUndefined();
+    });
+  });
+
+  describe('validate "not" criteria', () => {
+    it('should fail validation role-condition.conditions.not without rule', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          not: {
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['user:default/logarifm', 'group:default/team-a'],
+            },
+          },
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'rule' must be specified in the roleCondition.conditions.not.condition`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.not without resourceType', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          not: {
+            rule: 'IS_ENTITY_OWNER',
+            params: {
+              claims: ['user:default/logarifm', 'group:default/team-a'],
+            },
+          },
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'resourceType' must be specified in the roleCondition.conditions.not.condition`,
+      );
+    });
+
+    it('should validate role-condition.conditions.not without errors', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          not: {
+            rule: 'IS_ENTITY_OWNER',
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['user:default/logarifm', 'group:default/team-a'],
+            },
+          },
+        },
+      };
+      let unexpectedErr;
+      try {
+        validateRoleCondition(condition);
+      } catch (err) {
+        unexpectedErr = err;
+      }
+      expect(unexpectedErr).toBeUndefined();
+    });
+  });
+
+  describe('validate anyOf criteria', () => {
+    it('should fail validation role-condition.conditions.anyOf with an empty array value', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          anyOf: [],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `roleCondition.conditions.anyOf criteria must be non empty array`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.anyOf with non array value', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          anyOf: {
+            rule: 'IS_ENTITY_OWNER',
+            params: {
+              claims: ['group:default/team-a'],
+            },
+          },
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `roleCondition.conditions.anyOf criteria must be non empty array`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.anyOf without resourceType in the first param', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          anyOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'resourceType' must be specified in the roleCondition.conditions.anyOf[0].condition`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.anyOf without resourceType in the second param', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          anyOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'resourceType' must be specified in the roleCondition.conditions.anyOf[1].condition`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.anyOf without rule in the first param', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          anyOf: [
+            {
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'rule' must be specified in the roleCondition.conditions.anyOf[0].condition`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.anyOf without rule in the second param', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          anyOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'rule' must be specified in the roleCondition.conditions.anyOf[1].condition`,
+      );
+    });
+
+    it('should validate role-condition.conditions.anyOf without errors', () => {
+      const condition: RoleConditionalPolicyDecision = {
+        id: 1,
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissions: [{ name: 'catalog.entity-read', action: 'read' }],
+        conditions: {
+          anyOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      let unexpectedErr;
+      try {
+        validateRoleCondition(condition);
+      } catch (err) {
+        unexpectedErr = err;
+      }
+      expect(unexpectedErr).toBeUndefined();
+    });
+  });
+
+  describe('validate allOf criteria', () => {
+    it('should fail validation role-condition.conditions.allOf with an empty array value', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          allOf: [],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `roleCondition.conditions.allOf criteria must be non empty array`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.allOf with non array value', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          allOf: {
+            rule: 'IS_ENTITY_OWNER',
+            params: {
+              claims: ['group:default/team-a'],
+            },
+          },
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `roleCondition.conditions.allOf criteria must be non empty array`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.allOf without resourceType in the first param', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          allOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'resourceType' must be specified in the roleCondition.conditions.allOf[0].condition`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.allOf without resourceType in the second param', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          allOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'resourceType' must be specified in the roleCondition.conditions.allOf[1].condition`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.allOf without rule in the first param', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          allOf: [
+            {
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'rule' must be specified in the roleCondition.conditions.allOf[0].condition`,
+      );
+    });
+
+    it('should fail validation role-condition.conditions.allOf without rule in the second param', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          allOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'rule' must be specified in the roleCondition.conditions.allOf[1].condition`,
+      );
+    });
+
+    it('should success validation role-condition.conditions.allOf', () => {
+      const condition: RoleConditionalPolicyDecision = {
+        id: 1,
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissions: [{ name: 'catalog.entity.read', action: 'read' }],
+        conditions: {
+          allOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      let unexpectedErr;
+      try {
+        validateRoleCondition(condition);
+      } catch (err) {
+        unexpectedErr = err;
+      }
+      expect(unexpectedErr).toBeUndefined();
     });
   });
 });

--- a/plugins/rbac-backend/src/service/condition.validation.test.ts
+++ b/plugins/rbac-backend/src/service/condition.validation.test.ts
@@ -1,6 +1,9 @@
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
-import { RoleConditionalPolicyDecision } from '@janus-idp/backstage-plugin-rbac-common';
+import {
+  PermissionAction,
+  RoleConditionalPolicyDecision,
+} from '@janus-idp/backstage-plugin-rbac-common';
 
 import { validateRoleCondition } from './condition-validation';
 
@@ -11,6 +14,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           anyOf: [
             {
@@ -38,6 +42,7 @@ describe('condition-validation', () => {
         pluginId: 'catalog',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           anyOf: [
             {
@@ -60,11 +65,98 @@ describe('condition-validation', () => {
       );
     });
 
+    it('should fail validation role condition without permissionMapping', () => {
+      const condition: any = {
+        resourceType: 'catalog-entity',
+        pluginId: 'catalog',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          anyOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'permissionMapping' must be non empty array in the role condition`,
+      );
+    });
+
+    it('should fail validation role condition with empty array permissionMapping', () => {
+      const condition: any = {
+        resourceType: 'catalog-entity',
+        pluginId: 'catalog',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: [],
+        conditions: {
+          anyOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'permissionMapping' must be non empty array in the role condition`,
+      );
+    });
+
+    it('should fail validation role condition with array permissionMapping, but with wrong action value', () => {
+      const condition: any = {
+        resourceType: 'catalog-entity',
+        pluginId: 'catalog',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['wrong-value'],
+        conditions: {
+          anyOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: {
+                claims: ['user:default/logarifm', 'group:default/team-a'],
+              },
+            },
+            {
+              rule: 'IS_ENTITY_KIND',
+              resourceType: 'catalog-entity',
+              params: { kinds: ['Group'] },
+            },
+          ],
+        },
+      };
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'permissionMapping' array contains non action value: 'wrong-value'`,
+      );
+    });
+
     it('should fail validation role condition without role entity reference', () => {
       const condition: any = {
         pluginId: 'catalog',
         resourceType: 'catalog-entity',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           anyOf: [
             {
@@ -92,6 +184,7 @@ describe('condition-validation', () => {
         pluginId: 'catalog',
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
+        permissionMapping: ['read'],
         conditions: {
           anyOf: [
             {
@@ -120,6 +213,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
       };
       expect(() => validateRoleCondition(condition)).toThrow(
         `'conditions' must be specified in the role condition`,
@@ -134,6 +228,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           resourceType: 'catalog-entity',
           params: {
@@ -152,6 +247,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           rule: 'IS_ENTITY_OWNER',
           params: {
@@ -170,6 +266,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           rule: 'IS_ENTITY_OWNER',
           resourceType: 'catalog-entity',
@@ -194,6 +291,7 @@ describe('condition-validation', () => {
         pluginId: 'catalog',
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
+        permissionMapping: ['read'],
         result: AuthorizeResult.CONDITIONAL,
         conditions: {
           not: {
@@ -215,6 +313,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           not: {
             rule: 'IS_ENTITY_OWNER',
@@ -235,6 +334,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           not: {
             rule: 'IS_ENTITY_OWNER',
@@ -262,6 +362,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           anyOf: [],
         },
@@ -277,6 +378,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           anyOf: {
             rule: 'IS_ENTITY_OWNER',
@@ -297,6 +399,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           anyOf: [
             {
@@ -324,6 +427,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           anyOf: [
             {
@@ -351,6 +455,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           anyOf: [
             {
@@ -378,6 +483,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           anyOf: [
             {
@@ -400,13 +506,13 @@ describe('condition-validation', () => {
     });
 
     it('should validate role-condition.conditions.anyOf without errors', () => {
-      const condition: RoleConditionalPolicyDecision = {
+      const condition: RoleConditionalPolicyDecision<PermissionAction> = {
         id: 1,
         pluginId: 'catalog',
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
-        permissions: [{ name: 'catalog.entity-read', action: 'read' }],
+        permissionMapping: ['read'],
         conditions: {
           anyOf: [
             {
@@ -441,6 +547,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           allOf: [],
         },
@@ -456,6 +563,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           allOf: {
             rule: 'IS_ENTITY_OWNER',
@@ -476,6 +584,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           allOf: [
             {
@@ -503,6 +612,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           allOf: [
             {
@@ -530,6 +640,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           allOf: [
             {
@@ -557,6 +668,7 @@ describe('condition-validation', () => {
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
         conditions: {
           allOf: [
             {
@@ -579,13 +691,13 @@ describe('condition-validation', () => {
     });
 
     it('should success validation role-condition.conditions.allOf', () => {
-      const condition: RoleConditionalPolicyDecision = {
+      const condition: RoleConditionalPolicyDecision<PermissionAction> = {
         id: 1,
         pluginId: 'catalog',
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
-        permissions: [{ name: 'catalog.entity.read', action: 'read' }],
+        permissionMapping: ['read'],
         conditions: {
           allOf: [
             {

--- a/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -43,6 +43,10 @@ export class EnforcerDelegate {
     return await this.enforcer.getGroupingPolicy();
   }
 
+  async getRolesForUser(userEntityRef: string): Promise<string[]> {
+    return await this.enforcer.getRolesForUser(userEntityRef);
+  }
+
   async getFilteredPolicy(
     fieldIndex: number,
     ...filter: string[]

--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -1801,7 +1801,6 @@ describe('Policy checks for conditional policies', () => {
       tokenManagerMock,
     );
 
-    const knex = Knex.knex({ client: MockClient });
     const enfDelegate = new EnforcerDelegate(
       enf,
       policyMetadataStorageMock,

--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -30,6 +30,7 @@ import {
 import { resolve } from 'path';
 
 import { CasbinDBAdapterFactory } from '../database/casbin-adapter-factory';
+import { ConditionalStorage } from '../database/conditional-storage';
 import {
   PermissionPolicyMetadataDao,
   PolicyMetadataStorage,
@@ -66,7 +67,7 @@ const tokenManagerMock = {
   authenticate: jest.fn().mockImplementation(),
 };
 
-const conditionalStorage = {
+const conditionalStorage: ConditionalStorage = {
   getConditions: jest.fn().mockImplementation(),
   createCondition: jest.fn().mockImplementation(),
   findCondition: jest.fn().mockImplementation(),
@@ -1775,6 +1776,186 @@ describe('Policy checks for users and groups', () => {
       newIdentityResponse('user:default/mike'),
     );
     expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+});
+
+describe('Policy checks for conditional policies', () => {
+  let policy: RBACPermissionPolicy;
+
+  beforeEach(async () => {
+    const adapter = new StringAdapter(
+      `
+      p, role:default/test, catalog-entity, read, allow
+
+      g, group:default/test-group, role:default/test
+      g, group:default/qa, role:default/qa
+      `,
+    );
+    const config = newConfigReader();
+    const theModel = newModelFromString(MODEL);
+    const logger = getVoidLogger();
+    const enf = await createEnforcer(
+      theModel,
+      adapter,
+      logger,
+      tokenManagerMock,
+    );
+
+    const knex = Knex.knex({ client: MockClient });
+    const enfDelegate = new EnforcerDelegate(
+      enf,
+      policyMetadataStorageMock,
+      roleMetadataStorageMock,
+      knex,
+    );
+
+    policy = await RBACPermissionPolicy.build(
+      logger,
+      config,
+      conditionalStorage,
+      enfDelegate,
+      roleMetadataStorageMock,
+      policyMetadataStorageMock,
+      knex,
+    );
+
+    catalogApi.getEntities.mockReset();
+    (conditionalStorage.findCondition as jest.Mock).mockReset();
+  });
+
+  it('should execute condition policy', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'test-group',
+        namespace: 'default',
+      },
+      spec: {
+        members: ['mike'],
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({ items: [entityMock] });
+    (conditionalStorage.findCondition as jest.Mock).mockReturnValueOnce({
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      roleEntityRef: 'role:default/test',
+      result: AuthorizeResult.CONDITIONAL,
+      conditions: {
+        rule: 'IS_ENTITY_OWNER',
+        resourceType: 'catalog-entity',
+        params: {
+          claims: ['group:default/test-group'],
+        },
+      },
+    });
+
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'catalog.entity.read',
+        'catalog-entity',
+        'read',
+      ),
+      newIdentityResponse('user:default/mike'),
+    );
+    expect(decision).toStrictEqual({
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      result: AuthorizeResult.CONDITIONAL,
+      conditions: {
+        anyOf: [
+          {
+            rule: 'IS_ENTITY_OWNER',
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['group:default/test-group'],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('should merge condition policies for user assigned to few roles', async () => {
+    const entityMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'test-group',
+        namespace: 'default',
+      },
+      spec: {
+        members: ['mike'],
+      },
+    };
+    const qaGroupMock: Entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'qa',
+        namespace: 'default',
+      },
+      spec: {
+        members: ['mike'],
+      },
+    };
+    catalogApi.getEntities.mockReturnValue({
+      items: [entityMock, qaGroupMock],
+    });
+    (conditionalStorage.findCondition as jest.Mock)
+      .mockReturnValueOnce({
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          rule: 'IS_ENTITY_OWNER',
+          resourceType: 'catalog-entity',
+          params: {
+            claims: ['group:default/test-group'],
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/qa',
+        result: AuthorizeResult.CONDITIONAL,
+        conditions: {
+          rule: 'IS_ENTITY_KIND',
+          resourceType: 'catalog-entity',
+          params: { kinds: ['Group', 'User'] },
+        },
+      });
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'catalog.entity.read',
+        'catalog-entity',
+        'read',
+      ),
+      newIdentityResponse('user:default/mike'),
+    );
+    expect(decision).toStrictEqual({
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      result: AuthorizeResult.CONDITIONAL,
+      conditions: {
+        anyOf: [
+          {
+            rule: 'IS_ENTITY_OWNER',
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['group:default/test-group'],
+            },
+          },
+          {
+            rule: 'IS_ENTITY_KIND',
+            resourceType: 'catalog-entity',
+            params: { kinds: ['Group', 'User'] },
+          },
+        ],
+      },
+    });
   });
 });
 

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -269,8 +269,20 @@ export class RBACPermissionPolicy implements PermissionPolicy {
         status = await this.isAuthorized(userEntityRef, obj, action);
 
         if (status && identityResp) {
-          const conditionalDecision =
-            await this.conditionStorage.findCondition(resourceType);
+          const roles = await this.enforcer.getRolesForUser(userEntityRef);
+          console.log(`===== Roles ${roles} ${userEntityRef} ===`);
+          let conditionalDecision;
+          for (const role of roles) {
+            conditionalDecision = await this.conditionStorage.findCondition(
+              role,
+              resourceType,
+            );
+            // todo handle few roles
+            if (conditionalDecision) {
+              break;
+            }
+          }
+
           if (conditionalDecision) {
             this.logger.info(
               `${identityResp?.identity.userEntityRef} executed condition for permission ${request.permission.name}, resource type ${resourceType} and action ${action}`,

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -356,7 +356,6 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     identityResp?: BackstageIdentityResponse | undefined,
   ): Promise<PolicyDecision | undefined> {
     const roles = await this.enforcer.getRolesForUser(userEntityRef);
-    console.log(`===== Roles ${roles} ${userEntityRef} ===`);
 
     const conditions: PermissionCriteria<
       PermissionCondition<string, PermissionRuleParams>
@@ -377,7 +376,6 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     }
 
     if (conditions.length > 0) {
-      console.log(`----- ${JSON.stringify(conditions)}`);
       this.logger.info(
         `${identityResp?.identity.userEntityRef} executed condition for permission ${permissionName}, resource type ${resourceType} and action ${action}`,
       );

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -369,7 +369,6 @@ export class RBACPermissionPolicy implements PermissionPolicy {
         resourceType,
         [permissionName],
       );
-      console.log(`==== ${conditionalDecisions}`);
 
       if (conditionalDecisions.length > 0) {
         pluginId = conditionalDecisions[0].pluginId;

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -17,7 +17,10 @@ import {
 import { Knex } from 'knex';
 import { Logger } from 'winston';
 
-import { NonEmptyArray } from '@janus-idp/backstage-plugin-rbac-common';
+import {
+  NonEmptyArray,
+  PermissionAction,
+} from '@janus-idp/backstage-plugin-rbac-common';
 
 import { ConditionalStorage } from '../database/conditional-storage';
 import { PolicyMetadataStorage } from '../database/policy-metadata-storage';
@@ -355,7 +358,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     userEntityRef: string,
     resourceType: string,
     permissionName: string,
-    action: string,
+    action: PermissionAction,
   ): Promise<PolicyDecision | undefined> {
     const roles = await this.enforcer.getRolesForUser(userEntityRef);
 
@@ -368,6 +371,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
         role,
         undefined,
         resourceType,
+        [action],
         [permissionName],
       );
 

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -262,18 +262,9 @@ export class RBACPermissionPolicy implements PermissionPolicy {
 
       if (isResourcePermission(request.permission)) {
         const resourceType = request.permission.resourceType;
-        const hasNamedPermission =
-          await this.hasImplicitPermissionSpecifiedByName(
-            userEntityRef,
-            permissionName,
-            action,
-          );
-        // Let's set up higher priority for permission specified by name, than by resource type
-        const obj = hasNamedPermission ? permissionName : resourceType;
 
-        status = await this.isAuthorized(userEntityRef, obj, action);
-
-        if (status && identityResp) {
+        // handle conditions if they are present
+        if (identityResp) {
           const conditionResult = await this.handleConditions(
             userEntityRef,
             resourceType,
@@ -285,7 +276,20 @@ export class RBACPermissionPolicy implements PermissionPolicy {
             return conditionResult;
           }
         }
+
+        // handle permission with 'resource' type
+        const hasNamedPermission =
+          await this.hasImplicitPermissionSpecifiedByName(
+            userEntityRef,
+            permissionName,
+            action,
+          );
+        // Let's set up higher priority for permission specified by name, than by resource type
+        const obj = hasNamedPermission ? permissionName : resourceType;
+
+        status = await this.isAuthorized(userEntityRef, obj, action);
       } else {
+        // handle permission with 'basic' type
         status = await this.isAuthorized(userEntityRef, permissionName, action);
       }
 

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -4,6 +4,9 @@ import { BackstageIdentityResponse } from '@backstage/plugin-auth-node';
 import {
   AuthorizeResult,
   isResourcePermission,
+  PermissionCondition,
+  PermissionCriteria,
+  PermissionRuleParams,
   PolicyDecision,
 } from '@backstage/plugin-permission-common';
 import {
@@ -27,6 +30,8 @@ import { EnforcerDelegate } from './enforcer-delegate';
 import { validateEntityReference } from './policies-validation';
 
 const adminRoleName = 'role:default/rbac_admin';
+
+type NonEmptyArray<T> = [T, ...T[]];
 
 const useAdminsFromConfig = async (
   admins: Config[],
@@ -271,23 +276,38 @@ export class RBACPermissionPolicy implements PermissionPolicy {
         if (status && identityResp) {
           const roles = await this.enforcer.getRolesForUser(userEntityRef);
           console.log(`===== Roles ${roles} ${userEntityRef} ===`);
-          let conditionalDecision;
+
+          const conditions: PermissionCriteria<
+            PermissionCondition<string, PermissionRuleParams>
+          >[] = [];
+          let pluginId = '';
           for (const role of roles) {
-            conditionalDecision = await this.conditionStorage.findCondition(
-              role,
-              resourceType,
-            );
-            // todo handle few roles
+            const conditionalDecision =
+              await this.conditionStorage.findCondition(role, resourceType);
+
             if (conditionalDecision) {
-              break;
+              pluginId = conditionalDecision.pluginId;
+              conditions.push(conditionalDecision.conditions);
             }
           }
 
-          if (conditionalDecision) {
+          if (conditions.length > 0) {
+            console.log(`----- ${JSON.stringify(conditions)}`);
             this.logger.info(
               `${identityResp?.identity.userEntityRef} executed condition for permission ${request.permission.name}, resource type ${resourceType} and action ${action}`,
             );
-            return conditionalDecision;
+            return {
+              pluginId,
+              result: AuthorizeResult.CONDITIONAL,
+              resourceType,
+              conditions: {
+                allOf: conditions as NonEmptyArray<
+                  PermissionCriteria<
+                    PermissionCondition<string, PermissionRuleParams>
+                  >
+                >,
+              },
+            };
           }
         }
       } else {

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -280,8 +280,8 @@ export class RBACPermissionPolicy implements PermissionPolicy {
           const conditionResult = await this.handleConditions(
             userEntityRef,
             resourceType,
+            request.permission.name,
             action,
-            request,
             identityResp,
           );
           if (conditionResult) {
@@ -354,8 +354,8 @@ export class RBACPermissionPolicy implements PermissionPolicy {
   private async handleConditions(
     userEntityRef: string,
     resourceType: string,
-    action: PermissionAction,
-    request: PolicyQuery,
+    permissionName: string,
+    action: string,
     identityResp?: BackstageIdentityResponse | undefined,
   ): Promise<PolicyDecision | undefined> {
     const roles = await this.enforcer.getRolesForUser(userEntityRef);
@@ -370,8 +370,9 @@ export class RBACPermissionPolicy implements PermissionPolicy {
         role,
         undefined,
         resourceType,
-        [action],
+        [permissionName],
       );
+      console.log(`==== ${conditionalDecisions}`);
 
       if (conditionalDecisions.length > 0) {
         pluginId = conditionalDecisions[0].pluginId;
@@ -382,7 +383,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     if (conditions.length > 0) {
       console.log(`----- ${JSON.stringify(conditions)}`);
       this.logger.info(
-        `${identityResp?.identity.userEntityRef} executed condition for permission ${request.permission.name}, resource type ${resourceType} and action ${action}`,
+        `${identityResp?.identity.userEntityRef} executed condition for permission ${permissionName}, resource type ${resourceType} and action ${action}`,
       );
       return {
         pluginId,

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -17,10 +17,7 @@ import {
 import { Knex } from 'knex';
 import { Logger } from 'winston';
 
-import {
-  NonEmptyArray,
-  PermissionAction,
-} from '@janus-idp/backstage-plugin-rbac-common';
+import { NonEmptyArray } from '@janus-idp/backstage-plugin-rbac-common';
 
 import { ConditionalStorage } from '../database/conditional-storage';
 import { PolicyMetadataStorage } from '../database/policy-metadata-storage';

--- a/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
@@ -336,7 +336,7 @@ describe('plugin-endpoint', () => {
           resourceType: 'catalog-entity',
         },
       ]);
-      expect(metadata!.rules).toEqual([
+      expect(metadata?.rules).toEqual([
         {
           description: 'Allow entities with the specified label',
           name: 'HAS_LABEL',

--- a/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
@@ -306,4 +306,55 @@ describe('plugin-endpoint', () => {
       ]);
     });
   });
+
+  describe('Test get plugin metadata by id', () => {
+    it('should return metadata by id', async () => {
+      backendPluginIDsProviderMock.getPluginIds.mockReturnValue(['catalog']);
+
+      mockUrlReaderService.readUrl.mockReturnValue(mockReadUrlResponse);
+      bufferMock.toString.mockReturnValueOnce(
+        '{"permissions":[{"type":"resource","name":"catalog.entity.read","attributes":{"action":"read"},"resourceType":"catalog-entity"}], "rules": [{"description":"Allow entities with the specified label","name":"HAS_LABEL","paramsSchema":{"$schema":"http://json-schema.org/draft-07/schema#","additionalProperties":false,"properties":{"label":{"description":"Name of the label to match on","type":"string"}},"required":["label"],"type":"object"},"resourceType":"catalog-entity"}]}',
+      );
+
+      const collector = new PluginPermissionMetadataCollector(
+        mockPluginEndpointDiscovery,
+        backendPluginIDsProviderMock,
+        logger,
+        config,
+      );
+      const metadata = await collector.getMetadataByPluginId(
+        'catalog',
+        undefined,
+      );
+
+      expect(metadata).not.toBeUndefined();
+      expect(metadata?.permissions).toEqual([
+        {
+          name: 'catalog.entity.read',
+          attributes: { action: 'read' },
+          type: 'resource',
+          resourceType: 'catalog-entity',
+        },
+      ]);
+      expect(metadata!.rules).toEqual([
+        {
+          description: 'Allow entities with the specified label',
+          name: 'HAS_LABEL',
+          paramsSchema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            additionalProperties: false,
+            properties: {
+              label: {
+                description: 'Name of the label to match on',
+                type: 'string',
+              },
+            },
+            required: ['label'],
+            type: 'object',
+          },
+          resourceType: 'catalog-entity',
+        },
+      ]);
+    });
+  });
 });

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -150,9 +150,9 @@ const policyMetadataStorageMock: PolicyMetadataStorage = {
 };
 
 const conditionalStorage = {
-  getConditions: jest.fn().mockImplementation(),
+  filterConditions: jest.fn().mockImplementation(),
   createCondition: jest.fn().mockImplementation(),
-  findCondition: jest.fn().mockImplementation(),
+  findUniqueCondition: jest.fn().mockImplementation(),
   getCondition: jest.fn().mockImplementation(),
   deleteCondition: jest.fn().mockImplementation(),
   updateCondition: jest.fn().mockImplementation(),
@@ -2490,9 +2490,11 @@ describe('REST policies api', () => {
   describe('Conditions REST api', () => {
     const conditions: RoleConditionalPolicyDecision[] = [
       {
+        id: 1,
         pluginId: 'catalog',
         roleEntityRef: 'role:default/test',
         resourceType: 'catalog-entity',
+        actions: ['read'],
         result: AuthorizeResult.CONDITIONAL,
         conditions: {
           rule: 'IS_ENTITY_OWNER',
@@ -2503,7 +2505,7 @@ describe('REST policies api', () => {
     ];
 
     beforeEach(() => {
-      conditionalStorage.getConditions = jest
+      conditionalStorage.filterConditions = jest
         .fn()
         .mockImplementation(async () => {
           return conditions;
@@ -2545,7 +2547,7 @@ describe('REST policies api', () => {
       });
 
       it('should be returned condition decision by pluginId', async () => {
-        conditionalStorage.getConditions = jest
+        conditionalStorage.filterConditions = jest
           .fn()
           .mockImplementation(
             async (
@@ -2567,7 +2569,7 @@ describe('REST policies api', () => {
       });
 
       it('should be returned empty condition decision list by pluginId', async () => {
-        conditionalStorage.getConditions = jest
+        conditionalStorage.filterConditions = jest
           .fn()
           .mockImplementation(
             async (
@@ -2589,7 +2591,7 @@ describe('REST policies api', () => {
       });
 
       it('should be returned condition decision by resourceType', async () => {
-        conditionalStorage.getConditions = jest
+        conditionalStorage.filterConditions = jest
           .fn()
           .mockImplementation(
             async (
@@ -2772,9 +2774,11 @@ describe('REST policies api', () => {
           });
 
         const roleCondition: RoleConditionalPolicyDecision = {
+          id: 1,
           pluginId: 'catalog',
           roleEntityRef: 'role:default/test',
           resourceType: 'catalog-entity',
+          actions: ['read'],
           result: AuthorizeResult.CONDITIONAL,
           conditions: {
             rule: 'IS_ENTITY_OWNER',
@@ -2832,9 +2836,11 @@ describe('REST policies api', () => {
           { result: AuthorizeResult.ALLOW },
         ]);
         const conditionDecision: RoleConditionalPolicyDecision = {
+          id: 1,
           pluginId: 'catalog',
           roleEntityRef: 'role:default/test',
           resourceType: 'catalog-entity',
+          actions: ['read'],
           result: AuthorizeResult.CONDITIONAL,
           conditions: {
             rule: 'IS_ENTITY_OWNER',

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -226,6 +226,8 @@ describe('REST policies api', () => {
         return conditions;
       });
 
+    conditionalStorage.getCondition.mockReset();
+
     validateRoleConditionMock.mockReset();
     mockEnforcer.hasPolicy = jest
       .fn()
@@ -2510,16 +2512,14 @@ describe('REST policies api', () => {
   });
 
   // Define a test suite for the GET /conditions endpoint
-  describe('GET /roles/:kind/:namespace:/name/conditions', () => {
+  describe('GET /roles/conditions', () => {
     it('should return a status of Unauthorized', async () => {
       mockedAuthorizeConditional.mockImplementationOnce(async () => [
         { result: AuthorizeResult.DENY },
       ]);
 
       // Perform the GET request to the endpoint
-      const result = await request(app)
-        .get('/roles/role/default/test/conditions')
-        .send();
+      const result = await request(app).get('/roles/conditions').send();
 
       expect(mockedAuthorizeConditional).toHaveBeenCalledWith(
         [{ permission: policyEntityReadPermission }],
@@ -2535,9 +2535,7 @@ describe('REST policies api', () => {
     });
 
     it('should be returned list all condition decisions', async () => {
-      const result = await request(app)
-        .get('/roles/role/default/test/conditions')
-        .send();
+      const result = await request(app).get('/roles/conditions').send();
       expect(result.statusCode).toBe(200);
       expect(result.body).toEqual(conditions);
       expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(0);
@@ -2559,7 +2557,7 @@ describe('REST policies api', () => {
           },
         );
       const result = await request(app)
-        .get('/roles/role/default/test/conditions?pluginId=catalog')
+        .get('/roles/conditions?pluginId=catalog')
         .send();
       expect(result.statusCode).toBe(200);
       expect(result.body).toEqual(conditions);
@@ -2581,7 +2579,7 @@ describe('REST policies api', () => {
           },
         );
       const result = await request(app)
-        .get('/roles/role/default/test/conditions?pluginId=scaffolder')
+        .get('/roles/conditions?pluginId=scaffolder')
         .send();
       expect(result.statusCode).toBe(200);
       expect(result.body).toEqual([]);
@@ -2603,22 +2601,20 @@ describe('REST policies api', () => {
           },
         );
       const result = await request(app)
-        .get('/roles/role/default/test/conditions?resourceType=catalog-entity')
+        .get('/roles/conditions?resourceType=catalog-entity')
         .send();
       expect(result.statusCode).toBe(200);
       expect(result.body).toEqual(conditions);
     });
   });
 
-  describe('DELETE /roles/:kind/:namespace:/name/conditions/:id', () => {
+  describe('DELETE /roles/conditions/:id', () => {
     it('should return a status of Unauthorized', async () => {
       mockedAuthorizeConditional.mockImplementationOnce(async () => [
         { result: AuthorizeResult.DENY },
       ]);
 
-      const result = await request(app)
-        .delete('/roles/role/default/test/conditions/1')
-        .send();
+      const result = await request(app).delete('/roles/conditions/1').send();
 
       expect(mockedAuthorizeConditional).toHaveBeenCalledWith(
         [{ permission: policyEntityDeletePermission }],
@@ -2634,9 +2630,7 @@ describe('REST policies api', () => {
     });
 
     it('should delete condition decision by id', async () => {
-      const result = await request(app)
-        .delete('/roles/role/default/test/conditions/1')
-        .send();
+      const result = await request(app).delete('/roles/conditions/1').send();
 
       expect(result.statusCode).toEqual(204);
       expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(1);
@@ -2647,9 +2641,7 @@ describe('REST policies api', () => {
         throw new Error('Failed to delete condition decision by id');
       });
 
-      const result = await request(app)
-        .delete('/roles/role/default/test/conditions/1')
-        .send();
+      const result = await request(app).delete('/roles/conditions/1').send();
 
       expect(result.statusCode).toEqual(500);
       expect(result.body.error.message).toEqual(
@@ -2659,7 +2651,7 @@ describe('REST policies api', () => {
 
     it('should return return 400', async () => {
       const result = await request(app)
-        .delete('/roles/role/default/test/conditions/non-number')
+        .delete('/roles/conditions/non-number')
         .send();
       expect(result.statusCode).toBe(400);
       expect(result.body.error).toEqual({
@@ -2669,15 +2661,13 @@ describe('REST policies api', () => {
     });
   });
 
-  describe('GET /roles/:kind/:namespace:/name/condition/:id', () => {
+  describe('GET /roles/condition/:id', () => {
     it('should return a status of Unauthorized', async () => {
       mockedAuthorizeConditional.mockImplementationOnce(async () => [
         { result: AuthorizeResult.DENY },
       ]);
 
-      const result = await request(app)
-        .get('/roles/role/default/test/conditions/1')
-        .send();
+      const result = await request(app).get('/roles/conditions/1').send();
 
       expect(mockedAuthorizeConditional).toHaveBeenCalledWith(
         [{ permission: policyEntityReadPermission }],
@@ -2702,23 +2692,14 @@ describe('REST policies api', () => {
           return undefined;
         });
 
-      const result = await request(app)
-        .get('/roles/role/default/test/conditions/1')
-        .send();
+      const result = await request(app).get('/roles/conditions/1').send();
       expect(result.statusCode).toBe(200);
       expect(result.body).toEqual(conditions[0]);
       expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(0);
     });
 
     it('should return return 404', async () => {
-      conditionalStorage.getCondition = jest
-        .fn()
-        .mockImplementation(async () => {
-          return [];
-        });
-      const result = await request(app)
-        .get('/roles/role/default/test/conditions/1')
-        .send();
+      const result = await request(app).get('/roles/conditions/1').send();
       expect(result.statusCode).toBe(404);
       expect(result.body.error).toEqual({
         message: '',
@@ -2728,7 +2709,7 @@ describe('REST policies api', () => {
 
     it('should return return 400', async () => {
       const result = await request(app)
-        .get('/roles/role/default/test/conditions/non-number')
+        .get('/roles/conditions/non-number')
         .send();
       expect(result.statusCode).toBe(400);
       expect(result.body.error).toEqual({
@@ -2738,15 +2719,13 @@ describe('REST policies api', () => {
     });
   });
 
-  describe('POST /roles/:kind/:namespace:/name/conditions', () => {
+  describe('POST /roles/conditions', () => {
     it('should return a status of Unauthorized', async () => {
       mockedAuthorizeConditional.mockImplementationOnce(async () => [
         { result: AuthorizeResult.DENY },
       ]);
 
-      const result = await request(app)
-        .post('/roles/role/default/test/conditions')
-        .send();
+      const result = await request(app).post('/roles/conditions').send();
 
       expect(mockedAuthorizeConditional).toHaveBeenCalledWith(
         [{ permission: policyEntityCreatePermission }],
@@ -2780,7 +2759,7 @@ describe('REST policies api', () => {
         },
       };
       const result = await request(app)
-        .post('/roles/role/default/test/conditions')
+        .post('/roles/conditions')
         .send(roleCondition);
 
       expect(result.statusCode).toBe(201);
@@ -2790,15 +2769,13 @@ describe('REST policies api', () => {
     });
   });
 
-  describe('PUT /roles/:kind/:namespace:/name/conditions', () => {
+  describe('PUT /roles/conditions', () => {
     it('should return a status of Unauthorized', async () => {
       mockedAuthorizeConditional.mockImplementationOnce(async () => [
         { result: AuthorizeResult.DENY },
       ]);
 
-      const result = await request(app)
-        .put('/roles/role/default/test/conditions/1')
-        .send();
+      const result = await request(app).put('/roles/conditions/1').send();
 
       expect(mockedAuthorizeConditional).toHaveBeenCalledWith(
         [{ permission: policyEntityUpdatePermission }],
@@ -2815,7 +2792,7 @@ describe('REST policies api', () => {
 
     it('should return return 400', async () => {
       const result = await request(app)
-        .put('/roles/role/default/test/conditions/non-number')
+        .put('/roles/conditions/non-number')
         .send();
       expect(result.statusCode).toBe(400);
       expect(result.body.error).toEqual({
@@ -2842,7 +2819,7 @@ describe('REST policies api', () => {
         },
       };
       const result = await request(app)
-        .put('/roles/role/default/test/conditions/1')
+        .put('/roles/conditions/1')
         .send(conditionDecision);
 
       expect(mockedAuthorizeConditional).toHaveBeenCalledWith(

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -2494,7 +2494,7 @@ describe('REST policies api', () => {
         pluginId: 'catalog',
         roleEntityRef: 'role:default/test',
         resourceType: 'catalog-entity',
-        actions: ['read'],
+        permissions: [{ name: 'catalog.entity.read', action: 'read' }],
         result: AuthorizeResult.CONDITIONAL,
         conditions: {
           rule: 'IS_ENTITY_OWNER',
@@ -2778,7 +2778,7 @@ describe('REST policies api', () => {
           pluginId: 'catalog',
           roleEntityRef: 'role:default/test',
           resourceType: 'catalog-entity',
-          actions: ['read'],
+          permissions: [{ name: 'catalog.entity.read', action: 'read' }],
           result: AuthorizeResult.CONDITIONAL,
           conditions: {
             rule: 'IS_ENTITY_OWNER',
@@ -2840,7 +2840,7 @@ describe('REST policies api', () => {
           pluginId: 'catalog',
           roleEntityRef: 'role:default/test',
           resourceType: 'catalog-entity',
-          actions: ['read'],
+          permissions: [{ name: 'catalog.entity.read', action: 'read' }],
           result: AuthorizeResult.CONDITIONAL,
           conditions: {
             rule: 'IS_ENTITY_OWNER',

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -191,6 +191,22 @@ const conditions: RoleConditionalPolicyDecision<PermissionInfo>[] = [
   },
 ];
 
+const expectedConditions: RoleConditionalPolicyDecision<PermissionAction>[] = [
+  {
+    id: 1,
+    pluginId: 'catalog',
+    roleEntityRef: 'role:default/test',
+    resourceType: 'catalog-entity',
+    permissionMapping: ['read'],
+    result: AuthorizeResult.CONDITIONAL,
+    conditions: {
+      rule: 'IS_ENTITY_OWNER',
+      resourceType: 'catalog-entity',
+      params: { claims: ['group:default/team-a'] },
+    },
+  },
+];
+
 describe('REST policies api', () => {
   let app: express.Express;
 
@@ -2543,7 +2559,7 @@ describe('REST policies api', () => {
     it('should be returned list all condition decisions', async () => {
       const result = await request(app).get('/roles/conditions').send();
       expect(result.statusCode).toBe(200);
-      expect(result.body).toEqual(conditions);
+      expect(result.body).toEqual(expectedConditions);
       expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(0);
     });
 
@@ -2566,7 +2582,7 @@ describe('REST policies api', () => {
         .get('/roles/conditions?pluginId=catalog')
         .send();
       expect(result.statusCode).toBe(200);
-      expect(result.body).toEqual(conditions);
+      expect(result.body).toEqual(expectedConditions);
     });
 
     it('should be returned empty condition decision list by pluginId', async () => {
@@ -2610,7 +2626,7 @@ describe('REST policies api', () => {
         .get('/roles/conditions?resourceType=catalog-entity')
         .send();
       expect(result.statusCode).toBe(200);
-      expect(result.body).toEqual(conditions);
+      expect(result.body).toEqual(expectedConditions);
     });
   });
 
@@ -2700,7 +2716,7 @@ describe('REST policies api', () => {
 
       const result = await request(app).get('/roles/conditions/1').send();
       expect(result.statusCode).toBe(200);
-      expect(result.body).toEqual(conditions[0]);
+      expect(result.body).toEqual(expectedConditions[0]);
       expect(mockIdentityClient.getIdentity).toHaveBeenCalledTimes(0);
     });
 

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -48,6 +48,7 @@ import {
   RoleMetadataStorage,
 } from '../database/role-metadata';
 import { deepSortedEqual, policyToString } from '../helper';
+import { validateRoleCondition } from './condition-validation';
 import { EnforcerDelegate } from './enforcer-delegate';
 import { PluginPermissionMetadataCollector } from './plugin-endpoints';
 import {
@@ -622,11 +623,12 @@ export class PolicesServer {
         const roleEntityRef = this.getEntityReference(req, true);
 
         const conditionalPolicy: RoleConditionalPolicyDecision = req.body;
-        // TODO add validation.
         const roleConditionPolicy = {
           ...conditionalPolicy,
           roleEntityRef,
         };
+
+        validateRoleCondition(roleConditionPolicy);
 
         const id =
           await this.conditionalStorage.createCondition(roleConditionPolicy);
@@ -707,11 +709,11 @@ export class PolicesServer {
         }
 
         const conditionalPolicy: RoleConditionalPolicyDecision = req.body;
-        // TODO add validation.
         const roleConditionPolicy = {
           ...conditionalPolicy,
           roleEntityRef,
         };
+        validateRoleCondition(roleConditionPolicy);
 
         await this.conditionalStorage.updateCondition(id, roleConditionPolicy);
         resp.status(200).end();

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -605,7 +605,14 @@ export class PolicesServer {
         this.getActionQueries(request.query.actions),
       );
 
-      response.json(conditions);
+      const result: RoleConditionalPolicyDecision<PermissionAction>[] =
+        conditions.map(condition => {
+          return {
+            ...condition,
+            permissionMapping: condition.permissionMapping.map(pm => pm.action),
+          };
+        });
+      response.json(result);
     });
 
     router.post('/roles/conditions', async (request, response) => {
@@ -652,7 +659,12 @@ export class PolicesServer {
         throw new NotFoundError();
       }
 
-      response.json(condition);
+      const result: RoleConditionalPolicyDecision<PermissionAction> = {
+        ...condition,
+        permissionMapping: condition.permissionMapping.map(pm => pm.action),
+      };
+
+      response.json(result);
     });
 
     router.delete('/roles/conditions/:id', async (request, response) => {

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -927,7 +927,7 @@ export class PolicesServer {
         roleConditionPolicy.pluginId,
         token,
       );
-    if (!rule || !rule.permissions) {
+    if (!rule?.permissions) {
       throw new Error(
         `Unable to get permission list for plugin ${roleConditionPolicy.pluginId}`,
       );

--- a/plugins/rbac-common/src/types.ts
+++ b/plugins/rbac-common/src/types.ts
@@ -54,9 +54,12 @@ export type PermissionInfo = {
   action: PermissionAction;
 };
 
-export type RoleConditionalPolicyDecision = ConditionalPolicyDecision & {
+// Frontend should use RoleConditionalPolicyDecision<PermissionAction>
+export type RoleConditionalPolicyDecision<
+  T extends PermissionAction | PermissionInfo,
+> = ConditionalPolicyDecision & {
   id: number;
   roleEntityRef: string;
 
-  permissions: PermissionInfo[];
+  permissionMapping: T[];
 };

--- a/plugins/rbac-common/src/types.ts
+++ b/plugins/rbac-common/src/types.ts
@@ -48,3 +48,5 @@ export type PermissionPolicy = {
 export type RoleConditionalPolicyDecision = ConditionalPolicyDecision & {
   roleEntityRef: string;
 };
+
+export type NonEmptyArray<T> = [T, ...T[]];

--- a/plugins/rbac-common/src/types.ts
+++ b/plugins/rbac-common/src/types.ts
@@ -49,9 +49,14 @@ export type NonEmptyArray<T> = [T, ...T[]];
 
 export type PermissionAction = 'create' | 'read' | 'update' | 'delete' | 'use';
 
+export type PermissionInfo = {
+  name: string;
+  action: PermissionAction;
+};
+
 export type RoleConditionalPolicyDecision = ConditionalPolicyDecision & {
   id: number;
   roleEntityRef: string;
 
-  actions: PermissionAction[];
+  permissions: PermissionInfo[];
 };

--- a/plugins/rbac-common/src/types.ts
+++ b/plugins/rbac-common/src/types.ts
@@ -45,8 +45,13 @@ export type PermissionPolicy = {
   policies?: Policy[];
 };
 
-export type RoleConditionalPolicyDecision = ConditionalPolicyDecision & {
-  roleEntityRef: string;
-};
-
 export type NonEmptyArray<T> = [T, ...T[]];
+
+export type PermissionAction = 'create' | 'read' | 'update' | 'delete' | 'use';
+
+export type RoleConditionalPolicyDecision = ConditionalPolicyDecision & {
+  id: number;
+  roleEntityRef: string;
+
+  actions: PermissionAction[];
+};

--- a/plugins/rbac-common/src/types.ts
+++ b/plugins/rbac-common/src/types.ts
@@ -1,3 +1,5 @@
+import { ConditionalPolicyDecision } from '@backstage/plugin-permission-common';
+
 export type Source =
   | 'rest' // created via REST API
   | 'csv-file' // created via policies-csv-file with defined path in the application configuration
@@ -41,4 +43,8 @@ export type UpdatePolicy = {
 export type PermissionPolicy = {
   pluginId?: string;
   policies?: Policy[];
+};
+
+export type RoleConditionalPolicyDecision = ConditionalPolicyDecision & {
+  roleEntityRef: string;
 };


### PR DESCRIPTION
### What does this pull request do

Rework condition policies to bound them to RBAC roles

### What issue is referenced in this pull request?

https://issues.redhat.com/browse/RHIDP-1526
https://issues.redhat.com/browse/RHIDP-1616

### How to test it:

You need to have two users: admin and test user.  "user:default/logarifm" is my test user and member of group:defalt/team-a. Token should be retrieved for admin user.

#### Let's create test role:

`
curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences":  [ "user:default/logarifm" ], "name": "role:default/test" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
`

#### Let's create condition to display for user logarifm only his own catalogs:

`
curl -X POST "http://localhost:7007/api/permission/roles/conditions" -d '{"result":"CONDITIONAL","roleEntityRef": "role:default/test","pluginId":"catalog","resourceType":"catalog-entity", "permissionMapping": ["read"], "conditions":{"rule":"IS_ENTITY_OWNER","resourceType":"catalog-entity","params":{"claims":["group:default/team-a"]}}}' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
`

OR you can use criteria "not" and hide API catalogs for user logarifm:

`
curl -X POST "http://localhost:7007/api/permission/roles/conditions" -d '{"result":"CONDITIONAL","roleEntityRef": "role:default/test","pluginId":"catalog","resourceType":"catalog-entity","permissionMapping": ["read"],"conditions":{"not":{"rule":"IS_ENTITY_KIND","resourceType":"catalog-entity","params":{"kinds":["Api"]}}}}' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
`

Login like user logarifm and check catalog UI.

Retrieve list of all conditions: 

`
curl -X GET "http://localhost:7007/api/permission/roles/conditions" -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
`

Filter conditions with the query params:

`
curl -X GET "http://localhost:7007/api/permission/roles/conditions?roleEntityRef=role:default/test&&pluginId=catalog&&resourceType=catalog-entity&&actions=read" -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
`

#### Get condition by id:

`
curl -X GET "http://localhost:7007/api/permission/roles/conditions/1" -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
`

#### Update condition policy to display for logarifm user his own catalogs and list user groups:

`
curl -X PUT "http://localhost:7007/api/permission/roles/conditions/1" -d '{"result":"CONDITIONAL","roleEntityRef":"role:default/test", "pluginId":"catalog","resourceType":"catalog-entity","permissionMapping": ["read"],"conditions":{"anyOf":[{"rule":"IS_ENTITY_OWNER","resourceType":"catalog-entity","permissions": [{"name": "catalog.entity.read", "action": "read"}],"params":{"claims":["group:default/team-a"]}},{"rule":"IS_ENTITY_KIND","resourceType":"catalog-entity","params":{"kinds":["Group"]}}]}}' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
`

#### Delete condition by id:

`
curl -X DELETE "http://localhost:7007/api/permission/roles/conditions/1" -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
`