### PR TITLE
fix(cli): fix entrypoint validation when running with `npx`

### DIFF
--- a/packages/cli/src/commands/export-dynamic-plugin/backend-utils.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-utils.ts
@@ -100,9 +100,9 @@ export function addToMainDependencies(
 
 export function isValidPluginModule(pluginModule: any): boolean {
   return (
-    isBackendFeature(pluginModule.default) ||
-    isBackendFeatureFactory(pluginModule.default) ||
-    isBackendDynamicPluginInstaller(pluginModule.dynamicPluginInstaller)
+    isBackendFeature(pluginModule?.default) ||
+    isBackendFeatureFactory(pluginModule?.default) ||
+    isBackendDynamicPluginInstaller(pluginModule?.dynamicPluginInstaller)
   );
 }
 


### PR DESCRIPTION
This PR fixes 2 problems with the new `embed-as-dependencies` option of the `export-dynamic-plugin` CLI command for backend plugins:
- running the command with `npx` failed at validating that the required entrypoints are there
- resolved peer dependencies were added without respecting the original `workspace:` range specifier. 