### PR TITLE
chore: allow semantic release (RHIDP-1720) from main and 1.1.x+ branches (but not 1.0.x)

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+      # starting from 1.1.x, allow releases from the 1.yy.x branches as long as we remember to bump plugin versions in main immediately after creating a 1.new.x branch
+      # see this script for how to check which plugins need bumping
+      # see also root package.json -> .release.branches
+      - 1.**.x
+      # do not run on 1.0.x, as we didn't bump plugin versions correctly there
+      - '!1.0.x'
 
 concurrency:
   group: push

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "testTimeout": 15000
   },
   "release": {
-    "branches": "main",
+    "branches": ["main","[0-9]+.[0-9]+.x"],
     "plugins": [
       [
         "@semantic-release/commit-analyzer",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,10 @@
     "testTimeout": 15000
   },
   "release": {
-    "branches": ["main","[0-9]+.[0-9]+.x"],
+    "branches": [
+      "main",
+      "[0-9]+.[0-9]+.x"
+    ],
     "plugins": [
       [
         "@semantic-release/commit-analyzer",


### PR DESCRIPTION
### What does this PR do?

chore: [RHIDP-1720](https://issues.redhat.com//browse/RHIDP-1720) allow semantic release from main and 1.1.x+ branches (but not 1.0.x)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.