### PR TITLE
feat(rbac): add the ability to cache information

### DIFF
--- a/plugins/rbac-backend/README.md
+++ b/plugins/rbac-backend/README.md
@@ -175,3 +175,20 @@ The RBAC plugin offers the option to store policies in a database. It supports t
 - postgres: Recommended for production environments.
 
 Ensure that you have already configured the database backend for your Backstage instance, as the RBAC plugin utilizes the same database configuration.
+
+### Caching
+
+The RBAC offers optional cache support to enhance performance by reducing the need for the RBAC plugin to repeatedly traverse the user's group hierarchy graph. Although not mandatory, cache usage can cut down on the number of calls made while navigating Backstage. For instance, accessing the catalog page can trigger approximately 15 permission authorize API calls, which cache can help mitigate.
+
+However, we recognize the cache's downside: the potential for lingering user data after their removal from the organization. In such cases, we recommend using a short expiration time to manage essential API calls, ensuring cache validity during grouped API calls without prolonging user data retention.
+
+To enable caching, you will need to set maxSize and/or expiration under the cache section.
+
+```yaml
+permission:
+  enabled: true
+  rbac:
+    cache:
+      maxSize: 10 # Maximum size of the cache, defaults to 100
+      expiration: 60000 # Expiration in milliseconds (60 seconds), defaults to 1 hour
+```

--- a/plugins/rbac-backend/config.d.ts
+++ b/plugins/rbac-backend/config.d.ts
@@ -38,6 +38,23 @@ export interface Config {
        * The RBAC plugin will handle access control for plugins included in this list.
        */
       pluginsWithPermission?: string[];
+      /**
+       * An optional cache that can be used to help with performance issues
+       * Stores the groups that a user is attached to
+       * @visibility frontend
+       */
+      cache?: {
+        /**
+         * The maximum size of the cache
+         * @visibility frontend
+         */
+        maxSize?: number;
+        /**
+         * The expiration time of the cached user in milliseconds
+         * @visibility frontend
+         */
+        expiration?: number;
+      };
     };
   };
 }

--- a/plugins/rbac-backend/package.json
+++ b/plugins/rbac-backend/package.json
@@ -17,7 +17,7 @@
     "build": "backstage-cli package build",
     "tsc": "tsc",
     "lint": "backstage-cli package lint",
-    "test": "backstage-cli package test --passWithNoTests --coverage",
+    "test": "backstage-cli package test --passWithNoTests --coverage --testPathIgnorePatterns /__fixtures__/",
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack"

--- a/plugins/rbac-backend/src/__fixtures__/__utils__/utils.test.ts
+++ b/plugins/rbac-backend/src/__fixtures__/__utils__/utils.test.ts
@@ -1,0 +1,262 @@
+import { getVoidLogger, TokenManager } from '@backstage/backend-common';
+import { DatabaseService } from '@backstage/backend-plugin-api';
+import { ConfigReader } from '@backstage/config';
+
+import {
+  Adapter,
+  Enforcer,
+  Model,
+  newEnforcer,
+  newModelFromString,
+  StringAdapter,
+} from 'casbin';
+import * as Knex from 'knex';
+import { MockClient } from 'knex-mock-client';
+import { Logger } from 'winston';
+
+import {
+  PermissionPolicyMetadata,
+  RoleMetadata,
+  Source,
+} from '@janus-idp/backstage-plugin-rbac-common';
+
+import { resolve } from 'path';
+
+import { CasbinDBAdapterFactory } from '../../database/casbin-adapter-factory';
+import { ConditionalStorage } from '../../database/conditional-storage';
+import {
+  PermissionPolicyMetadataDao,
+  PolicyMetadataStorage,
+} from '../../database/policy-metadata-storage';
+import { RoleMetadataStorage } from '../../database/role-metadata';
+import { BackstageRoleManager } from '../../role-manager/role-manager';
+import { EnforcerDelegate } from '../../service/enforcer-delegate';
+import { MODEL } from '../../service/permission-model';
+import { RBACPermissionPolicy } from '../../service/permission-policy';
+
+const csvPermFile = resolve(
+  __dirname,
+  './../__fixtures__/data/valid-csv/rbac-policy.csv',
+);
+
+const knex = Knex.knex({ client: MockClient });
+
+export const catalogApiMock = {
+  getEntityAncestors: jest.fn().mockImplementation(),
+  getLocationById: jest.fn().mockImplementation(),
+  getEntities: jest.fn().mockImplementation(),
+  getEntitiesByRefs: jest.fn().mockImplementation(),
+  queryEntities: jest.fn().mockImplementation(),
+  getEntityByRef: jest.fn().mockImplementation(),
+  refreshEntity: jest.fn().mockImplementation(),
+  getEntityFacets: jest.fn().mockImplementation(),
+  addLocation: jest.fn().mockImplementation(),
+  getLocationByRef: jest.fn().mockImplementation(),
+  removeLocationById: jest.fn().mockImplementation(),
+  removeEntityByUid: jest.fn().mockImplementation(),
+  validateEntity: jest.fn().mockImplementation(),
+  getLocationByEntity: jest.fn().mockImplementation(),
+};
+
+export const roleMetadataStorageMock: RoleMetadataStorage = {
+  findRoleMetadata: jest
+    .fn()
+    .mockImplementation(
+      async (
+        _roleEntityRef: string,
+        _trx: Knex.Knex.Transaction,
+      ): Promise<RoleMetadata> => {
+        return { source: 'csv-file' };
+      },
+    ),
+  createRoleMetadata: jest.fn().mockImplementation(),
+  updateRoleMetadata: jest.fn().mockImplementation(),
+  removeRoleMetadata: jest.fn().mockImplementation(),
+};
+
+export const policyMetadataStorageMock: PolicyMetadataStorage = {
+  findPolicyMetadataBySource: jest
+    .fn()
+    .mockImplementation(
+      async (_source: Source): Promise<PermissionPolicyMetadataDao[]> => {
+        return [];
+      },
+    ),
+  findPolicyMetadata: jest
+    .fn()
+    .mockImplementation(
+      async (
+        _policy: string[],
+        _trx: Knex.Knex.Transaction,
+      ): Promise<PermissionPolicyMetadata> => {
+        const test: PermissionPolicyMetadata = {
+          source: 'csv-file',
+        };
+        return test;
+      },
+    ),
+  createPolicyMetadata: jest.fn().mockImplementation(),
+  removePolicyMetadata: jest.fn().mockImplementation(),
+};
+
+export const conditionalStorageMock: ConditionalStorage = {
+  filterConditions: jest.fn().mockImplementation(() => []),
+  createCondition: jest.fn().mockImplementation(),
+  findUniqueCondition: jest.fn().mockImplementation(),
+  getCondition: jest.fn().mockImplementation(),
+  deleteCondition: jest.fn().mockImplementation(),
+  updateCondition: jest.fn().mockImplementation(),
+};
+
+export const tokenManagerMock = {
+  getToken: jest.fn().mockImplementation(async () => {
+    return Promise.resolve({ token: 'some-token' });
+  }),
+  authenticate: jest.fn().mockImplementation(),
+};
+
+export const dbManagerMock: DatabaseService = {
+  getClient: jest.fn().mockImplementation(),
+};
+
+export const loggerMock: any = {
+  warn: jest.fn().mockImplementation(),
+  debug: jest.fn().mockImplementation(),
+};
+
+export function newConfigReader(
+  permFile?: string,
+  users?: Array<{ name: string }>,
+  superUsers?: Array<{ name: string }>,
+  cached?: boolean,
+): ConfigReader {
+  let cache;
+
+  const testUsers = [
+    {
+      name: 'user:default/guest',
+    },
+    {
+      name: 'group:default/guests',
+    },
+  ];
+
+  if (cached) {
+    cache = {
+      maxSize: 5,
+      expiration: 1000,
+    };
+  }
+
+  return new ConfigReader({
+    permission: {
+      rbac: {
+        'policies-csv-file': permFile || csvPermFile,
+        policyFileReload: true,
+        admin: {
+          users: users || testUsers,
+          superUsers: superUsers,
+        },
+        cache,
+      },
+    },
+    backend: {
+      database: {
+        client: 'better-sqlite3',
+        connection: ':memory:',
+      },
+    },
+  });
+}
+
+export async function newAdapter(
+  config: ConfigReader,
+  stringPolicy?: string,
+): Promise<Adapter> {
+  if (stringPolicy) {
+    return new StringAdapter(stringPolicy);
+  }
+  return await new CasbinDBAdapterFactory(
+    config,
+    dbManagerMock,
+  ).createAdapter();
+}
+
+export async function createEnforcer(
+  theModel: Model,
+  adapter: Adapter,
+  logger: Logger,
+  tokenManager: TokenManager,
+  config?: ConfigReader,
+): Promise<Enforcer> {
+  const configRead = config || new ConfigReader({});
+  const catalogDBClient = Knex.knex({ client: MockClient });
+  const enf = await newEnforcer(theModel, adapter);
+
+  const rm = new BackstageRoleManager(
+    catalogApiMock,
+    logger,
+    tokenManager,
+    catalogDBClient,
+    configRead,
+  );
+  enf.setRoleManager(rm);
+  enf.enableAutoBuildRoleLinks(false);
+  await enf.buildRoleLinks();
+
+  return enf;
+}
+
+export async function newEnforcerDelegate(
+  adapter: Adapter,
+  config: ConfigReader,
+  storedPolicies?: string[][],
+  storedGroupingPolicies?: string[][],
+  policyMock?: PolicyMetadataStorage,
+  roleMock?: RoleMetadataStorage,
+): Promise<EnforcerDelegate> {
+  const theModel = newModelFromString(MODEL);
+  const logger = getVoidLogger();
+
+  const enf = await createEnforcer(
+    theModel,
+    adapter,
+    logger,
+    tokenManagerMock,
+    config,
+  );
+
+  if (storedPolicies) {
+    await enf.addPolicies(storedPolicies);
+  }
+
+  if (storedGroupingPolicies) {
+    await enf.addGroupingPolicies(storedGroupingPolicies);
+  }
+
+  return new EnforcerDelegate(
+    enf,
+    policyMock || policyMetadataStorageMock,
+    roleMock || roleMetadataStorageMock,
+    knex,
+  );
+}
+
+export async function newPermissionPolicy(
+  config: ConfigReader,
+  enfDelegate: EnforcerDelegate,
+  roleMock?: RoleMetadataStorage,
+  policyMock?: PolicyMetadataStorage,
+  conMock?: ConditionalStorage,
+): Promise<RBACPermissionPolicy> {
+  const logger = getVoidLogger();
+  return await RBACPermissionPolicy.build(
+    logger,
+    config,
+    conMock || conditionalStorageMock,
+    enfDelegate,
+    roleMock || roleMetadataStorageMock,
+    policyMock || policyMetadataStorageMock,
+    knex,
+  );
+}

--- a/plugins/rbac-backend/src/role-manager/role-cache.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-cache.test.ts
@@ -63,6 +63,22 @@ describe('RoleCache', () => {
     });
   });
 
+  describe('delete', () => {
+    it('should delete the cached role', () => {
+      let cachedGroups = roleCache.get('user:default/todd');
+
+      expect(cachedGroups).toEqual(
+        new Set(['role:default/test', 'role:default/qe']),
+      );
+
+      roleCache.delete('user:default/todd');
+
+      cachedGroups = roleCache.get('user:default/todd');
+
+      expect(cachedGroups).toEqual(undefined);
+    });
+  });
+
   describe('shouldUpdate', () => {
     it('should not need updating if the cache has not expired', () => {
       const isExpired = roleCache.shouldUpdate('user:default/todd');
@@ -81,14 +97,6 @@ describe('RoleCache', () => {
       const isExpired = roleCache.shouldUpdate('user:default/test-user');
 
       expect(isExpired).toEqual(false);
-    });
-  });
-
-  describe('isEnabled', () => {
-    it('should be enabled', () => {
-      const isEnabled = roleCache.isEnabled();
-
-      expect(isEnabled).toEqual(true);
     });
   });
 });

--- a/plugins/rbac-backend/src/role-manager/role-cache.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-cache.test.ts
@@ -1,0 +1,93 @@
+import { GroupCache } from './role-cache';
+
+const usersToBeCached = [
+  'user:default/a',
+  'user:default/b',
+  'user:default/c',
+  'user:default/d',
+  'user:default/e',
+];
+
+const pause = (ms: number | undefined) =>
+  new Promise(res => setTimeout(res, ms));
+
+describe('GroupCache', () => {
+  let groupCache: GroupCache;
+
+  beforeEach(() => {
+    const maxSize = 5;
+    const maxAge = 1000; // one second
+    groupCache = new GroupCache(maxSize, maxAge);
+    groupCache.put('user:default/todd', [
+      'user:default/todd',
+      'group:default/qe',
+    ]);
+  });
+
+  describe('initialize', () => {
+    it('should initialize even when no parameters are given', () => {
+      const cache = new GroupCache();
+
+      expect(cache).not.toBeNull();
+    });
+  });
+
+  describe('get', () => {
+    it('should return the cached user by key', () => {
+      const cachedGroups = groupCache.get('user:default/todd');
+
+      expect(cachedGroups).toEqual(['user:default/todd', 'group:default/qe']);
+    });
+  });
+
+  describe('put', () => {
+    it('should add the cached user by key', () => {
+      groupCache.put('user:default/adam', [
+        'user:default/adam',
+        'group:default/qe',
+      ]);
+
+      const cachedGroups = groupCache.get('user:default/adam');
+      expect(cachedGroups).toEqual(['user:default/adam', 'group:default/qe']);
+    });
+
+    it('should remove the cached user if they were the last to be added', () => {
+      for (const user of usersToBeCached) {
+        groupCache.put(user, [user, 'group:default/qe']);
+      }
+
+      const removedCachedUser = groupCache.get('user:default/todd');
+
+      expect(removedCachedUser).toEqual(undefined);
+    });
+  });
+
+  describe('shouldUpdate', () => {
+    it('should not need updating if the cache has not expired', () => {
+      const isExpired = groupCache.shouldUpdate('user:default/todd');
+
+      expect(isExpired).toEqual(false);
+    });
+
+    it('should need updating if the cache is expired', async () => {
+      await pause(1001);
+      const isExpired = groupCache.shouldUpdate('user:default/todd');
+
+      expect(isExpired).toEqual(true);
+    });
+
+    it('should not need updating if the cache does not exist', () => {
+      const isExpired = groupCache.shouldUpdate('user:default/test-user');
+
+      expect(isExpired).toEqual(false);
+    });
+  });
+
+  describe('isEnabled', () => {
+    it('should be enabled', () => {
+      const isEnabled = groupCache.isEnabled();
+
+      expect(isEnabled).toEqual(true);
+    });
+  });
+});

--- a/plugins/rbac-backend/src/role-manager/role-cache.ts
+++ b/plugins/rbac-backend/src/role-manager/role-cache.ts
@@ -1,0 +1,48 @@
+export class GroupCache {
+  private cache: Map<string, { data: string[]; timestamp: number }> = new Map();
+  private maxEntries: number;
+  private maxAge: number;
+  constructor(maxEntries?: number, maxAge?: number) {
+    this.maxEntries = maxEntries || 100;
+    this.maxAge = maxAge || 60 * 60 * 1000; // 1 hour (60 minutes * 60 seconds * 1000 milliseconds) <-- double check this math? I think we want is in millisecond
+  }
+
+  public get(key: string): string[] | undefined {
+    const hasKey = this.cache.has(key);
+    if (!hasKey) return undefined;
+
+    const { data, timestamp } = this.cache.get(key)!;
+    this.cache.delete(key);
+    this.cache.set(key, { data, timestamp });
+
+    return data;
+  }
+
+  public put(key: string, value: string[]) {
+    if (this.cache.size >= this.maxEntries) {
+      const keyToDelete = this.cache.keys().next().value;
+      this.cache.delete(keyToDelete);
+    }
+
+    const currentTime = Date.now();
+
+    this.cache.set(key, { data: value, timestamp: currentTime });
+  }
+
+  public shouldUpdate(key: string): boolean {
+    const currentTime = Date.now();
+    const hasKey = this.cache.has(key);
+    if (!hasKey) return false;
+
+    const { timestamp } = this.cache.get(key)!;
+    if (currentTime - timestamp > this.maxAge) {
+      return true;
+    }
+
+    return false;
+  }
+
+  public isEnabled(): boolean {
+    return true;
+  }
+}

--- a/plugins/rbac-backend/src/role-manager/role-cache.ts
+++ b/plugins/rbac-backend/src/role-manager/role-cache.ts
@@ -30,6 +30,10 @@ export class RoleCache {
     this.cache.set(key, { data: value, timestamp: currentTime });
   }
 
+  public delete(key: string) {
+    this.cache.delete(key);
+  }
+
   public shouldUpdate(key: string): boolean {
     const currentTime = Date.now();
     const hasKey = this.cache.has(key);
@@ -41,9 +45,5 @@ export class RoleCache {
     }
 
     return false;
-  }
-
-  public isEnabled(): boolean {
-    return true;
   }
 }

--- a/plugins/rbac-backend/src/role-manager/role-cache.ts
+++ b/plugins/rbac-backend/src/role-manager/role-cache.ts
@@ -1,5 +1,6 @@
-export class GroupCache {
-  private cache: Map<string, { data: string[]; timestamp: number }> = new Map();
+export class RoleCache {
+  private cache: Map<string, { data: Set<string>; timestamp: number }> =
+    new Map();
   private maxEntries: number;
   private maxAge: number;
   constructor(maxEntries?: number, maxAge?: number) {
@@ -7,7 +8,7 @@ export class GroupCache {
     this.maxAge = maxAge || 60 * 60 * 1000; // 1 hour (60 minutes * 60 seconds * 1000 milliseconds) <-- double check this math? I think we want is in millisecond
   }
 
-  public get(key: string): string[] | undefined {
+  public get(key: string): Set<string> | undefined {
     const hasKey = this.cache.has(key);
     if (!hasKey) return undefined;
 
@@ -18,7 +19,7 @@ export class GroupCache {
     return data;
   }
 
-  public put(key: string, value: string[]) {
+  public put(key: string, value: Set<string>) {
     if (this.cache.size >= this.maxEntries) {
       const keyToDelete = this.cache.keys().next().value;
       this.cache.delete(keyToDelete);

--- a/plugins/rbac-backend/src/role-manager/role-manager.test.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.test.ts
@@ -1295,6 +1295,25 @@ describe('BackstageRoleManager', () => {
         'Detected cycle dependencies in the Group graph: [["group:default/team-a","group:default/team-b"]]. Admin/(catalog owner) have to fix it to make RBAC permission evaluation correct for groups: [["group:default/team-a","group:default/team-b"]]',
       );
     });
+
+    it('should return false after the the link has been deleted even after caching', async () => {
+      let result = await roleManager.hasLink(
+        'user:default/mike',
+        'role:default/somerole',
+      );
+      expect(result).toBeTruthy();
+
+      await roleManager.deleteLink(
+        'group:default/somegroup',
+        'role:default/somerole',
+      );
+
+      result = await roleManager.hasLink(
+        'user:default/mike',
+        'role:default/somerole',
+      );
+      expect(result).toBeFalsy();
+    });
   });
 
   function createGroupEntity(

--- a/plugins/rbac-backend/src/role-manager/role-manager.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.ts
@@ -110,10 +110,8 @@ export class BackstageRoleManager implements RoleManager {
       return false;
     }
 
-    await this.cacheResults(name1);
-    if (this.roleCache) {
-      const cachedResult = this.roleCache.get(name1)!;
-
+    const cachedResult = this.roleCache?.get(name1)!;
+    if ((await this.cacheResults(name1)) && cachedResult) {
       return cachedResult.has(name2);
     }
 
@@ -167,10 +165,8 @@ export class BackstageRoleManager implements RoleManager {
    * because we don't support role inheritance and we notify casbin about end of the role sub-tree.
    */
   async getRoles(name: string, ..._domain: string[]): Promise<string[]> {
-    await this.cacheResults(name);
-    if (this.roleCache) {
-      const cachedResult = this.roleCache.get(name)!;
-
+    const cachedResult = this.roleCache?.get(name)!;
+    if ((await this.cacheResults(name)) && cachedResult) {
       return Array.from(cachedResult);
     }
 

--- a/plugins/rbac-backend/src/role-manager/role-manager.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.ts
@@ -110,8 +110,9 @@ export class BackstageRoleManager implements RoleManager {
       return false;
     }
 
-    if (await this.cacheResults(name1)) {
-      const cachedResult = this.roleCache?.get(name1)!;
+    await this.cacheResults(name1);
+    if (this.roleCache) {
+      const cachedResult = this.roleCache.get(name1)!;
 
       return cachedResult.has(name2);
     }
@@ -166,8 +167,9 @@ export class BackstageRoleManager implements RoleManager {
    * because we don't support role inheritance and we notify casbin about end of the role sub-tree.
    */
   async getRoles(name: string, ..._domain: string[]): Promise<string[]> {
-    if (await this.cacheResults(name)) {
-      const cachedResult = this.roleCache?.get(name)!;
+    await this.cacheResults(name);
+    if (this.roleCache) {
+      const cachedResult = this.roleCache.get(name)!;
 
       return Array.from(cachedResult);
     }

--- a/plugins/rbac-backend/src/role-manager/role-manager.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.ts
@@ -46,7 +46,7 @@ export class BackstageRoleManager implements RoleManager {
    *
    * ex. `g, name1, name2`.
    * @param name1 User or group that will be assigned to a role
-   * @param name2 The role that will be created
+   * @param name2 The role that will be created or updated
    * @param _domain Unimplemented
    */
   async addLink(
@@ -69,8 +69,8 @@ export class BackstageRoleManager implements RoleManager {
    * are removed by the enforcer.
    *
    * ex. `g, name1, name2`.
-   * @param name1 User or group that will be assigned to a role
-   * @param name2 The role that will be created
+   * @param name1 User or group that will be removed from assignment of a role
+   * @param name2 The role that will be deleted or updated
    * @param _domain Unimplemented
    */
   async deleteLink(
@@ -262,7 +262,7 @@ export class BackstageRoleManager implements RoleManager {
    * the group hierarchy graph.
    * @param memo The group hierarchy graph
    * @param name2 The name of the role that we are authorizing with
-   * @returns True or false if the group is present in the tree and attached to the role
+   * @returns True if the group is present in the tree and attached to the role
    */
   private nonCachedCheck(memo: AncestorSearchMemo, name2: string): boolean {
     if (!memo.hasEntityRef(name2) && this.parseEntityKind(name2) === 'role') {

--- a/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -15,14 +15,7 @@ import {
   tokenManagerMock,
 } from '../__fixtures__/__utils__/utils.test';
 import { CasbinDBAdapterFactory } from '../database/casbin-adapter-factory';
-import {
-  PermissionPolicyMetadataDao,
-  PolicyMetadataStorage,
-} from '../database/policy-metadata-storage';
-import {
-  RoleMetadataDao,
-  RoleMetadataStorage,
-} from '../database/role-metadata';
+import { RoleMetadataDao } from '../database/role-metadata';
 import { CSV_PERMISSION_POLICY_FILE_AUTHOR } from '../file-permissions/csv';
 import { policyToString } from '../helper';
 import { BackstageRoleManager } from '../role-manager/role-manager';

--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -32,7 +32,6 @@ import {
 } from '../database/policy-metadata-storage';
 import { RoleMetadataStorage } from '../database/role-metadata';
 import { EnforcerDelegate } from './enforcer-delegate';
-import { MODEL } from './permission-model';
 import { ADMIN_ROLE_NAME, RBACPermissionPolicy } from './permission-policy';
 
 type PermissionAction = 'create' | 'read' | 'update' | 'delete';
@@ -1299,10 +1298,7 @@ describe('Policy checks for resourced permissions defined by name', () => {
       ['group:default/team-b', 'role:default/catalog_user'],
       { source: 'csv-file', roleEntityRef: 'role:default/catalog_user' },
     );
-    await enfDelegate.addGroupingPolicy(
-      ['group:default/team-a', 'group:default/team-b'],
-      { source: 'csv-file', roleEntityRef: 'role:default/catalog_user' },
-    );
+
     await enfDelegate.addPolicies(
       [['role:default/catalog_user', 'catalog.entity.read', 'read', 'allow']],
       'csv-file',

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -963,11 +963,6 @@ export class PolicesServer {
           }' and action ${JSON.stringify(action)}`,
         );
       }
-      console.log(
-        `Found permission ${JSON.stringify(perm)} for resource type ${
-          roleConditionPolicy.resourceType
-        } and action ${action}`,
-      );
       permInfo.push({ name: perm.name, action });
     }
 

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -60,6 +60,7 @@ export class PolicyBuilder {
       env.logger,
       env.tokenManager,
       catalogDBClient,
+      env.config,
     );
     enf.setRoleManager(rm);
     enf.enableAutoBuildRoleLinks(false);


### PR DESCRIPTION
## Description

As part of our ongoing work, this PR introduces the ability to cache information for the role manager to use. This should help further alleviate the problem of constantly having to rebuild the group hierarchy graph each time there is a request to the role manager.

## Fixes
 - Fixes https://issues.redhat.com/browse/RHIDP-1377

## Special note to the reviews

There are a lot of changes to the test files. The reason for this is because I refactored some of the tests to bring out common functionality to a utils file. Now, we have a `utils.test.ts` file that stores some of the common functions that are spread throughout some of our tests.

I didn't refactor all of the tests, this was more of a starting point. There still needs to be some ongoing effort to 