### PR TITLE
fix(argocd): fix argocd configurations visibility

### DIFF
--- a/plugins/argocd/config.d.ts
+++ b/plugins/argocd/config.d.ts
@@ -26,7 +26,7 @@ export interface Config {
      * @visibility frontend
      */
     appLocatorMethods?: Array</**
-     * @visibility secret
+     * @visibility frontend
      */
     {
       /**
@@ -43,6 +43,14 @@ export interface Config {
          * @visibility frontend
          */
         url: string;
+        /**
+         * @visibility secret
+         */
+        username: string;
+        /**
+         * @visibility secret
+         */
+        password: string;
       }>;
     }>;
   };


### PR DESCRIPTION
Change visibility of the argocd appLocatorMethods configuration and explicitly mask the visibility of username and password fields.