### PR TITLE
fix(cli): remove the requirement for `app-config` when exporting fronted plugins to dynamic.

### DIFF
--- a/packages/cli/src/lib/bundler/bundlePlugin.ts
+++ b/packages/cli/src/lib/bundler/bundlePlugin.ts
@@ -9,7 +9,6 @@ import fs from 'fs-extra';
 import webpack from 'webpack';
 import yn from 'yn';
 
-import { resolveBaseUrl } from './config';
 import { BundlingPathsOptions, resolveBundlingPaths } from './paths';
 import { createScalprumConfig } from './scalprumConfig';
 import { DynamicPluginOptions } from './types';
@@ -38,7 +37,6 @@ export async function buildScalprumBundle(
       ...options,
       checksEnabled: false,
       isDev: false,
-      baseUrl: resolveBaseUrl(options.frontendConfig),
     },
   );
 

--- a/packages/cli/src/lib/bundler/scalprumConfig.ts
+++ b/packages/cli/src/lib/bundler/scalprumConfig.ts
@@ -107,7 +107,6 @@ export async function createScalprumConfig(
   plugins.push(
     new webpack.EnvironmentPlugin({
       HAS_REACT_DOM_CLIENT: false,
-      APP_CONFIG: options.frontendAppConfigs,
     }),
   );
 

--- a/packages/cli/src/lib/bundler/types.ts
+++ b/packages/cli/src/lib/bundler/types.ts
@@ -34,9 +34,6 @@ export type BundlingOptions = {
 export type DynamicPluginOptions = {
   checksEnabled?: boolean;
   isDev?: boolean;
-  frontendConfig: Config;
-  frontendAppConfigs: AppConfig[];
-  baseUrl?: URL;
   parallelism?: number;
   pluginMetadata: PluginBuildMetadata;
 };


### PR DESCRIPTION
This PR removes the requirement of having a nearly-empty `app-config.yaml` file when exporting fronted plugins to dynamic.

In fact this requirement has been borrowed from the webpack configuration for the frontend application. But it makes no sense for dynamic plugins.