### PR TITLE
chore: use the new Events service in the Showcase

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -23,7 +23,7 @@ import { TaskScheduler } from '@backstage/backend-tasks';
 import { CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
-import { DefaultEventBroker } from '@backstage/plugin-events-backend';
+import { DefaultEventsService } from '@backstage/plugin-events-node';
 import { ServerPermissionClient } from '@backstage/plugin-permission-node';
 
 import Router from 'express-promise-router';
@@ -46,6 +46,7 @@ function makeCreateEnv(config: Config) {
   const databaseManager = DatabaseManager.fromConfig(config, { logger: root });
   const tokenManager = ServerTokenManager.fromConfig(config, { logger: root });
   const taskScheduler = TaskScheduler.fromConfig(config);
+  const eventsService = DefaultEventsService.create({ logger: root });
   const catalogApi = new CatalogClient({
     discoveryApi: HostDiscovery.fromConfig(config),
   });
@@ -57,8 +58,6 @@ function makeCreateEnv(config: Config) {
     discovery,
     tokenManager,
   });
-
-  const eventBroker = new DefaultEventBroker(root.child({ type: 'plugin' }));
 
   root.info(`Created UrlReader ${reader}`);
 
@@ -78,7 +77,7 @@ function makeCreateEnv(config: Config) {
       scheduler,
       permissions,
       identity,
-      eventBroker,
+      eventsService,
       catalogApi,
     };
   };

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -9,7 +9,7 @@ import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { IdentityApi } from '@backstage/plugin-auth-node';
-import { EventBroker } from '@backstage/plugin-events-node';
+import { EventsService } from '@backstage/plugin-events-node';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 
 import { Logger } from 'winston';
@@ -25,6 +25,6 @@ export type PluginEnvironment = {
   scheduler: PluginTaskScheduler;
   permissions: PermissionEvaluator;
   identity: IdentityApi;
-  eventBroker: EventBroker;
+  eventsService: EventsService;
   catalogApi: CatalogApi;
 };

--- a/plugins/orchestrator-backend/dev/index.ts
+++ b/plugins/orchestrator-backend/dev/index.ts
@@ -3,7 +3,6 @@ import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
-import { EventBroker } from '@backstage/plugin-events-node';
 
 import { Logger } from 'winston';
 
@@ -15,7 +14,6 @@ export interface ServerOptions {
   port: number;
   enableCors: boolean;
   logger: Logger;
-  eventBroker: EventBroker;
   config: Config;
   discovery: DiscoveryApi;
   catalogApi: CatalogApi;

--- a/plugins/orchestrator-backend/src/run.ts
+++ b/plugins/orchestrator-backend/src/run.ts
@@ -6,7 +6,6 @@ import {
 } from '@backstage/backend-common';
 import { TaskScheduler } from '@backstage/backend-tasks';
 import { CatalogClient } from '@backstage/catalog-client';
-import { DefaultEventBroker } from '@backstage/plugin-events-backend';
 
 import yn from 'yn';
 
@@ -16,7 +15,6 @@ const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 const config = await loadBackendConfig({ logger, argv: process.argv });
-const eventBroker = new DefaultEventBroker(logger);
 const discovery = HostDiscovery.fromConfig(config);
 const scheduler = TaskScheduler.fromConfig(config).forPlugin('orchestrator');
 const catalogApi = new CatalogClient({
@@ -28,7 +26,6 @@ startStandaloneServer({
   port,
   enableCors,
   logger,
-  eventBroker,
   config,
   discovery,
   catalogApi,


### PR DESCRIPTION
Removing references to the deprecated `ServiceBroker` and importing the new `EventsService`.


Changes were made based on this documentation: https://github.com/backstage/backstage/tree/master/plugins/events-node
