### PR TITLE
chore(renovate): fix warnings, use matchDepPatterns instead

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,11 +37,12 @@
       "automerge": true
     },    
     {
-      "matchPackagePatterns": ["^@backstage/"],
-      "groupName": "Core Backstage packages"
+      "matchDepPatterns": ["^@backstage/"],
+      "groupName": "Core Backstage packages",
+      "enabled": "false"
     },
     {
-      "matchPackagePatterns": [
+      "matchDepPatterns": [
         "^@semantic-release/",
         "^@semrel-extra/",
         "^multi-semantic-release$"


### PR DESCRIPTION
- Seeing warnings.  Looks like we are using the wrong field.  

    WARN: Use matchDepPatterns instead of matchPackagePatterns
    WARN: Error updating branch: update failure
    

- Disabled backstage core updates
