### PR TITLE
feat(rbac): add support for rejectUnauthorized in PG SSL options

### DIFF
--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
@@ -220,6 +220,39 @@ describe('CasbinAdapterFactory', () => {
         },
       });
     });
+
+    it('test building an adapter using a PostgreSQL configuration with intentionally ssl without CA.', async () => {
+      const config = new ConfigReader({
+        backend: {
+          database: {
+            client: 'pg',
+            connection: {
+              host: 'localhost',
+              port: '5432',
+              user: 'postgresUser',
+              password: process.env.TEST,
+              ssl: {
+                rejectUnauthorized: false,
+              },
+            },
+          },
+        },
+      });
+      const factory = new CasbinDBAdapterFactory(config, mockDatabaseManager);
+      const adapter = await factory.createAdapter();
+      expect(adapter).not.toBeNull();
+      expect(newAdapterMock).toHaveBeenCalledWith({
+        type: 'postgres',
+        host: 'localhost',
+        port: 5432,
+        username: 'postgresUser',
+        password: process.env.TEST,
+        database: 'test-database',
+        ssl: {
+          rejectUnauthorized: false,
+        },
+      });
+    });
   });
 
   it('ensure that building an adapter with an unknown configuration fails.', async () => {

--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
@@ -185,6 +185,41 @@ describe('CasbinAdapterFactory', () => {
         },
       });
     });
+
+    it('test building an adapter using a PostgreSQL configuration with intentionally ssl and TLS options.', async () => {
+      const config = new ConfigReader({
+        backend: {
+          database: {
+            client: 'pg',
+            connection: {
+              host: 'localhost',
+              port: '5432',
+              user: 'postgresUser',
+              password: process.env.TEST,
+              ssl: {
+                ca: 'abc',
+                rejectUnauthorized: false,
+              },
+            },
+          },
+        },
+      });
+      const factory = new CasbinDBAdapterFactory(config, mockDatabaseManager);
+      const adapter = await factory.createAdapter();
+      expect(adapter).not.toBeNull();
+      expect(newAdapterMock).toHaveBeenCalledWith({
+        type: 'postgres',
+        host: 'localhost',
+        port: 5432,
+        username: 'postgresUser',
+        password: process.env.TEST,
+        database: 'test-database',
+        ssl: {
+          ca: 'abc',
+          rejectUnauthorized: false,
+        },
+      });
+    });
   });
 
   it('ensure that building an adapter with an unknown configuration fails.', async () => {

--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
@@ -10,7 +10,7 @@ import { TlsOptions } from 'tls';
 const DEFAULT_SQLITE3_STORAGE_FILE_NAME = 'rbac.sqlite';
 
 type DbSSLOptions = {
-  ca: string;
+  ca?: string;
   rejectUnauthorized?: boolean;
 };
 
@@ -85,7 +85,7 @@ export class CasbinDBAdapterFactory {
       const sslOpts = ssl as DbSSLOptions;
       const tlsOpts = {
         ca: sslOpts.ca,
-        rejectUnauthorized: sslOpts.rejectUnauthorized ?? undefined,
+        rejectUnauthorized: sslOpts.rejectUnauthorized,
       };
 
       if (Object.values(tlsOpts).every(el => el === undefined)) {


### PR DESCRIPTION
Backstage's database configurations support various options that are being passed to the DB connection, example:
```yaml
ssl:
  require: true
  rejectUnauthorized: false
```

This PR adds support for rejectUnauthorized.