### PR TITLE
fix(topology): adds check on service and routes to match same namespace as workloads

### DIFF
--- a/plugins/topology/src/__fixtures__/1-deployments.ts
+++ b/plugins/topology/src/__fixtures__/1-deployments.ts
@@ -1,7 +1,7 @@
 export const customResourceRoute = {
   metadata: {
     name: 'hello-minikube2',
-    namespace: 'jai-test',
+    namespace: 'test-app',
     uid: '17c0f520-3878-4834-96a1-b19854f0d06f',
     resourceVersion: '174049',
     creationTimestamp: '2023-05-22T08:14:25Z',

--- a/plugins/topology/src/utils/resource-utils.ts
+++ b/plugins/topology/src/utils/resource-utils.ts
@@ -106,6 +106,8 @@ export const getServicesForResource = (
   }
   const template = getPodTemplate(resource);
   return services.filter((service: V1Service) => {
+    if (resource.metadata?.namespace !== service.metadata?.namespace)
+      return false;
     const specSelector = service.spec?.selector || {};
     const selector = new LabelSelector(specSelector);
     return selector.matches(template);
@@ -262,7 +264,11 @@ export const getRoutesDataForResourceServices = (
 
   const routesData: RoutesData = routes.reduce(
     (acc: RoutesData, route: RouteKind) => {
-      if (route.spec?.to?.name && servicesNames.includes(route.spec.to.name)) {
+      if (
+        route.spec?.to?.name &&
+        servicesNames.includes(route.spec.to.name) &&
+        resource.metadata?.namespace === route.metadata?.namespace
+      ) {
         acc.push({
           route,
           url: getRouteWebURL(route),


### PR DESCRIPTION
**Fixes:** 

https://issues.redhat.com/browse/RHTAPBUGS-1166

https://issues.redhat.com/browse/RHIDP-1693

**Description:** 
Adds check on service and routes to match the same namespace as workloads, if resources are fetched across namespaces

**Test Setup:**
Create two workloads with the same name in two different namespaces.

**Screenshots:**

Before:

<img width="1725" alt="image" src="https://github.com/janus-idp/backstage-plugins/assets/5129024/b40b05c4-ea13-47ab-a94b-9b7661b4c8fb">


After:
<img width="1724" alt="image" src="https://github.com/janus-idp/backstage-plugins/assets/5129024/4686b835-95a3-43f7-813c-b70b420d9437">


