### PR TITLE
chore(orchestrator): set npx packages version for openapi generation

### DIFF
--- a/plugins/orchestrator-common/scripts/openapi.sh
+++ b/plugins/orchestrator-common/scripts/openapi.sh
@@ -8,9 +8,9 @@ DEFINITION_FILE="./src/auto-generated/api/definition.ts"
 METADATA_FILE="./src/auto-generated/.METADATA.sha1"
 
 openapi_generate() {
-    npx openapi-typescript ${OPENAPI_SPEC_FILE} -o ${SCHEMA_FILE}
-    npx openapi-generator-cli generate -g asciidoc -i ./src/openapi/openapi.yaml -o ./src/auto-generated/docs/index.adoc
-    npx yaml2json -f ${OPENAPI_SPEC_FILE}
+    npx --yes openapi-typescript ${OPENAPI_SPEC_FILE} -o ${SCHEMA_FILE}
+    npx --yes openapi-generator-cli generate -g asciidoc -i ./src/openapi/openapi.yaml -o ./src/auto-generated/docs/index.adoc
+    npx --yes yaml2json -f ${OPENAPI_SPEC_FILE}
 
     OPENAPI_SPEC_FILE_JSON=$(tr -d '[:space:]' < "$(dirname $OPENAPI_SPEC_FILE)"/openapi.json)
     cat << EOF > ${DEFINITION_FILE}

--- a/plugins/orchestrator-common/scripts/openapi.sh
+++ b/plugins/orchestrator-common/scripts/openapi.sh
@@ -8,9 +8,9 @@ DEFINITION_FILE="./src/auto-generated/api/definition.ts"
 METADATA_FILE="./src/auto-generated/.METADATA.sha1"
 
 openapi_generate() {
-    npx --yes openapi-typescript ${OPENAPI_SPEC_FILE} -o ${SCHEMA_FILE}
-    npx --yes openapi-generator-cli generate -g asciidoc -i ./src/openapi/openapi.yaml -o ./src/auto-generated/docs/index.adoc
-    npx --yes yaml2json -f ${OPENAPI_SPEC_FILE}
+    npx --yes openapi-typescript@6.7.5 ${OPENAPI_SPEC_FILE} -o ${SCHEMA_FILE}
+    npx --yes @openapitools/openapi-generator-cli@v2.13.1 generate -g asciidoc -i ./src/openapi/openapi.yaml -o ./src/auto-generated/docs/index.adoc
+    npx --yes --package=js-yaml-cli@0.6.0 -- yaml2json -f ${OPENAPI_SPEC_FILE}
 
     OPENAPI_SPEC_FILE_JSON=$(tr -d '[:space:]' < "$(dirname $OPENAPI_SPEC_FILE)"/openapi.json)
     cat << EOF > ${DEFINITION_FILE}


### PR DESCRIPTION
Improve the openapi generation [script](https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator-common/scripts/openapi.sh#L5-L7) 

* use the `--yes` flag
so that the script doesn't need to prompt the user for the installation 
* fix a version to the packages that we are using

Solve [FLPATH-1072](https://issues.redhat.com/browse/FLPATH-1072)