### PR TITLE
fix(cli): fix the `embed-as-dependencies` option on the `export-dynamic-plugin` CLI...

### DIFF
--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -61,7 +61,7 @@ export async function backend(opts: OptionValues): Promise<string> {
     pkg,
     packagesToEmbed,
     monoRepoPackages,
-    createRequire(paths.targetDir),
+    createRequire(`${paths.targetDir}/package.json`),
     [],
   );
   const embeddedPackages = embeddedResolvedPackages.map(e => e.packageName);
@@ -731,7 +731,7 @@ function isPackageShared(
 }
 
 function validatePluginEntryPoints(target: string): string {
-  const dynamicPluginRequire = createRequire(target);
+  const dynamicPluginRequire = createRequire(`${target}/package.json`);
 
   // require plugin main module
 


### PR DESCRIPTION
Fix the `embed-as-dependencies` option on the `export-dynamic-plugin` CLI when run on a wrapper plugin that doesn't use a monorepo structure.

Before this fix, this would fail, failing to resolve the wrapped plugin in the wrapper `node_modules` folder.