### PR TITLE
chore(deps): dependabot.yml to work on monorepo root and do daily/weekly checks for yarn deps & GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "yarn" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,6 @@ updates:
       # pin to @keycloak/keycloak-admin-client <19 - see https://github.com/janus-idp/backstage-plugins/issues/47 https://github.com/janus-idp/backstage-plugins/issues/1046
       - dependency-name: "keycloak-admin-client"
         versions: ['> 18']
+      # pin to version that keycloak 18 needs
+      - dependency-name: "axios"
+        versions: ['>0.26.1']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,18 @@
 
 version: 2
 updates:
-  - package-ecosystem: "yarn" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "keycloak-admin-client"
+        # pin to @keycloak/keycloak-admin-client <19 - see https://github.com/janus-idp/backstage-plugins/issues/47 https://github.com/janus-idp/backstage-plugins/issues/1046
+        versions: ['> 18']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,11 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/" # for a monorepo, use root package.json and yarn.lock files
     schedule:
       interval: "daily"
     ignore:
+      # pin to @keycloak/keycloak-admin-client <19 - see https://github.com/janus-idp/backstage-plugins/issues/47 https://github.com/janus-idp/backstage-plugins/issues/1046
       - dependency-name: "keycloak-admin-client"
-        # pin to @keycloak/keycloak-admin-client <19 - see https://github.com/janus-idp/backstage-plugins/issues/47 https://github.com/janus-idp/backstage-plugins/issues/1046
         versions: ['> 18']


### PR DESCRIPTION
Create dependabot.yml to work on / of the monorepo and do daily/weekly checks for yarn deps & GH actions