### PR TITLE
feat(feedback): add capture events in feedback plugin

### DIFF
--- a/plugins/feedback/src/components/CreateFeedbackModal/CreateFeedbackModal.tsx
+++ b/plugins/feedback/src/components/CreateFeedbackModal/CreateFeedbackModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useAnalytics, useApi } from '@backstage/core-plugin-api';
 
 import {
   Button,
@@ -82,6 +82,7 @@ export const CreateFeedbackModal = React.forwardRef(
   ) => {
     const classes = useStyles();
     const api = useApi(feedbackApiRef);
+    const analytics = useAnalytics();
     const [feedbackType, setFeedbackType] = useState('BUG');
     const [selectedTag, setSelectedTag] = useState(issueTags[0]);
     const app = useApi(configApiRef);
@@ -130,6 +131,7 @@ export const CreateFeedbackModal = React.forwardRef(
         tag: selectedTag,
       });
       props.handleModalCloseFn(resp);
+      analytics.captureEvent('click', `submit - ${summary.value}`);
     }
 
     function handleInputChange(

--- a/plugins/feedback/src/components/EntityFeedbackPage/EntityFeedbackPage.tsx
+++ b/plugins/feedback/src/components/EntityFeedbackPage/EntityFeedbackPage.tsx
@@ -4,6 +4,7 @@ import { Progress } from '@backstage/core-components';
 import {
   configApiRef,
   identityApiRef,
+  useAnalytics,
   useApi,
 } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
@@ -46,6 +47,7 @@ export const EntityFeedbackPage = () => {
   const classes = useStyles();
   const { entity } = useEntity();
   const user = useApi(identityApiRef);
+  const analytics = useAnalytics();
 
   const [modalProps, setModalProps] = useState<{
     projectEntity: string;
@@ -84,6 +86,7 @@ export const EntityFeedbackPage = () => {
 
   async function handleModalOpen() {
     const userEntity = (await user.getBackstageIdentity()).userEntityRef;
+    analytics.captureEvent('click', 'open - create feedback modal');
     setModalProps({
       projectEntity: projectEntity,
       userEntity: userEntity,
@@ -95,6 +98,7 @@ export const EntityFeedbackPage = () => {
 
   const handleModalClose = (respObj: { [key: string]: string } | false) => {
     setModalOpen(false);
+    analytics.captureEvent('click', 'close - feedback modal');
     if (respObj) {
       setReload(true);
       if (respObj.error) {
@@ -125,6 +129,7 @@ export const EntityFeedbackPage = () => {
   };
 
   const handleResyncClick = () => {
+    analytics.captureEvent('click', 'refresh');
     setReload(true);
   };
 

--- a/plugins/feedback/src/components/FeedbackDetailsModal/FeedbackDetailsModal.tsx
+++ b/plugins/feedback/src/components/FeedbackDetailsModal/FeedbackDetailsModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { parseEntityRef } from '@backstage/catalog-model';
 import { Progress, useQueryParamState } from '@backstage/core-components';
-import { useApi } from '@backstage/core-plugin-api';
+import { useAnalytics, useApi } from '@backstage/core-plugin-api';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
 
 import {
@@ -78,6 +78,7 @@ const useStyles = makeStyles((theme: Theme) =>
 export const FeedbackDetailsModal = () => {
   const classes = useStyles();
   const api = useApi(feedbackApiRef);
+  const analytics = useAnalytics();
   const [queryState, setQueryState] = useQueryParamState<string | undefined>(
     'id',
   );

--- a/plugins/feedback/src/components/FeedbackDetailsModal/FeedbackDetailsModal.tsx
+++ b/plugins/feedback/src/components/FeedbackDetailsModal/FeedbackDetailsModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { parseEntityRef } from '@backstage/catalog-model';
 import { Progress, useQueryParamState } from '@backstage/core-components';
-import { useAnalytics, useApi } from '@backstage/core-plugin-api';
+import { useApi } from '@backstage/core-plugin-api';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
 
 import {
@@ -78,7 +78,6 @@ const useStyles = makeStyles((theme: Theme) =>
 export const FeedbackDetailsModal = () => {
   const classes = useStyles();
   const api = useApi(feedbackApiRef);
-  const analytics = useAnalytics();
   const [queryState, setQueryState] = useQueryParamState<string | undefined>(
     'id',
   );

--- a/plugins/feedback/src/components/OpcFeedbackComponent/OpcFeedbackComponent.tsx
+++ b/plugins/feedback/src/components/OpcFeedbackComponent/OpcFeedbackComponent.tsx
@@ -5,6 +5,7 @@ import '@one-platform/opc-feedback';
 import {
   configApiRef,
   identityApiRef,
+  useAnalytics,
   useApi,
   useRouteRef,
 } from '@backstage/core-plugin-api';
@@ -20,6 +21,7 @@ export const OpcFeedbackComponent = () => {
   const appConfig = useApi(configApiRef);
   const feedbackApi = useApi(feedbackApiRef);
   const identityApi = useApi(identityApiRef);
+  const analytics = useAnalytics();
 
   const footer = JSON.stringify({
     name: appConfig.getString('app.title'),
@@ -62,6 +64,7 @@ export const OpcFeedbackComponent = () => {
         });
         throw Error('Summary cannot be empty');
       }
+      analytics.captureEvent('click', `submit - ${event.detail.data.summary}`);
       const userEntity = (await identityApi.getBackstageIdentity())
         .userEntityRef;
       const resp = await feedbackApi.createFeedback({
@@ -97,7 +100,7 @@ export const OpcFeedbackComponent = () => {
     };
     const elem: any = document.querySelector('opc-feedback');
     elem.onSubmit = onSubmit;
-  }, [feedbackApi, projectId, identityApi]);
+  }, [feedbackApi, projectId, identityApi, analytics]);
 
   return (
     <>


### PR DESCRIPTION
Added capture events for feedback plugin
The events captured are:
- Searching
- Button clicks
- Feedback details modal
- Pagination events

closes #1437 