### PR TITLE
fix(rbac): pass token to readUrl for well-known permission endpoint

### DIFF
--- a/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
@@ -34,6 +34,7 @@ jest.mock('@backstage/backend-common', () => {
 });
 
 describe('plugin-endpoint', () => {
+  const fakeToken = 'fakeToken';
   const mockPluginEndpointDiscovery = {
     getBaseUrl: jest.fn().mockImplementation(async (pluginId: string) => {
       return `https://localhost:7007/api/${pluginId}`;
@@ -63,7 +64,7 @@ describe('plugin-endpoint', () => {
         logger,
         config,
       );
-      const policiesMetadata = await collector.getPluginPolicies();
+      const policiesMetadata = await collector.getPluginPolicies(fakeToken);
 
       expect(policiesMetadata.length).toEqual(0);
     });
@@ -82,7 +83,7 @@ describe('plugin-endpoint', () => {
         logger,
         config,
       );
-      const policiesMetadata = await collector.getPluginPolicies();
+      const policiesMetadata = await collector.getPluginPolicies(fakeToken);
 
       expect(policiesMetadata.length).toEqual(1);
       expect(policiesMetadata[0].pluginId).toEqual('permission');
@@ -112,7 +113,7 @@ describe('plugin-endpoint', () => {
         logger,
         config,
       );
-      const policiesMetadata = await collector.getPluginPolicies();
+      const policiesMetadata = await collector.getPluginPolicies(fakeToken);
 
       expect(policiesMetadata.length).toEqual(1);
       expect(policiesMetadata[0].pluginId).toEqual('permission');
@@ -151,7 +152,7 @@ describe('plugin-endpoint', () => {
         logger,
         config,
       );
-      const policiesMetadata = await collector.getPluginPolicies();
+      const policiesMetadata = await collector.getPluginPolicies(fakeToken);
 
       expect(policiesMetadata.length).toEqual(1);
       expect(policiesMetadata[0].pluginId).toEqual('permission');
@@ -192,7 +193,7 @@ describe('plugin-endpoint', () => {
         config,
       );
 
-      const policiesMetadata = await collector.getPluginPolicies();
+      const policiesMetadata = await collector.getPluginPolicies(fakeToken);
 
       expect(policiesMetadata.length).toEqual(1);
       expect(policiesMetadata[0].pluginId).toEqual('permission');
@@ -233,7 +234,7 @@ describe('plugin-endpoint', () => {
         logger,
         config,
       );
-      const policiesMetadata = await collector.getPluginPolicies();
+      const policiesMetadata = await collector.getPluginPolicies(fakeToken);
 
       expect(policiesMetadata.length).toEqual(1);
       expect(policiesMetadata[0].pluginId).toEqual('permission');
@@ -259,7 +260,8 @@ describe('plugin-endpoint', () => {
         logger,
         config,
       );
-      const conditionRulesMetadata = await collector.getPluginConditionRules();
+      const conditionRulesMetadata =
+        await collector.getPluginConditionRules(fakeToken);
 
       expect(conditionRulesMetadata.length).toEqual(0);
     });
@@ -278,7 +280,8 @@ describe('plugin-endpoint', () => {
         logger,
         config,
       );
-      const conditionRulesMetadata = await collector.getPluginConditionRules();
+      const conditionRulesMetadata =
+        await collector.getPluginConditionRules(fakeToken);
 
       expect(conditionRulesMetadata.length).toEqual(1);
       expect(conditionRulesMetadata[0].pluginId).toEqual('catalog');

--- a/plugins/rbac-backend/src/service/plugin-endpoints.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoints.ts
@@ -54,10 +54,10 @@ export class PluginPermissionMetadataCollector {
     });
   }
 
-  async getPluginConditionRules(): Promise<
-    PluginMetadataResponseSerializedRule[]
-  > {
-    const pluginMetadata = await this.getPluginMetaData();
+  async getPluginConditionRules(
+    token: string | undefined,
+  ): Promise<PluginMetadataResponseSerializedRule[]> {
+    const pluginMetadata = await this.getPluginMetaData(token);
 
     return pluginMetadata
       .filter(metadata => metadata.metaDataResponse.rules.length > 0)
@@ -69,8 +69,10 @@ export class PluginPermissionMetadataCollector {
       });
   }
 
-  async getPluginPolicies(): Promise<PluginPermissionMetaData[]> {
-    const pluginMetadata = await this.getPluginMetaData();
+  async getPluginPolicies(
+    token: string | undefined,
+  ): Promise<PluginPermissionMetaData[]> {
+    const pluginMetadata = await this.getPluginMetaData(token);
 
     return pluginMetadata
       .filter(metadata => metadata.metaDataResponse.permissions !== undefined)
@@ -88,14 +90,16 @@ export class PluginPermissionMetadataCollector {
     return [{ reader: new FetchUrlReader(), predicate: (_url: URL) => true }];
   };
 
-  private async getPluginMetaData(): Promise<PluginMetadataResponse[]> {
+  private async getPluginMetaData(
+    token: string | undefined,
+  ): Promise<PluginMetadataResponse[]> {
     let pluginResponses: PluginMetadataResponse[] = [];
 
     for (const pluginId of this.pluginIds) {
       const baseEndpoint = await this.discovery.getBaseUrl(pluginId);
       const wellKnownURL = `${baseEndpoint}/.well-known/backstage/permissions/metadata`;
       try {
-        const permResp = await this.urlReader.readUrl(wellKnownURL);
+        const permResp = await this.urlReader.readUrl(wellKnownURL, { token });
         const permMetaDataRaw = (await permResp.buffer()).toString();
         let permMetaData;
         try {

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -551,8 +551,8 @@ export class PolicesServer {
       },
     );
 
-    router.get('/plugins/policies', async (req, resp) => {
-      const decision = await this.authorize(req, {
+    router.get('/plugins/policies', async (request, response) => {
+      const decision = await this.authorize(request, {
         permission: policyEntityReadPermission,
       });
 
@@ -560,12 +560,15 @@ export class PolicesServer {
         throw new NotAllowedError(); // 403
       }
 
-      const policies = await pluginPermMetaData.getPluginPolicies();
-      resp.json(policies);
+      const authHeader = request.header('authorization');
+      const token = getBearerTokenFromAuthorizationHeader(authHeader);
+
+      const policies = await pluginPermMetaData.getPluginPolicies(token);
+      response.json(policies);
     });
 
-    router.get('/plugins/condition-rules', async (req, resp) => {
-      const decision = await this.authorize(req, {
+    router.get('/plugins/condition-rules', async (request, response) => {
+      const decision = await this.authorize(request, {
         permission: policyEntityReadPermission,
       });
 
@@ -573,8 +576,11 @@ export class PolicesServer {
         throw new NotAllowedError(); // 403
       }
 
-      const rules = await pluginPermMetaData.getPluginConditionRules();
-      resp.json(rules);
+      const authHeader = request.header('authorization');
+      const token = getBearerTokenFromAuthorizationHeader(authHeader);
+
+      const rules = await pluginPermMetaData.getPluginConditionRules(token);
+      response.json(rules);
     });
 
     router.get('/conditions', async (req, resp) => {


### PR DESCRIPTION
## Description

Passes a token to `readUrl` whenever we are looking up the permissions for a particular plugin using the `well-known` endpoint. Passing this token is important because if a user decides to implement the custom auth middleware mentioned within this documentation, then the `readUrl` will return with a 401 error leading to a 500 for the endpoints `/plugins/policies` and `/plugins/condition-rules`

## Fixes

- Fixes #1248 