### PR TITLE
fix(3scale): revert readme change to pull plugin deps

### DIFF
--- a/plugins/3scale-backend/README.md
+++ b/plugins/3scale-backend/README.md
@@ -112,7 +112,7 @@ yarn workspace backend add @janus-idp/backstage-plugin-3scale-backend
 #### New Backend Procedure
 
 1. If installing into the new backend system, make the same configurations to the `app=config.yaml` as in the [Legacy Backend Installation Procedure](#legacy-backend-installation-procedure). Make sure to configure the schedule inside the `app-config.yaml` file. The default schedule is a frequency of 30 minutes and a timeout of 3 minutes.
-2. Add the following code to the `packages/backend/src/index.ts`  file:
+2. Add the following code to the `packages/backend/src/index.ts` file:
 
    ```ts title="packages/backend/src/index.ts"
    const backend = createBackend();


### PR DESCRIPTION
What does this PR do?

Similar to PR #1407, we are making a change to the readme in an attempt to get the new dependencies in the yarn lock file to be released. PR 1407 failed to release because of the prettier check. This change, hopefully, will allow us to get a good build.