### PR TITLE
chore(owners): remove OWNERS files from orchestrator plugins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,24 +20,25 @@ yarn.lock                    @janus-idp/maintainers-plugins
 *.md                         @janus-idp/maintainers-docs
 
 # Plugin specific owners:
-/plugins/jfrog-artifactory/         @janus-idp/maintainers-plugins @fmenesesg
-/plugins/3scale-backend/            @janus-idp/maintainers-plugins @fmenesesg
-/plugins/topology/                  @janus-idp/maintainers-plugins @debsmita1 @divyanshiGupta
-/plugins/rbac-backend/              @janus-idp/maintainers-plugins @AndrienkoAleksandr @PatAKnight
-/plugins/rbac-common/               @janus-idp/maintainers-plugins @AndrienkoAleksandr @PatAKnight
-/plugins/notifications              @janus-idp/maintainers-plugins @janus-idp/notifications
-/plugins/notifications-backend      @janus-idp/maintainers-plugins @janus-idp/notifications
-/plugins/orchestrator               @janus-idp/maintainers-plugins @janus-idp/orchestrator-codeowners
-/plugins/orchestrator-backend       @janus-idp/maintainers-plugins @janus-idp/orchestrator-codeowners
-/plugins/orchestrator-common        @janus-idp/maintainers-plugins @janus-idp/orchestrator-codeowners
-/plugins/feedback                   @janus-idp/maintainers-plugins @janus-idp/devex-uxe
-/plugins/feedback-backend           @janus-idp/maintainers-plugins @janus-idp/devex-uxe
-/plugins/matomo                     @janus-idp/maintainers-plugins @janus-idp/devex-uxe
-/plugins/matomo-backend             @janus-idp/maintainers-plugins @janus-idp/devex-uxe
-/plugins/analytics-module-matomo    @janus-idp/maintainers-plugins @janus-idp/devex-uxe
-/plugins/kiali                      @janus-idp/maintainers-plugins @janus-idp/kiali
-/plugins/kiali-backend              @janus-idp/maintainers-plugins @janus-idp/kiali
-/plugins/kiali-common               @janus-idp/maintainers-plugins @janus-idp/kiali
-/plugins/quay                       @janus-idp/rhtap
-/plugins/tekton                     @janus-idp/rhtap
-/plugins/argocd                     @janus-idp/rhtap
+/plugins/jfrog-artifactory/                 @janus-idp/maintainers-plugins @fmenesesg
+/plugins/3scale-backend/                    @janus-idp/maintainers-plugins @fmenesesg
+/plugins/topology/                          @janus-idp/maintainers-plugins @debsmita1 @divyanshiGupta
+/plugins/rbac-backend/                      @janus-idp/maintainers-plugins @AndrienkoAleksandr @PatAKnight
+/plugins/rbac-common/                       @janus-idp/maintainers-plugins @AndrienkoAleksandr @PatAKnight
+/plugins/notifications                      @janus-idp/maintainers-plugins @janus-idp/notifications
+/plugins/notifications-backend              @janus-idp/maintainers-plugins @janus-idp/notifications
+/plugins/orchestrator                       @janus-idp/maintainers-plugins @janus-idp/orchestrator-codeowners
+/plugins/orchestrator-backend               @janus-idp/maintainers-plugins @janus-idp/orchestrator-codeowners
+/plugins/orchestrator-common                @janus-idp/maintainers-plugins @janus-idp/orchestrator-codeowners
+/plugins/orchestrator-swf-editor-envelope   @janus-idp/maintainers-plugins @janus-idp/orchestrator-codeowners
+/plugins/feedback                           @janus-idp/maintainers-plugins @janus-idp/devex-uxe
+/plugins/feedback-backend                   @janus-idp/maintainers-plugins @janus-idp/devex-uxe
+/plugins/matomo                             @janus-idp/maintainers-plugins @janus-idp/devex-uxe
+/plugins/matomo-backend                     @janus-idp/maintainers-plugins @janus-idp/devex-uxe
+/plugins/analytics-module-matomo            @janus-idp/maintainers-plugins @janus-idp/devex-uxe
+/plugins/kiali                              @janus-idp/maintainers-plugins @janus-idp/kiali
+/plugins/kiali-backend                      @janus-idp/maintainers-plugins @janus-idp/kiali
+/plugins/kiali-common                       @janus-idp/maintainers-plugins @janus-idp/kiali
+/plugins/quay                               @janus-idp/rhtap
+/plugins/tekton                             @janus-idp/rhtap
+/plugins/argocd                             @janus-idp/rhtap

--- a/plugins/notifications-backend/OWNERS
+++ b/plugins/notifications-backend/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-  - mareklibra
-  - ydayagi
-reviewers:
-  - mareklibra
-  - ydayagi

--- a/plugins/notifications/OWNERS
+++ b/plugins/notifications/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-  - mareklibra
-  - ydayagi
-reviewers:
-  - mareklibra
-  - ydayagi

--- a/plugins/orchestrator-backend/OWNERS
+++ b/plugins/orchestrator-backend/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-  - caponetto
-  - jkilzi
-  - batzionb
-reviewers:
-  - caponetto
-  - jkilzi
-  - batzionb

--- a/plugins/orchestrator-common/OWNERS
+++ b/plugins/orchestrator-common/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-  - caponetto
-  - jkilzi
-  - batzionb
-reviewers:
-  - caponetto
-  - jkilzi
-  - batzionb

--- a/plugins/orchestrator-swf-editor-envelope/OWNERS
+++ b/plugins/orchestrator-swf-editor-envelope/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-  - caponetto
-  - jkilzi
-  - batzionb
-reviewers:
-  - caponetto
-  - jkilzi
-  - batzionb

--- a/plugins/orchestrator/OWNERS
+++ b/plugins/orchestrator/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-  - caponetto
-  - jkilzi
-  - batzionb
-reviewers:
-  - caponetto
-  - jkilzi
-  - batzionb


### PR DESCRIPTION
- Confirmed with the @janus-idp/orchestrator team that they would prefer to use CODEOWNERS over OWNERS.  Deleting OWNERS to avoid dup assignments
- Update CODEOWNERS to add the missing `/plugins/orchestrator-swf-editor-envelope` plugin