### PR TITLE
chore: revert changes to allow semantic...

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -3,14 +3,9 @@ name: Push
 on:
   push:
     branches:
+      # since we use multi-semantic-release, which assumes that all plugins in the 1.1.x branch
+      # are versioned < 1.2, we can only release from main branch. See RHIDP-1720 for more info
       - main
-      # starting from 1.1.x, allow releases from the 1.yy.x branches as long as we remember to bump plugin versions in main immediately after creating a 1.new.x branch
-      # see this script for how to check which plugins need bumping
-      # see also root package.json -> .release.branches
-      - 1.**.x
-      # do not run on 1.0.x, as we didn't bump plugin versions correctly there
-      - '!1.0.x'
-
 concurrency:
   group: push
   cancel-in-progress: true

--- a/package.json
+++ b/package.json
@@ -71,10 +71,7 @@
     "testTimeout": 15000
   },
   "release": {
-    "branches": [
-      "main",
-      "[0-9]+.[0-9]+.x"
-    ],
+    "branches": "main",
     "plugins": [
       [
         "@semantic-release/commit-analyzer",


### PR DESCRIPTION
### What does this PR do?

chore: revert changes to allow semantic release from 1.y.x branches, as this isn't possible with multi-semantic-release action

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
reverts https://github.com/janus-idp/backstage-plugins/pull/1514/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519
for https://issues.redhat.com/browse/RHIDP-1720

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.