### PR TITLE
docs(servicenow): fix typo in the service now documentation

### DIFF
--- a/plugins/servicenow-actions/README.md
+++ b/plugins/servicenow-actions/README.md
@@ -58,7 +58,7 @@ const backend = createBackend();
 
 // Add the following line
 backend.add(
-  import('@janus-idp/backstage-scaffolder-backend-module-regex/alpha'),
+  import('@janus-idp/backstage-scaffolder-backend-module-servicenow/alpha'),
 );
 
 backend.start();


### PR DESCRIPTION
### Description
Fix a typo in the `servicenow` custom action documentation for the new backend setup

### What issue(s) does this fix
Fixes: #1585