### PR TITLE
fix(kiali): update load for overview page

### DIFF
--- a/plugins/kiali/src/components/VirtualList/VirtualList.tsx
+++ b/plugins/kiali/src/components/VirtualList/VirtualList.tsx
@@ -18,6 +18,7 @@ import { kialiStyle } from '../../styles/StyleUtils';
 import { Namespace } from '../../types/Namespace';
 import { NamespaceInfo } from '../../types/NamespaceInfo';
 import { SortField } from '../../types/SortFilters';
+import { ENTITY } from '../../types/types';
 import { StatefulFiltersProps } from '../Filters/StatefulFilters';
 import { config, RenderResource, Resource, ResourceType } from './Config';
 import { VirtualItem } from './VirtualItem';
@@ -73,6 +74,16 @@ export const VirtualList = <R extends RenderResource>(
   const { rows } = listProps;
   const typeDisplay =
     listProps.type === 'istio' ? 'Istio config' : listProps.type;
+
+  const tableEntityHeaderStyle: any = {
+    minWidth: '100px',
+    fontWeight: '700',
+    color: 'grey',
+    borderTop: '1px solid #d5d5d5',
+    borderBottom: '1px solid #d5d5d5',
+    whiteSpace: 'nowrap',
+    padding: '15px',
+  };
 
   const tableHeaderStyle: any = {
     minWidth: '120px',
@@ -144,7 +155,11 @@ export const VirtualList = <R extends RenderResource>(
                   <TableCell
                     key={`column_${index}`}
                     align="center"
-                    style={tableHeaderStyle}
+                    style={
+                      listProps.view === ENTITY
+                        ? tableEntityHeaderStyle
+                        : tableHeaderStyle
+                    }
                     sortDirection={
                       column.sortable && orderBy === column.title.toLowerCase()
                         ? order
@@ -161,7 +176,10 @@ export const VirtualList = <R extends RenderResource>(
                         handleRequestSort(e, column.title.toLowerCase())
                       }
                     >
-                      {column.title.toUpperCase()}
+                      {listProps.view === ENTITY &&
+                      column.title === 'Configuration'
+                        ? 'CONFIG'
+                        : column.title.toUpperCase()}
                     </TableSortLabel>
                   </TableCell>
                 ))}

--- a/plugins/kiali/src/components/VirtualList/VirtualList.tsx
+++ b/plugins/kiali/src/components/VirtualList/VirtualList.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
 import {
+  Box,
+  CircularProgress,
   Paper,
   SortDirection,
   Table,
@@ -44,6 +46,7 @@ type VirtualListProps<R> = {
   tableToolbar?: React.ReactNode;
   type: string;
   view?: string;
+  loading: boolean;
 };
 
 export const VirtualList = <R extends RenderResource>(
@@ -165,7 +168,18 @@ export const VirtualList = <R extends RenderResource>(
               </TableRow>
             </TableHead>
             <TableBody>
-              {listProps.rows.length > 0 ? (
+              {/* eslint-disable-next-line no-nested-ternary */}
+              {listProps.loading === true ? (
+                <Box
+                  display="flex"
+                  justifyContent="center"
+                  alignItems="center"
+                  minHeight="10vh"
+                  marginLeft="60vh"
+                >
+                  <CircularProgress />
+                </Box>
+              ) : listProps.rows.length > 0 ? (
                 stableSort(rows, getComparator()).map(
                   (row: RenderResource, index: number) => (
                     <VirtualItem

--- a/plugins/kiali/src/pages/AppList/AppListPage.tsx
+++ b/plugins/kiali/src/pages/AppList/AppListPage.tsx
@@ -31,6 +31,7 @@ export const AppListPage = (props: { view?: string }): React.JSX.Element => {
   const activeNs = kialiState.namespaces.activeNamespaces.map(ns => ns.name);
   const prevActiveNs = useRef(activeNs);
   const prevDuration = useRef(duration);
+  const [loadingD, setLoading] = React.useState<boolean>(true);
 
   const hiddenColumns = isMultiCluster ? [] : ['cluster'];
   if (props.view === ENTITY) {
@@ -96,6 +97,9 @@ export const AppListPage = (props: { view?: string }): React.JSX.Element => {
       setNamespaces(namespaceInfos);
       fetchApps(namespaceInfos, duration);
     });
+    setTimeout(function () {
+      setLoading(false);
+    }, 400);
   };
 
   const [_, refresh] = useAsyncFn(
@@ -112,6 +116,7 @@ export const AppListPage = (props: { view?: string }): React.JSX.Element => {
       duration !== prevDuration.current ||
       !nsEqual(activeNs, prevActiveNs.current)
     ) {
+      setLoading(true);
       getNS();
       prevDuration.current = duration;
       prevActiveNs.current = activeNs;
@@ -134,6 +139,7 @@ export const AppListPage = (props: { view?: string }): React.JSX.Element => {
           type="applications"
           hiddenColumns={hiddenColumns}
           view={props.view}
+          loading={loadingD}
         />
       </Content>
     </div>

--- a/plugins/kiali/src/pages/AppList/AppListPage.tsx
+++ b/plugins/kiali/src/pages/AppList/AppListPage.tsx
@@ -97,7 +97,7 @@ export const AppListPage = (props: { view?: string }): React.JSX.Element => {
       setNamespaces(namespaceInfos);
       fetchApps(namespaceInfos, duration);
     });
-    setTimeout(function () {
+    setTimeout(() => {
       setLoading(false);
     }, 400);
   };

--- a/plugins/kiali/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/plugins/kiali/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -63,7 +63,7 @@ export const IstioConfigListPage = (props: {
       setNamespaces(nsl);
       fetchIstioConfigs(nsl);
     });
-    setTimeout(function () {
+    setTimeout(() => {
       setLoading(false);
     }, 400);
   };

--- a/plugins/kiali/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/plugins/kiali/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -29,6 +29,7 @@ export const IstioConfigListPage = (props: {
   );
   const activeNs = kialiState.namespaces.activeNamespaces.map(ns => ns.name);
   const prevActiveNs = React.useRef(activeNs);
+  const [loadingD, setLoading] = React.useState<boolean>(true);
 
   const fetchIstioConfigs = async (nss: NamespaceInfo[]): Promise<void> => {
     return kialiClient
@@ -62,6 +63,9 @@ export const IstioConfigListPage = (props: {
       setNamespaces(nsl);
       fetchIstioConfigs(nsl);
     });
+    setTimeout(function () {
+      setLoading(false);
+    }, 400);
   };
 
   const [{ loading }, refresh] = useAsyncFn(
@@ -76,6 +80,7 @@ export const IstioConfigListPage = (props: {
 
   React.useEffect(() => {
     if (!nsEqual(activeNs, prevActiveNs.current)) {
+      setLoading(true);
       load();
       prevActiveNs.current = activeNs;
     }
@@ -100,6 +105,7 @@ export const IstioConfigListPage = (props: {
           type="istio"
           hiddenColumns={hiddenColumns}
           view={props.view}
+          loading={loadingD}
         />
       </Content>
     </div>

--- a/plugins/kiali/src/pages/Overview/ListView/ListViewPage.tsx
+++ b/plugins/kiali/src/pages/Overview/ListView/ListViewPage.tsx
@@ -4,7 +4,6 @@ import { CardTab, TabbedCard } from '@backstage/core-components';
 
 import { ENTITY } from '../../../types/types';
 import { AppListPage } from '../../AppList/AppListPage';
-import { IstioConfigListPage } from '../../IstioConfigList/IstioConfigListPage';
 import { ServiceListPage } from '../../ServiceList/ServiceListPage';
 import { WorkloadListPage } from '../../WorkloadList/WorkloadListPage';
 
@@ -34,11 +33,6 @@ export const ListViewPage = () => {
         <CardTab label="Applications">
           <div style={tabStyle}>
             <AppListPage view={ENTITY} />
-          </div>
-        </CardTab>
-        <CardTab label="Istio Config">
-          <div style={tabStyle}>
-            <IstioConfigListPage view={ENTITY} />
           </div>
         </CardTab>
       </TabbedCard>

--- a/plugins/kiali/src/pages/ServiceList/ServiceListPage.tsx
+++ b/plugins/kiali/src/pages/ServiceList/ServiceListPage.tsx
@@ -163,7 +163,7 @@ export const ServiceListPage = (props: {
       setNamespaces(nsl);
       fetchServices(nsl, duration, activeToggles);
     });
-    setTimeout(function () {
+    setTimeout(() => {
       setLoading(false);
     }, 400);
   };

--- a/plugins/kiali/src/pages/ServiceList/ServiceListPage.tsx
+++ b/plugins/kiali/src/pages/ServiceList/ServiceListPage.tsx
@@ -168,16 +168,6 @@ export const ServiceListPage = (props: {
     }, 400);
   };
 
-  const [{ loading }, refresh] = useAsyncFn(
-    async () => {
-      // Check if the config is loaded
-      await load();
-    },
-    [],
-    { loading: true },
-  );
-  useDebounce(refresh, 10);
-
   React.useEffect(() => {
     if (
       duration !== prevDuration.current ||
@@ -190,6 +180,16 @@ export const ServiceListPage = (props: {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeNs, duration]);
+
+  const [{ loading }, refresh] = useAsyncFn(
+    async () => {
+      // Check if the config is loaded
+      await load();
+    },
+    [],
+    { loading: true },
+  );
+  useDebounce(refresh, 10);
 
   if (loading) {
     return <CircularProgress />;

--- a/plugins/kiali/src/pages/ServiceList/ServiceListPage.tsx
+++ b/plugins/kiali/src/pages/ServiceList/ServiceListPage.tsx
@@ -41,6 +41,7 @@ export const ServiceListPage = (props: {
   const prevActiveNs = useRef(activeNs);
   const prevDuration = useRef(duration);
   const activeToggles: ActiveTogglesInfo = Toggles.getToggles();
+  const [loadingD, setLoading] = React.useState<boolean>(true);
 
   const hiddenColumns = isMultiCluster ? [] : ['cluster'];
   if (props.view === ENTITY) {
@@ -162,6 +163,9 @@ export const ServiceListPage = (props: {
       setNamespaces(nsl);
       fetchServices(nsl, duration, activeToggles);
     });
+    setTimeout(function () {
+      setLoading(false);
+    }, 400);
   };
 
   const [{ loading }, refresh] = useAsyncFn(
@@ -179,6 +183,7 @@ export const ServiceListPage = (props: {
       duration !== prevDuration.current ||
       !nsEqual(activeNs, prevActiveNs.current)
     ) {
+      setLoading(true);
       load();
       prevDuration.current = duration;
       prevActiveNs.current = activeNs;
@@ -205,6 +210,7 @@ export const ServiceListPage = (props: {
           type="services"
           hiddenColumns={hiddenColumns}
           view={props.view}
+          loading={loadingD}
         />
       </Content>
     </div>

--- a/plugins/kiali/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/plugins/kiali/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -72,7 +72,7 @@ export const WorkloadListPage = (props: { view?: string }) => {
       fetchWorkloads(nsl, duration);
     });
     // Add a delay so it doesn't look like a flash
-    setTimeout(function () {
+    setTimeout(() => {
       setLoading(false);
     }, 400);
   };

--- a/plugins/kiali/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/plugins/kiali/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -32,6 +32,7 @@ export const WorkloadListPage = (props: { view?: string }) => {
   const activeNs = kialiState.namespaces.activeNamespaces.map(ns => ns.name);
   const prevActiveNs = useRef(activeNs);
   const prevDuration = useRef(duration);
+  const [loadingD, setLoading] = React.useState<boolean>(true);
 
   const fetchWorkloads = (
     nss: NamespaceInfo[],
@@ -70,6 +71,10 @@ export const WorkloadListPage = (props: { view?: string }) => {
       setNamespaces(nsl);
       fetchWorkloads(nsl, duration);
     });
+    // Add a delay so it doesn't look like a flash
+    setTimeout(function () {
+      setLoading(false);
+    }, 400);
   };
 
   const [{ loading }, refresh] = useAsyncFn(
@@ -87,6 +92,7 @@ export const WorkloadListPage = (props: { view?: string }) => {
       duration !== prevDuration.current ||
       !nsEqual(activeNs, prevActiveNs.current)
     ) {
+      setLoading(true);
       load();
       prevDuration.current = duration;
       prevActiveNs.current = activeNs;
@@ -133,6 +139,7 @@ export const WorkloadListPage = (props: { view?: string }) => {
           type="workloads"
           hiddenColumns={hiddenColumns}
           view={props.view}
+          loading={loadingD}
         />
       </Content>
     </div>

--- a/plugins/kiali/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/plugins/kiali/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -92,7 +92,7 @@ export const WorkloadListPage = (props: { view?: string }) => {
       duration !== prevDuration.current ||
       !nsEqual(activeNs, prevActiveNs.current)
     ) {
-      setLoading(true);
+      setLoadingData(true);
       load();
       prevDuration.current = duration;
       prevActiveNs.current = activeNs;

--- a/plugins/kiali/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/plugins/kiali/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -32,7 +32,7 @@ export const WorkloadListPage = (props: { view?: string }) => {
   const activeNs = kialiState.namespaces.activeNamespaces.map(ns => ns.name);
   const prevActiveNs = useRef(activeNs);
   const prevDuration = useRef(duration);
-  const [loadingD, setLoading] = React.useState<boolean>(true);
+  const [loadingData, setLoadingData] = React.useState<boolean>(true);
 
   const fetchWorkloads = (
     nss: NamespaceInfo[],
@@ -73,7 +73,7 @@ export const WorkloadListPage = (props: { view?: string }) => {
     });
     // Add a delay so it doesn't look like a flash
     setTimeout(() => {
-      setLoading(false);
+      setLoadingData(false);
     }, 400);
   };
 
@@ -139,7 +139,7 @@ export const WorkloadListPage = (props: { view?: string }) => {
           type="workloads"
           hiddenColumns={hiddenColumns}
           view={props.view}
-          loading={loadingD}
+          loading={loadingData}
         />
       </Content>
     </div>


### PR DESCRIPTION
Sometimes the graph data is not loaded until you click a second time, and it looks like it has no data.
It looks like the view is not being refreshing after the request finished loading.

- Added loading message instead of "No resources found" for lists