### PR TITLE
fix(quay): add queued status for tags waiting for scan

### DIFF
--- a/plugins/quay/src/components/QuayRepository/QuayRepository.test.tsx
+++ b/plugins/quay/src/components/QuayRepository/QuayRepository.test.tsx
@@ -97,6 +97,31 @@ describe('QuayRepository', () => {
     expect(queryByTestId('quay-repo-security-scan-progress')).not.toBeNull();
   });
 
+  it('should show queued status for the tag that are waiting in the queue to be scanned', () => {
+    (useTags as jest.Mock).mockReturnValue({
+      loading: false,
+      data: [
+        {
+          name: 'latest',
+          manifest_digest: undefined,
+          securityStatus: 'queued',
+          size: null,
+          last_modified: 'Wed, 15 Mar 2023 18:22:18 -0000',
+        },
+      ],
+    });
+    const { queryByTestId, queryByText } = render(
+      <BrowserRouter>
+        <QuayRepository />
+      </BrowserRouter>,
+    );
+
+    expect(queryByTestId('quay-repo-table')).not.toBeNull();
+    expect(queryByTestId('quay-repo-table-empty')).toBeNull();
+    expect(queryByText(/Quay repository/i)).toBeInTheDocument();
+    expect(queryByTestId('quay-repo-queued-for-scan')).not.toBeNull();
+  });
+
   it('should show table if loaded and data is present but shows unsupported if security scan is not supported', () => {
     (useTags as jest.Mock).mockReturnValue({
       loading: false,

--- a/plugins/quay/src/components/QuayRepository/tableHeading.tsx
+++ b/plugins/quay/src/components/QuayRepository/tableHeading.tsx
@@ -32,6 +32,14 @@ export const columns: TableColumn<QuayTagData>[] = [
         );
       }
 
+      if (rowData.securityStatus === 'queued') {
+        return (
+          <Tooltip title="The manifest for this tag is queued to be scanned for vulnerabilities">
+            <span data-testid="quay-repo-queued-for-scan">Queued</span>
+          </Tooltip>
+        );
+      }
+
       if (rowData.securityStatus === 'unsupported') {
         return (
           <Tooltip title="The manifest for this tag has an operating system or package manager unsupported by Quay Security Scanner">


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/RHTAPBUGS-1184

**Description:**

Quay plugin intercepts queued vulnerability image scan as `Passed`. I have added queued status to convey the right status to the users.

**Before:**

![image-2024-03-25-12-57-21-946](https://github.com/janus-idp/backstage-plugins/assets/9964343/ebec9243-23b2-410e-8fcb-2e61957477a3)

**After:**
<img width="1351" alt="Screenshot 2024-03-26 at 7 39 03 PM" src="https://github.com/janus-idp/backstage-plugins/assets/9964343/d492157c-8923-4775-af65-84f959ccd396">

**How to test:**

Push an image to quay.io and you can see it will be queued for scan, meanwhile go back to backstage quay plugin to see the new queued status there as well.
