### PR TITLE
chore(owners): remove OWNERS files from kiali, update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,6 @@ yarn.lock                    @janus-idp/maintainers-plugins
 /plugins/analytics-module-matomo            @janus-idp/maintainers-plugins @janus-idp/devex-uxe
 /plugins/kiali                              @janus-idp/maintainers-plugins @janus-idp/kiali
 /plugins/kiali-backend                      @janus-idp/maintainers-plugins @janus-idp/kiali
-/plugins/kiali-common                       @janus-idp/maintainers-plugins @janus-idp/kiali
 /plugins/quay                               @janus-idp/rhtap
 /plugins/tekton                             @janus-idp/rhtap
 /plugins/argocd                             @janus-idp/rhtap

--- a/plugins/kiali-backend/OWNERS
+++ b/plugins/kiali-backend/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-  - aljesusg
-  - josunect
-  - leandroberetta
-reviewers:
-  - aljesusg
-  - josunect
-  - leandroberetta

--- a/plugins/kiali/OWNERS
+++ b/plugins/kiali/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-  - aljesusg
-  - josunect
-  - leandroberetta
-reviewers:
-  - aljesusg
-  - josunect
-  - leandroberetta


### PR DESCRIPTION
* confirmed with @aljesusg that it's ok to remove the OWNERS file from their plugins
* removed `/plugins/kiali-common` from CODEOWNERS since that no longer exists