### PR TITLE
fix(cli): allow retrieving scalprum config from an external file in `export-dynamic-plugin`.

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -133,6 +133,10 @@ export function registerScriptCommand(program: Command) {
       true,
     )
     .option('--no-in-place', undefined, false)
+    .option(
+      '--scalprum-config <file>',
+      'Allows retrieving scalprum configuration from an external JSON file, instead of using a `scalprum` field of the `package.json`. Frontend plugins only.',
+    )
     .action(lazy(() => import('./export-dynamic-plugin').then(m => m.command)));
 
   command


### PR DESCRIPTION
This PR adds the avalability, in the `export-dynamic-plugin` command of the `janus-idp/cli` package, to take the frontend plugin scalprum-specific configuration from an external JSON file instead of expecting the config to be specified in a `scalprum` field of the source plugin `package.json`.

#### Background

It should be possible to run the `export-dynamic-plugin` CLI command directly on normal & typical backstage static frontend plugin without having to change its source.

With the current behavior, before this PR, when additional scalprum configuration is needed, there is still the requirement to update the source `package.json` in order to add the `scalprum` field with additional configuration. 