### PR TITLE
refactor(cli): New `--in-place`/`--no-in-place` option to the `export-dynamic-plugin` CLI command to allow exporting to `dist-dynamic` (when value is `false`).

### DIFF
--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -600,7 +600,7 @@ function checkWorkspacePackageVersion(
   );
 }
 
-function customizeForDynamicUse(options: {
+export function customizeForDynamicUse(options: {
   embedded: ResolvedEmbedded[];
   monoRepoPackages: Packages | undefined;
   sharedPackages?: SharedPackagesRules | undefined;

--- a/packages/cli/src/commands/export-dynamic-plugin/command.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/command.ts
@@ -20,6 +20,8 @@ import chalk from 'chalk';
 import { OptionValues } from 'commander';
 import fs from 'fs-extra';
 
+import path from 'path';
+
 import { paths } from '../../lib/paths';
 import { getConfigSchema } from '../../lib/schema/collect';
 import { Task } from '../../lib/tasks';
@@ -28,9 +30,9 @@ import { backend as backendEmbedAsDependencies } from './backend-embed-as-depend
 import { applyDevOptions } from './dev';
 import { frontend } from './frontend';
 
-const saveSchema = async (packageName: string, path: string) => {
+const saveSchema = async (packageName: string, destination: string) => {
   const configSchema = await getConfigSchema(packageName);
-  await fs.writeJson(paths.resolveTarget(path), configSchema, {
+  await fs.writeJson(paths.resolveTarget(destination), configSchema, {
     encoding: 'utf8',
     spaces: 2,
   });
@@ -53,10 +55,10 @@ export async function command(opts: OptionValues): Promise<void> {
     } else {
       targetPath = await backendEmbedAsCode(roleInfo, opts);
     }
-    configSchemaPath = 'dist-dynamic/dist/configSchema.json';
+    configSchemaPath = path.join(targetPath, 'dist/configSchema.json');
   } else if (role === 'frontend-plugin') {
     targetPath = await frontend(roleInfo, opts);
-    configSchemaPath = 'dist-scalprum/configSchema.json';
+    configSchemaPath = path.join(targetPath, 'dist-scalprum/configSchema.json');
   } else {
     throw new Error(
       'Only packages with the "backend-plugin", "backend-plugin-module" or "frontend-plugin" roles can be exported as dynamic backend plugins',

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -123,8 +123,16 @@ export function registerScriptCommand(program: Command) {
     )
     .option(
       '--embed-as-dependencies',
-      'Include embedded packages as private dependencies, instead of merging the with the generated code. Experimental for now, but expected to become the default.',
+      'Include embedded packages as private dependencies of backend plugins, instead of merging them with the generated code. Experimental for now, but expected to become the default.',
+      false,
     )
+    .option('--no-embed-as-dependencies', undefined, true)
+    .option(
+      '--in-place',
+      'Adds the frontend dynamic plugin assets to the `dist-scalprum` folder of the original plugin package. When value is `false` (using `--no-in-place`), it produces the assets in a distinct package located in the `dist-dynamic` sub-folder, as for backend plugins. `true` by default for now, it is expected to become `false` by default.',
+      true,
+    )
+    .option('--no-in-place', undefined, false)
     .action(lazy(() => import('./export-dynamic-plugin').then(m => m.command)));
 
   command

--- a/packages/cli/src/lib/builder/buildScalprumPlugin.ts
+++ b/packages/cli/src/lib/builder/buildScalprumPlugin.ts
@@ -10,10 +10,12 @@ interface BuildScalprumPluginOptions {
   configPaths: string[];
   pluginMetadata: PluginBuildMetadata;
   fromPackage: string;
+  resolvedScalprumDistPath: string;
 }
 
 export async function buildScalprumPlugin(options: BuildScalprumPluginOptions) {
-  const { targetDir, pluginMetadata, fromPackage } = options;
+  const { targetDir, pluginMetadata, fromPackage, resolvedScalprumDistPath } =
+    options;
   await buildScalprumBundle({
     targetDir,
     entry: 'src/index',
@@ -23,5 +25,6 @@ export async function buildScalprumPlugin(options: BuildScalprumPluginOptions) {
       args: [],
       fromPackage,
     })),
+    resolvedScalprumDistPath,
   });
 }

--- a/packages/cli/src/lib/bundler/paths.ts
+++ b/packages/cli/src/lib/bundler/paths.ts
@@ -63,7 +63,6 @@ export function resolveBundlingPaths(options: BundlingPathsOptions) {
     targetPath: resolvePath(targetDir, '.'),
     targetRunFile: runFileExists ? targetRunFile : undefined,
     targetDist: resolvePath(targetDir, 'dist'),
-    targetScalprumDist: resolvePath(targetDir, 'dist-scalprum'),
     targetAssets: resolvePath(targetDir, 'assets'),
     targetSrc: resolvePath(targetDir, 'src'),
     targetDev: resolvePath(targetDir, 'dev'),

--- a/packages/cli/src/lib/bundler/scalprumConfig.ts
+++ b/packages/cli/src/lib/bundler/scalprumConfig.ts
@@ -71,7 +71,7 @@ export const sharedModules = {
 };
 
 export async function createScalprumConfig(
-  paths: BundlingPaths,
+  paths: BundlingPaths & { targetScalprumDist: string },
   options: DynamicPluginOptions,
 ): Promise<webpack.Configuration> {
   const { checksEnabled, isDev } = options;


### PR DESCRIPTION
Add an `--in-place` option (`true` by default) to the `Janus-idp/cli` `export-dynamic-plugin` command for frontend plugins.
When setting this option to `false` (with the `--no-in-place` sibling option), the export would generate the dynamic frontend plugin package (including the scalprum assets) as a derived package in the `dist-dynamic` subfolder, whose name would be suffixed by `-dynamic`.

This is important to:
- have the same export experience and flow with both frontend and backend plugins
- avoid pushing to NPMJS packages whose size is much bigger, just because of all the static Javascript files added in the `dist-scalprum` folder.

#### Background

It should be possible to run the `export-dynamic-plugin` CLI command directly on normal & typical backstage static frontend plugin without having to change its source.
With the current behavior, there is still the requirement to update the source `package.json` in order to add the `dist-scalprum` folder in the `dist` field. This is required to include the `dist-scalprum` assets when packaging the dynamic plugin.

Using this new `--no-in-place` CLI option will allow exporting a distinct `package.json` with the `dist-scalprum` folder added in the `files` field without changing the code of the original frontend plugin.  



Signed-off-by: David Festal <dfestal@redhat.com>