### PR TITLE
fix(orchestrator): disabled MUI table thirdSortClick

### DIFF
--- a/plugins/orchestrator/src/components/WorkflowRunsTabContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowRunsTabContent.tsx
@@ -5,7 +5,6 @@ import {
   InfoCard,
   Link,
   SelectItem,
-  Table,
   TableColumn,
 } from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
@@ -24,6 +23,7 @@ import { DEFAULT_TABLE_PAGE_SIZE, VALUE_UNAVAILABLE } from '../constants';
 import usePolling from '../hooks/usePolling';
 import { workflowInstanceRouteRef } from '../routes';
 import { Selector } from './Selector';
+import OverrideBackstageTable from './ui/OverrideBackstageTable';
 import { mapProcessInstanceToDetails } from './WorkflowInstancePageContent';
 import { WorkflowInstanceStatusIndicator } from './WorkflowInstanceStatusIndicator';
 import { WorkflowRunDetail } from './WorkflowRunDetail';
@@ -128,7 +128,7 @@ export const WorkflowRunsTabContent = () => {
     <ErrorPanel error={error} />
   ) : (
     <InfoCard noPadding title={selectors}>
-      <Table
+      <OverrideBackstageTable
         title="Workflow Runs"
         options={{
           paging,

--- a/plugins/orchestrator/src/components/ui/OverrideBackstageTable.tsx
+++ b/plugins/orchestrator/src/components/ui/OverrideBackstageTable.tsx
@@ -23,7 +23,10 @@ const OverrideBackstageTable = <T extends object>(props: TableProps<T>) => {
   const classes = useStyles();
   return (
     <div className={classes.orchestratorTable}>
-      <BackstageTable {...props} />
+      <BackstageTable
+        {...props}
+        options={{ ...props.options, thirdSortClick: false }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
[FLPATH-1191](https://issues.redhat.com/browse/FLPATH-1191)

The default behavior of material UI is confusing, clicking on the sort button the third time disables the sort, and it's not clear what the stage of the table should be making it feel like a bug.
There's a [discussion](https://github.com/mbrn/material-table/issues/985) about it both in Material UI and a [bug](https://github.com/backstage/backstage/issues/23969) open in backstage upstream.
Following the discussion in the upstream bug, it was agreed that each plugin should disable this feature on their own.

Since there's already a component OverrideBackstageTable for the orchestrator, used because of a theme issue, I added this fix there as well, this way the fix applies to both the instance and workflows tables.