### PR TITLE
fix(ui): remove extra inline style

### DIFF
--- a/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
+++ b/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
@@ -35,7 +35,7 @@ export function QuayRepository(_props: QuayRepositoryProps) {
   }
 
   return (
-    <div data-testid="quay-repo-table" style={{ border: '1px solid #ddd' }}>
+    <div data-testid="quay-repo-table">
       <Table
         title={title}
         options={{ sorting: true, paging: true, padding: 'dense' }}


### PR DESCRIPTION
This is for [RHIDP-2074](https://issues.redhat.com/browse/RHIDP-2074): Test the new theme on as many as supported pages

Before:
<img width="1512" alt="rhidp_2074_quay" src="https://github.com/janus-idp/backstage-plugins/assets/26255262/2f136271-8e3d-4a02-aafa-39ec89b98a3b">
<img width="1512" alt="rhidp_2074_quay_tab" src="https://github.com/janus-idp/backstage-plugins/assets/26255262/ee3e254a-216d-4bfe-83b1-af2689444563">

After:
<img width="1512" alt="rhidp_2074_quay_card_border" src="https://github.com/janus-idp/backstage-plugins/assets/26255262/1b4d4a70-48a3-4042-986d-d361e3790547">
<img width="1512" alt="rhidp_2074_quay_card_border_dark" src="https://github.com/janus-idp/backstage-plugins/assets/26255262/60b0d6fd-bef2-4798-9b68-24254eec2924">
