### PR TITLE
fix(cli): completely removing the requirement for `app-config` when exporting fronted plugins to dynamic.

### DIFF
--- a/packages/cli/src/commands/export-dynamic-plugin/frontend.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/frontend.ts
@@ -144,7 +144,6 @@ export async function frontend(
       ...scalprum,
       version,
     },
-    fromPackage: name,
     resolvedScalprumDistPath,
   });
 

--- a/packages/cli/src/lib/builder/buildScalprumPlugin.ts
+++ b/packages/cli/src/lib/builder/buildScalprumPlugin.ts
@@ -1,7 +1,6 @@
 import { PluginBuildMetadata } from '@openshift/dynamic-plugin-sdk-webpack';
 
 import { buildScalprumBundle } from '../bundler/bundlePlugin';
-import { loadCliConfig } from '../config';
 import { getEnvironmentParallelism } from '../parallel';
 
 interface BuildScalprumPluginOptions {
@@ -9,22 +8,16 @@ interface BuildScalprumPluginOptions {
   writeStats: boolean;
   configPaths: string[];
   pluginMetadata: PluginBuildMetadata;
-  fromPackage: string;
   resolvedScalprumDistPath: string;
 }
 
 export async function buildScalprumPlugin(options: BuildScalprumPluginOptions) {
-  const { targetDir, pluginMetadata, fromPackage, resolvedScalprumDistPath } =
-    options;
+  const { targetDir, pluginMetadata, resolvedScalprumDistPath } = options;
   await buildScalprumBundle({
     targetDir,
     entry: 'src/index',
     parallelism: getEnvironmentParallelism(),
     pluginMetadata,
-    ...(await loadCliConfig({
-      args: [],
-      fromPackage,
-    })),
     resolvedScalprumDistPath,
   });
 }


### PR DESCRIPTION
This PR completely removes the requirement of having a nearly-empty app-config.yaml file when exporting fronted plugins to dynamic.

This is a followup of previous [PR #1592](https://github.com/janus-idp/backstage-plugins/pull/1592) which was incomplete.