### PR TITLE
fix(orchestrator): fixes v2/instances endpoint (#1414)

### DIFF
--- a/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.test.ts
+++ b/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.test.ts
@@ -133,30 +133,30 @@ describe('scenarios to verify mapWorkflowCategoryDTOFromString', () => {
 describe('scenarios to verify mapToProcessInstanceDTO', () => {
   it('correctly maps ProcessInstanceDTO for not completed workflow', () => {
     // Arrange
-    const processIntanceV1: ProcessInstance = generateProcessInstance(1);
-    processIntanceV1.end = undefined;
+    const processInstanceV1: ProcessInstance = generateProcessInstance(1);
+    processInstanceV1.end = undefined;
 
     // Act
-    const result = mapToProcessInstanceDTO(processIntanceV1);
+    const result = mapToProcessInstanceDTO(processInstanceV1);
 
     // Assert
     expect(result).toBeDefined();
     expect(result.id).toBeDefined();
     expect(result.start).toBeDefined();
-    expect(result.start).toEqual(processIntanceV1.start?.toUTCString());
+    expect(result.start).toEqual(processInstanceV1.start);
     expect(result.end).toBeUndefined();
     expect(result.duration).toBeUndefined();
     expect(result.status).toEqual(
-      getProcessInstancesDTOFromString(processIntanceV1.state),
+      getProcessInstancesDTOFromString(processInstanceV1.state),
     );
-    expect(result.description).toEqual(processIntanceV1.description);
+    expect(result.description).toEqual(processInstanceV1.description);
     expect(result.category).toEqual('infrastructure');
     expect(result.workflowdata).toEqual(
       // @ts-ignore
-      processIntanceV1?.variables?.workflowdata,
+      processInstanceV1?.variables?.workflowdata,
     );
     expect(result.workflow).toEqual(
-      processIntanceV1.processName ?? processIntanceV1.processId,
+      processInstanceV1.processName ?? processInstanceV1.processId,
     );
   });
   it('correctly maps ProcessInstanceDTO', () => {
@@ -171,16 +171,16 @@ describe('scenarios to verify mapToProcessInstanceDTO', () => {
 
     // Assert
     expect(result.id).toBeDefined();
-    expect(result.start).toEqual(processIntanceV1.start?.toUTCString());
+    expect(result.start).toEqual(processIntanceV1.start);
     expect(result.end).toBeDefined();
-    expect(result.end).toEqual(processIntanceV1.end!.toUTCString());
+    expect(result.end).toEqual(processIntanceV1.end);
     expect(result.duration).toEqual(duration);
 
     expect(result).toBeDefined();
     expect(result.status).toEqual(
       getProcessInstancesDTOFromString(processIntanceV1.state),
     );
-    expect(result.end).toEqual(processIntanceV1.end?.toUTCString());
+    expect(result.end).toEqual(processIntanceV1.end);
     expect(result.duration).toEqual(duration);
     expect(result.duration).toEqual('an hour');
     expect(result.description).toEqual(processIntanceV1.description);

--- a/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.ts
+++ b/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.ts
@@ -115,11 +115,10 @@ export function mapToProcessInstanceDTO(
     description: processInstance.description,
     id: processInstance.id,
     name: processInstance.processName,
-    // To be fixed https://issues.redhat.com/browse/FLPATH-950
     // @ts-ignore
     workflowdata: variables?.workflowdata,
-    start: processInstance.start?.toUTCString(),
-    end: processInstance.end?.toUTCString(),
+    start: processInstance.start,
+    end: processInstance.end,
     duration: duration,
     status: getProcessInstancesDTOFromString(processInstance.state),
     workflow: processInstance.processName ?? processInstance.processId,

--- a/plugins/orchestrator-backend/src/service/api/test-utils.ts
+++ b/plugins/orchestrator-backend/src/service/api/test-utils.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import {
   ProcessInstance,
   ProcessInstanceState,
@@ -11,8 +13,8 @@ import {
   WorkflowOverviewListResult,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
 
-const baseDate = new Date('2023-02-19T11:45:21.123Z');
-const HOUR = 60 * 60 * 1000;
+const BASE_DATE = '2023-02-19T11:45:21.123Z';
+
 interface WorkflowOverviewParams {
   suffix?: string;
   workflowId?: string;
@@ -108,8 +110,8 @@ export function generateProcessInstance(id: number): ProcessInstance {
     processName: `name${id}`,
     processId: `proceesId${id}`,
     state: ProcessInstanceState.Active,
-    start: baseDate,
-    end: new Date(baseDate.getTime() + 1 * HOUR),
+    start: BASE_DATE,
+    end: moment(BASE_DATE).add(1, 'hour').toISOString(),
     nodes: [],
     endpoint: 'enpoint/foo',
     serviceUrl: 'service/bar',

--- a/plugins/orchestrator-backend/src/service/api/v2.ts
+++ b/plugins/orchestrator-backend/src/service/api/v2.ts
@@ -83,7 +83,7 @@ export class V2 {
       await this.orchestratorService.fetchInstancesTotalCount();
 
     const result: ProcessInstanceListResultDTO = {
-      items: instances?.map(def => mapToProcessInstanceDTO(def)),
+      items: instances?.map(mapToProcessInstanceDTO),
       paginationInfo: {
         pageSize: pagination.limit,
         page: pagination.offset,

--- a/plugins/orchestrator-common/src/models.ts
+++ b/plugins/orchestrator-common/src/models.ts
@@ -67,8 +67,10 @@ export interface ProcessInstance {
   nodes: NodeInstance[];
   milestones?: Milestone[];
   variables?: ProcessInstanceVariables | string;
-  start?: Date;
-  end?: Date;
+  /** Format: date-time */
+  start?: string;
+  /** Format: date-time */
+  end?: string;
   parentProcessInstance?: ProcessInstance;
   childProcessInstances?: ProcessInstance[];
   error?: ProcessInstanceError;

--- a/plugins/orchestrator/src/__fixtures__/fakeLongProcessInstanceList.ts
+++ b/plugins/orchestrator/src/__fixtures__/fakeLongProcessInstanceList.ts
@@ -50,7 +50,7 @@ export const generateFakeProcessInstances = (
           .workflowId,
       state: randomState,
       endpoint: 'enpoint/foo',
-      start: valuesGenerator.getNextDate(),
+      start: valuesGenerator.getNextDate().toISOString(),
       nodes: [],
       variables: {},
       isOpen: false,

--- a/plugins/orchestrator/src/__fixtures__/fakeProcessInstance.ts
+++ b/plugins/orchestrator/src/__fixtures__/fakeProcessInstance.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import {
   ProcessInstance,
   ProcessInstanceState,
@@ -7,17 +9,14 @@ import {
 import { fakeWorkflowOverviewList } from './fakeWorkflowOverviewList';
 
 let id = 10;
-const baseDate = new Date('2023-11-16T10:50:34.346Z');
-const HOUR = 60 * 60 * 1000;
-const DAY = 24 * HOUR;
-
+const baseDate = '2023-11-16T10:50:34.346Z';
 export const fakeProcessInstance1: ProcessInstance = {
   id: `12f767c1-9002-43af-9515-62a72d0eaf${id++}`,
   processName: fakeWorkflowOverviewList[0].name,
   processId: fakeWorkflowOverviewList[0].workflowId,
   state: ProcessInstanceState.Error,
   start: baseDate,
-  end: new Date(baseDate.getTime() + 13 * HOUR),
+  end: moment(baseDate).add(13, 'hours').toISOString(),
   nodes: [],
   endpoint: 'enpoint/foo',
   serviceUrl: 'service/bar',
@@ -52,8 +51,8 @@ export const fakeCompletedInstance: ProcessInstance = {
   processName: fakeWorkflowOverviewList[1].name,
   processId: fakeWorkflowOverviewList[1].workflowId,
   state: ProcessInstanceState.Completed,
-  start: new Date(baseDate.getTime() + HOUR),
-  end: new Date(baseDate.getTime() + DAY),
+  start: moment(baseDate).add(1, 'hour').toISOString(),
+  end: moment(baseDate).add(1, 'day').toISOString(),
   nodes: [],
   variables: {},
   endpoint: 'enpoint/foo',
@@ -68,7 +67,7 @@ export const fakeActiveInstance: ProcessInstance = {
   processName: fakeWorkflowOverviewList[2].name,
   processId: fakeWorkflowOverviewList[2].workflowId,
   state: ProcessInstanceState.Active,
-  start: new Date(baseDate.getTime() + 2 * HOUR),
+  start: moment(baseDate).add(2, 'hours').toISOString(),
   nodes: [],
   variables: {},
   endpoint: 'enpoint/foo',


### PR DESCRIPTION
cherry-pick from: 88b49df35cf10e231ba69c239e873cb10e7cc25b

* fix(orchestrator): fixes v2/instances endpoint

The `start` and `end` fields are annotated as `strings` instead of `Date`. The format of the string is provided as a hint for the developer as a comment (date-time)  due to limitations in the OpenAPI code generator.

* chore(orchestrator): removes format: date-time
