### PR TITLE
feat: checkPluginVersion.sh bump plugins for 1.2.0 release

### DIFF
--- a/packages/cli/.versionhistory.md
+++ b/packages/cli/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.8.0 in main branch for next release 1.2.0

--- a/plugins/3scale-backend/.versionhistory.md
+++ b/plugins/3scale-backend/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.5.0 in main branch for next release 1.2.0

--- a/plugins/aap-backend/.versionhistory.md
+++ b/plugins/aap-backend/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.6.0 in main branch for next release 1.2.0

--- a/plugins/acr/.versionhistory.md
+++ b/plugins/acr/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.3.0 in main branch for next release 1.2.0

--- a/plugins/analytics-provider-segment/.versionhistory.md
+++ b/plugins/analytics-provider-segment/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.3.0 in main branch for next release 1.2.0

--- a/plugins/dynamic-frontend-plugin/.versionhistory.md
+++ b/plugins/dynamic-frontend-plugin/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 0.1.0 in main branch for next release 1.2.0

--- a/plugins/dynamic-plugins-info/.versionhistory.md
+++ b/plugins/dynamic-plugins-info/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.1.0 in main branch for next release 1.2.0

--- a/plugins/feedback-backend/.versionhistory.md
+++ b/plugins/feedback-backend/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.2.0 in main branch for next release 1.2.0

--- a/plugins/jfrog-artifactory/.versionhistory.md
+++ b/plugins/jfrog-artifactory/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.3.0 in main branch for next release 1.2.0

--- a/plugins/keycloak-backend/.versionhistory.md
+++ b/plugins/keycloak-backend/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.9.0 in main branch for next release 1.2.0

--- a/plugins/kubernetes-actions/.versionhistory.md
+++ b/plugins/kubernetes-actions/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.4.0 in main branch for next release 1.2.0

--- a/plugins/matomo-backend/.versionhistory.md
+++ b/plugins/matomo-backend/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.4.0 in main branch for next release 1.2.0

--- a/plugins/matomo/.versionhistory.md
+++ b/plugins/matomo/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.3.0 in main branch for next release 1.2.0

--- a/plugins/nexus-repository-manager/.versionhistory.md
+++ b/plugins/nexus-repository-manager/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.5.0 in main branch for next release 1.2.0

--- a/plugins/notifications/.versionhistory.md
+++ b/plugins/notifications/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.2.0 in main branch for next release 1.2.0

--- a/plugins/ocm-backend/.versionhistory.md
+++ b/plugins/ocm-backend/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 3.6.0 in main branch for next release 1.2.0

--- a/plugins/ocm-common/.versionhistory.md
+++ b/plugins/ocm-common/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 2.3.0 in main branch for next release 1.2.0

--- a/plugins/ocm/.versionhistory.md
+++ b/plugins/ocm/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 3.8.0 in main branch for next release 1.2.0

--- a/plugins/openshift-image-registry/.versionhistory.md
+++ b/plugins/openshift-image-registry/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.4.0 in main branch for next release 1.2.0

--- a/plugins/quay-actions/.versionhistory.md
+++ b/plugins/quay-actions/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.4.0 in main branch for next release 1.2.0

--- a/plugins/quay/.versionhistory.md
+++ b/plugins/quay/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.6.0 in main branch for next release 1.2.0

--- a/plugins/rbac-node/.versionhistory.md
+++ b/plugins/rbac-node/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.1.0 in main branch for next release 1.2.0

--- a/plugins/regex-actions/.versionhistory.md
+++ b/plugins/regex-actions/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.4.0 in main branch for next release 1.2.0

--- a/plugins/servicenow-actions/.versionhistory.md
+++ b/plugins/servicenow-actions/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.4.0 in main branch for next release 1.2.0

--- a/plugins/shared-react/.versionhistory.md
+++ b/plugins/shared-react/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 2.6.0 in main branch for next release 1.2.0

--- a/plugins/sonarqube-actions/.versionhistory.md
+++ b/plugins/sonarqube-actions/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.4.0 in main branch for next release 1.2.0

--- a/plugins/tekton/.versionhistory.md
+++ b/plugins/tekton/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 3.6.0 in main branch for next release 1.2.0

--- a/plugins/topology/.versionhistory.md
+++ b/plugins/topology/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.19.0 in main branch for next release 1.2.0

--- a/plugins/web-terminal/.versionhistory.md
+++ b/plugins/web-terminal/.versionhistory.md
@@ -1,0 +1,1 @@
+- Bumped to 1.4.0 in main branch for next release 1.2.0


### PR DESCRIPTION
- **feat: checkPluginVersion.sh bump plugins/3scale-backend to 1.5.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/aap-backend to 1.6.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/acr to 1.3.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/analytics-provider-segment to 1.3.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/dynamic-frontend-plugin to 0.1.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/dynamic-plugins-info to 1.1.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/feedback-backend to 1.2.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/jfrog-artifactory to 1.3.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/keycloak-backend to 1.9.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/kubernetes-actions to 1.4.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/matomo to 1.3.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/matomo-backend to 1.4.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/nexus-repository-manager to 1.5.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/notifications to 1.2.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/ocm to 3.8.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/ocm-backend to 3.6.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/ocm-common to 2.3.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/openshift-image-registry to 1.4.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/quay to 1.6.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/quay-actions to 1.4.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/rbac-node to 1.1.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/regex-actions to 1.4.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/servicenow-actions to 1.4.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/shared-react to 2.6.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/sonarqube-actions to 1.4.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/tekton to 3.6.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/topology to 1.19.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/web-terminal to 1.4.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  

- **feat: checkPluginVersion.sh bump packages/cli to 1.8.0 in main**
  Signed-off-by: Nick Boldt <nboldt@redhat.com>
  