### PR TITLE
fix(tekton): fix low vulnerability tooltip text

### DIFF
--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunVulnerabilities.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunVulnerabilities.tsx
@@ -109,7 +109,7 @@ const PipelineRunVulnerabilities: React.FC<PipelineRunVulnerabilitiesProps> = ({
           </div>
           <div className={classes.severityContainer}>
             <span className={classes.severityStatus}>
-              <Tooltip content="medium">
+              <Tooltip content="Low">
                 <AngleDoubleDownIcon
                   title="Low"
                   className={classes.lowStatus}


### PR DESCRIPTION
**Fixes:**

https://github.com/janus-idp/backstage-plugins/issues/1346

**Description:**

Hovering on low vulnerability count should open a tooltip that reads "Low"

Before:


https://github.com/janus-idp/backstage-plugins/assets/9964343/a58e4ffb-b075-4e37-a6a6-e17028a54270



After:


https://github.com/janus-idp/backstage-plugins/assets/9964343/53723995-dfed-462a-9424-8ef3a426b175


**steps to test this bug**

- Start the tekton plugin in dev mode
- Hover on the last count in the vulnerabilities column