### PR TITLE
feat(rbac): add the optional maxDepth feature

### DIFF
--- a/plugins/rbac-backend/README.md
+++ b/plugins/rbac-backend/README.md
@@ -175,3 +175,16 @@ The RBAC plugin offers the option to store policies in a database. It supports t
 - postgres: Recommended for production environments.
 
 Ensure that you have already configured the database backend for your Backstage instance, as the RBAC plugin utilizes the same database configuration.
+
+### Optional maximum depth
+
+The RBAC plugin also includes an option max depth feature for organizations with potentially complex group hierarchy, this configuration value will ensure that the RBAC plugin will stop at a certain depth when building user graphs.
+
+```YAML
+permission:
+  enabled: true
+  rbac:
+    maxDepth: 1
+```
+
+The maxDepth must be greater than 0 to ensure that the graphs are built correctly. Also the graph will be built with a hierarchy of 1 + maxDepth.

--- a/plugins/rbac-backend/config.d.ts
+++ b/plugins/rbac-backend/config.d.ts
@@ -38,6 +38,11 @@ export interface Config {
        * The RBAC plugin will handle access control for plugins included in this list.
        */
       pluginsWithPermission?: string[];
+      /**
+       * An optional value that limits the depth when building the hierarchy group graph
+       * @visibility frontend
+       */
+      maxDepth?: number;
     };
   };
 }

--- a/plugins/rbac-backend/src/file-permissions/csv.test.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv.test.ts
@@ -1,4 +1,5 @@
 import { TokenManager } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
 
 import {
   Adapter,
@@ -115,11 +116,14 @@ async function createEnforcer(
   const catalogDBClient = Knex.knex({ client: MockClient });
   const enf = await newEnforcer(theModel, adapter);
 
+  const config = newConfigReader();
+
   const rm = new BackstageRoleManager(
     catalogApi,
     log,
     tokenManager,
     catalogDBClient,
+    config,
   );
   enf.setRoleManager(rm);
   enf.enableAutoBuildRoleLinks(false);
@@ -1005,3 +1009,34 @@ describe('CSV file', () => {
     });
   });
 });
+
+function newConfigReader(
+  users?: Array<{ name: string }>,
+  superUsers?: Array<{ name: string }>,
+): ConfigReader {
+  const testUsers = [
+    {
+      name: 'user:default/guest',
+    },
+    {
+      name: 'group:default/guests',
+    },
+  ];
+
+  return new ConfigReader({
+    permission: {
+      rbac: {
+        admin: {
+          users: users || testUsers,
+          superUsers: superUsers,
+        },
+      },
+    },
+    backend: {
+      database: {
+        client: 'better-sqlite3',
+        connection: ':memory:',
+      },
+    },
+  });
+}

--- a/plugins/rbac-backend/src/role-manager/role-manager.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.ts
@@ -1,6 +1,7 @@
 import { TokenManager } from '@backstage/backend-common';
 import { CatalogApi } from '@backstage/catalog-client';
 import { parseEntityRef } from '@backstage/catalog-model';
+import { Config } from '@backstage/config';
 
 import { RoleManager } from 'casbin';
 import { Knex } from 'knex';
@@ -11,13 +12,17 @@ import { RoleList } from './role-list';
 
 export class BackstageRoleManager implements RoleManager {
   private allRoles: Map<string, RoleList>;
+  private maxDepth?: number;
   constructor(
     private readonly catalogApi: CatalogApi,
     private readonly log: Logger,
     private readonly tokenManager: TokenManager,
     private readonly catalogDBClient: Knex,
+    private readonly config: Config,
   ) {
     this.allRoles = new Map<string, RoleList>();
+    const rbacConfig = this.config.getOptionalConfig('permission.rbac');
+    this.maxDepth = rbacConfig?.getOptionalNumber('maxDepth');
   }
 
   /**
@@ -99,6 +104,7 @@ export class BackstageRoleManager implements RoleManager {
       this.tokenManager,
       this.catalogApi,
       this.catalogDBClient,
+      this.maxDepth,
     );
     await memo.buildUserGraph(memo);
 
@@ -175,6 +181,7 @@ export class BackstageRoleManager implements RoleManager {
         this.tokenManager,
         this.catalogApi,
         this.catalogDBClient,
+        this.maxDepth,
       );
       await memo.getAllGroups();
       await memo.buildUserGraph(memo);

--- a/plugins/rbac-backend/src/role-manager/role-manager.ts
+++ b/plugins/rbac-backend/src/role-manager/role-manager.ts
@@ -23,6 +23,11 @@ export class BackstageRoleManager implements RoleManager {
     this.allRoles = new Map<string, RoleList>();
     const rbacConfig = this.config.getOptionalConfig('permission.rbac');
     this.maxDepth = rbacConfig?.getOptionalNumber('maxDepth');
+    if (this.maxDepth !== undefined && this.maxDepth! <= 0) {
+      throw new Error(
+        'Max Depth for RBAC group hierarchy must be greater than zero',
+      );
+    }
   }
 
   /**

--- a/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -173,6 +173,7 @@ describe('EnforcerDelegate', () => {
       logger,
       tokenManagerMock,
       catalogDBClient,
+      config,
     );
     enf.setRoleManager(rm);
     enf.enableAutoBuildRoleLinks(false);

--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -133,7 +133,7 @@ describe('RBACPermissionPolicy Tests', () => {
     const stringPolicy = `p, user:default/known_user, test-resource, update, allow `;
     const config = newConfigReader();
     const adapter = await newAdapter(config, stringPolicy);
-    const enfDelegate = await newEnforcerDelegate(adapter);
+    const enfDelegate = await newEnforcerDelegate(adapter, config);
 
     const policy = await newPermissionPolicy(config, enfDelegate);
 
@@ -147,7 +147,7 @@ describe('RBACPermissionPolicy Tests', () => {
     beforeEach(async () => {
       const config = newConfigReader();
       const adapter = await newAdapter(config);
-      enfDelegate = await newEnforcerDelegate(adapter);
+      enfDelegate = await newEnforcerDelegate(adapter, config);
       policy = await newPermissionPolicy(config, enfDelegate);
 
       catalogApi.getEntities.mockReturnValue({ items: [] });
@@ -305,6 +305,7 @@ describe('RBACPermissionPolicy Tests', () => {
 
       enforcerDelegate = await newEnforcerDelegate(
         adapter,
+        config,
         storedPolicies,
         storedGroupPolicies,
         policyMetadataStorage,
@@ -379,6 +380,7 @@ describe('RBACPermissionPolicy Tests', () => {
 
       enforcerDelegate = await newEnforcerDelegate(
         adapter,
+        config,
         storedPolicies,
         storedGroupPolicies,
         policyMetadataStorage,
@@ -480,6 +482,7 @@ describe('RBACPermissionPolicy Tests', () => {
 
       enforcerDelegate = await newEnforcerDelegate(
         adapter,
+        config,
         storedPolicies,
         storedGroupPolicies,
         policyMetadataStorage,
@@ -571,6 +574,7 @@ describe('RBACPermissionPolicy Tests', () => {
 
       enforcerDelegate = await newEnforcerDelegate(
         adapter,
+        config,
         storedPolicies,
         storedGroupPolicies,
         policyMetadataStorage,
@@ -645,6 +649,7 @@ describe('RBACPermissionPolicy Tests', () => {
 
       enforcerDelegate = await newEnforcerDelegate(
         adapter,
+        config,
         storedPolicies,
         storedGroupPolicies,
         policyMetadataStorage,
@@ -734,6 +739,7 @@ describe('RBACPermissionPolicy Tests', () => {
 
       enforcerDelegate = await newEnforcerDelegate(
         adapter,
+        config,
         storedPolicies,
         storedGroupPolicies,
         policyMetadataStorage,
@@ -842,7 +848,7 @@ describe('RBACPermissionPolicy Tests', () => {
       );
       const config = newConfigReader(basicAndResourcePermissions);
       const adapter = await newAdapter(config);
-      enfDelegate = await newEnforcerDelegate(adapter);
+      enfDelegate = await newEnforcerDelegate(adapter, config);
 
       policy = await newPermissionPolicy(
         config,
@@ -1110,7 +1116,7 @@ describe('RBACPermissionPolicy Tests', () => {
       const config = newConfigReader(csvPermFile, admins, superUser);
       const adapter = await newAdapter(config);
 
-      enfDelegate = await newEnforcerDelegate(adapter);
+      enfDelegate = await newEnforcerDelegate(adapter, config);
 
       await enfDelegate.addGroupingPolicy(oldGroupPolicy, {
         source: 'configuration',
@@ -1230,7 +1236,7 @@ describe('Policy checks for resourced permissions defined by name', () => {
   beforeEach(async () => {
     const config = newConfigReader();
     const adapter = await newAdapter(config);
-    enfDelegate = await newEnforcerDelegate(adapter);
+    enfDelegate = await newEnforcerDelegate(adapter, config);
     policy = await newPermissionPolicy(
       config,
       enfDelegate,
@@ -1411,7 +1417,7 @@ describe('Policy checks for users and groups', () => {
     const config = newConfigReader(policyChecksCSV);
     const adapter = await newAdapter(config);
 
-    const enfDelegate = await newEnforcerDelegate(adapter);
+    const enfDelegate = await newEnforcerDelegate(adapter, config);
 
     policy = await newPermissionPolicy(config, enfDelegate);
 
@@ -1801,6 +1807,7 @@ describe('Policy checks for conditional policies', () => {
       adapter,
       logger,
       tokenManagerMock,
+      config,
     );
 
     const enfDelegate = new EnforcerDelegate(
@@ -2123,6 +2130,7 @@ async function createEnforcer(
   adapter: Adapter,
   logger: Logger,
   tokenManager: TokenManager,
+  config: ConfigReader,
 ): Promise<Enforcer> {
   const catalogDBClient = Knex.knex({ client: MockClient });
   const enf = await newEnforcer(theModel, adapter);
@@ -2132,6 +2140,7 @@ async function createEnforcer(
     logger,
     tokenManager,
     catalogDBClient,
+    config,
   );
   enf.setRoleManager(rm);
   enf.enableAutoBuildRoleLinks(false);
@@ -2142,6 +2151,7 @@ async function createEnforcer(
 
 async function newEnforcerDelegate(
   adapter: Adapter,
+  config: ConfigReader,
   storedPolicies?: string[][],
   storedGroupingPolicies?: string[][],
   policyMock?: PolicyMetadataStorage,
@@ -2149,7 +2159,13 @@ async function newEnforcerDelegate(
   const theModel = newModelFromString(MODEL);
   const logger = getVoidLogger();
 
-  const enf = await createEnforcer(theModel, adapter, logger, tokenManagerMock);
+  const enf = await createEnforcer(
+    theModel,
+    adapter,
+    logger,
+    tokenManagerMock,
+    config,
+  );
 
   if (storedPolicies) {
     await enf.addPolicies(storedPolicies);

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -60,6 +60,7 @@ export class PolicyBuilder {
       env.logger,
       env.tokenManager,
       catalogDBClient,
+      env.config,
     );
     enf.setRoleManager(rm);
     enf.enableAutoBuildRoleLinks(false);


### PR DESCRIPTION
## Description

Introduces the optional configuration value `maxDepth` that will limit the depth that hierarchy group graphs are built. This should help reduce the amount of time building complex graphs and will help with performance.

## Fixes
- Fixes https://issues.redhat.com/browse/RHIDP-1376

## Special notes to the reviewer

I did the bare minimum for updating the tests because I have updates to tests in this [PR](https://github.com/janus-idp/backstage-plugins/pull/1446). I will rebase and fix the tests in this PR in the event the other is merged.