### PR TITLE
fix(cli): allow exporting dynamic plugins from `frontend-plugin-module` packages.

### DIFF
--- a/packages/cli/src/commands/export-dynamic-plugin/command.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/command.ts
@@ -56,7 +56,7 @@ export async function command(opts: OptionValues): Promise<void> {
       targetPath = await backendEmbedAsCode(roleInfo, opts);
     }
     configSchemaPath = path.join(targetPath, 'dist/configSchema.json');
-  } else if (role === 'frontend-plugin') {
+  } else if (role === 'frontend-plugin' || role === 'frontend-plugin-module') {
     targetPath = await frontend(roleInfo, opts);
     configSchemaPath = path.join(targetPath, 'dist-scalprum/configSchema.json');
   } else {


### PR DESCRIPTION
The `export-dynamic-plugin` command of the `@janus-idp/cli` package, when applied to frontend plugins, doesn't support packages with the `frontend-plugin-module`.

This should be allowed so that `APIFactories` can be added, for example to support additional analytics providers.

This PR drops this unnecessary limitation.