### PR TITLE
chore(orchestrator): add yarn scripts to copy to showcase

### DIFF
--- a/plugins/orchestrator-backend/package.json
+++ b/plugins/orchestrator-backend/package.json
@@ -54,7 +54,9 @@
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
     "postversion": "yarn run export-dynamic",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin",
+    "build:copy": "yarn tsc && yarn build && yarn export-dynamic && yarn node scripts/copyToShowcase",
+    "watch": "nodemon --exec 'yarn build:copy' --ext ts,tsx --ignore dist --ignore dist-scalprum src"
   },
   "dependencies": {
     "@backstage/backend-app-api": "^0.6.2",

--- a/plugins/orchestrator-backend/scripts/copyToShowcase.js
+++ b/plugins/orchestrator-backend/scripts/copyToShowcase.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-console */
+const path = require('path');
+const fs = require('fs-extra');
+
+const scriptDir = path.dirname(__filename);
+
+const distDynamic = path.join(scriptDir, '..', 'dist-dynamic');
+const showcaseFolder =
+  process.env.BACKSTAGE_SHOWCASE ||
+  path.join(scriptDir, '..', '..', '..', '..', 'backstage-showcase');
+
+const targetFolder = path.join(
+  showcaseFolder,
+  'dynamic-plugins-root',
+  'orchestrator-plugin-backend',
+);
+
+console.log(new Date().toLocaleTimeString('en-US', { hour12: false }));
+fs.removeSync(targetFolder);
+fs.copySync(distDynamic, targetFolder);
+console.log(`copied ${distDynamic} to ${targetFolder}}`);
+
+console.log(
+  `${new Date().toLocaleTimeString('en-US', {
+    hour12: false,
+  })}: done copying orchestrator-backend plugin to showcase`,
+);

--- a/plugins/orchestrator/package.json
+++ b/plugins/orchestrator/package.json
@@ -35,7 +35,9 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
-    "postpack": "backstage-cli package postpack"
+    "postpack": "backstage-cli package postpack",
+    "build:copy": "yarn tsc && yarn build && yarn export-dynamic && yarn node scripts/copyToShowcase",
+    "watch": "nodemon --exec 'yarn build:copy' --ext ts,tsx --ignore dist --ignore dist-scalprum src"
   },
   "dependencies": {
     "@backstage/core-components": "^0.14.3",
@@ -77,7 +79,8 @@
     "@testing-library/react": "14.2.1",
     "@storybook/preview-api": "7.5.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "fs-extra": "11.1.1"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.2.0",

--- a/plugins/orchestrator/scripts/copyToShowcase.js
+++ b/plugins/orchestrator/scripts/copyToShowcase.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+const path = require('path');
+const fs = require('fs-extra');
+
+const scriptDir = path.dirname(__filename);
+
+const distScalprum = path.join(scriptDir, '..', 'dist-scalprum');
+const packageJsonFile = path.join(scriptDir, '..', 'package.json');
+const showcaseFolder =
+  process.env.SHOWCASE_DIR ||
+  path.join(scriptDir, '..', '..', '..', '..', 'backstage-showcase');
+
+const targetFolder = path.join(
+  showcaseFolder,
+  'dynamic-plugins-root',
+  'orchestrator-plugin',
+);
+
+fs.copySync(distScalprum, path.join(targetFolder, 'dist-scalprum'));
+fs.copyFileSync(packageJsonFile, path.join(targetFolder, 'package.json'));
+
+console.log(
+  `copied ${distScalprum} and ${packageJsonFile} to ${targetFolder}}`,
+);
+console.log(
+  `${new Date().toLocaleTimeString('en-US', {
+    hour12: false,
+  })}: done copying orchestrator plugin to showcase`,
+);


### PR DESCRIPTION
added yarn tasks to orchestrator plugin to assist with developing against showcase application
the frontend watch enables making a change and seeing at after refresh of the browser
the backend watch requires rerunning "yarn start" in the showcase app after each change
