### PR TITLE
fix(tekton): bump aonic-ui/pipelines package to fix acs table crashing issue

### DIFF
--- a/plugins/tekton/package.json
+++ b/plugins/tekton/package.json
@@ -26,7 +26,7 @@
     "ui-test": "yarn playwright test"
   },
   "dependencies": {
-    "@aonic-ui/pipelines": "^1.1.0",
+    "@aonic-ui/pipelines": "^1.1.1",
     "@backstage/catalog-model": "^1.4.4",
     "@backstage/core-components": "^0.14.0",
     "@backstage/core-plugin-api": "^1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
     tslib "^2.6.2"
     typescript "^5.2.2"
 
-"@aonic-ui/pipelines@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@aonic-ui/pipelines/-/pipelines-1.1.0.tgz#b40b1ffdc0c4c6d21a53c7dca9c7e48169e5e798"
-  integrity sha512-C5BvabW3Hhffn691DL3pwoUbN/2GcASjbFg3kDeFEElPp8G9UEJw5l4+c7esr/64/F/ffd2qA0ODNwAIcUVlcg==
+"@aonic-ui/pipelines@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@aonic-ui/pipelines/-/pipelines-1.1.1.tgz#7592d974bb69bbd403dc4c53f14ec80ba2a37a67"
+  integrity sha512-plfmKczOLdQltSO6hjOC7krx4NOWJm6gMOO6jwMo4H6jeMF+ABczagI7f7pONVe0iTG1TYyif4l6YZjJVAtBBQ==
   dependencies:
     "@patternfly/react-table" "^5.1.2"
     js-yaml "^4.1.0"


### PR DESCRIPTION
**Fixes:**
https://github.com/janus-idp/backstage-plugins/issues/1355


**Description:**
Handles the invalid ACS inputs gracefully instead of crashing the UI. 

**Steps to reproduce:**
1. Create Tasks and Pipelinerun from this gist - https://gist.github.com/karthikjeeyar/c3c4bf69df5e035f5dd4115cbccd5bf4
2. Once the Pipelinerun is complete, click on the output action to view the report.

**Before**:
<img width="1772" alt="Screenshot 2024-03-22 at 11 37 14 PM" src="https://github.com/janus-idp/backstage-plugins/assets/9964343/d71b6ec1-8a86-4c41-b18b-6a4c71a2aa3e">

**After**:

<img width="1732" alt="Screenshot 2024-03-22 at 10 52 14 PM" src="https://github.com/janus-idp/backstage-plugins/assets/9964343/560a96b5-e789-4120-bba4-bd05a0bed08f">





cc: @rohitkrai03 