### PR TITLE
fix(feedback-backend): fix the feedback url for mail and jira

### DIFF
--- a/plugins/feedback-backend/src/mocks/config.ts
+++ b/plugins/feedback-backend/src/mocks/config.ts
@@ -1,6 +1,7 @@
 export const mockConfig = {
   app: {
     title: 'Backstage Test App',
+    baseUrl: 'http://localhost:3000',
   },
   backend: {
     baseUrl: 'http://localhost:7007',


### PR DESCRIPTION
Closes to #1431

### About the PR

- Fixed feedback url in mail and jira body, when feedback is created using api
![image](https://github.com/janus-idp/backstage-plugins/assets/42431299/2d2ec4b9-3b08-48a5-8398-9dc72b887759)
- added conditions to check `entityRef` and `feedbackType` fields in post body