### PR TITLE
feat(orchestrator): make the internal sonata podman compatible

### DIFF
--- a/plugins/orchestrator-backend/src/service/DevModeService.ts
+++ b/plugins/orchestrator-backend/src/service/DevModeService.ts
@@ -126,6 +126,8 @@ export class DevModeService {
 
     const launcherArgs = [
       'run',
+      '--name',
+      'backstage-internal-sonataflow',
       '--add-host',
       'host.docker.internal:host-gateway',
     ];
@@ -141,7 +143,7 @@ export class DevModeService {
     launcherArgs.push('-e', `KOGITO_SERVICE_URL=${this.devModeUrl}`);
     launcherArgs.push(
       '-v',
-      `${resourcesAbsPath}:${SONATA_FLOW_RESOURCES_PATH}`,
+      `${resourcesAbsPath}:${SONATA_FLOW_RESOURCES_PATH}:Z`,
     );
     launcherArgs.push('-e', 'KOGITO.CODEGEN.PROCESS.FAILONERROR=false');
     launcherArgs.push(


### PR DESCRIPTION
1.This makes sure selinux context is passed when mounting
src/main/resources when starting the container using `yarn
start:backstage`

This is mainly for those developers working with podman and not docker
There's no need to hack the permissions of /tmp/orchestrator

2. Set a name for the container so it is easily identified

Signed-off-by: Roy Golan <rgolan@redhat.com>
