### PR TITLE
Fix type in orchestrator documentation

### DIFF
--- a/plugins/orchestrator/README.md
+++ b/plugins/orchestrator/README.md
@@ -10,7 +10,7 @@ The Backstage Orchestrator plugin aims to provide a better option to Scaffolder,
 
 The orchestrator relies on [SonataFlow](https://sonataflow.org/), a powerful tool for building cloud-native workflow applications.
 
-The main idea is to keep the same user experience for users, levering the UI components, input forms, and flow that Scaffolder provides, this way it should be straightforward for users and transparent no matter whether using Templates or Workflows, both can live together being compatible with integration points.
+The main idea is to keep the same user experience for users, leveraging the UI components, input forms, and flow that Scaffolder provides, this way it should be straightforward for users and transparent no matter whether using Templates or Workflows, both can live together being compatible with integration points.
 
 The orchestrator controls the flow orchestrating operations/tasks that may be executed in any external service including Scaffolder Actions, this way it is possible to leverage any existing Action hence Software Templates can be easily migrated to workflows opening the door to extend them to more complex use cases.
 


### PR DESCRIPTION
Fix `levering` for `leveraging`. `Levering` is the present participle of lever, which I don't think it makes much sense in this sentence.

@caponetto PTAL.