### PR TITLE
test(orchestrator): add  OrchestratorClient unit tests

### DIFF
--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -474,4 +474,55 @@ describe('OrchestratorClient', () => {
       await expect(promise).rejects.toThrow();
     });
   });
+  describe('retriggerInstanceInError', () => {
+    it('should retrigger instance when successful', async () => {
+      // Given
+      const instanceId = 'instance123';
+      const inputData = { key: 'value' };
+      const mockResponse = { id: 'newInstanceId', status: 'running' };
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      // When
+      const result = await orchestratorClient.retriggerInstanceInError({
+        instanceId,
+        inputData,
+      });
+
+      // Then
+      const expectedUrlToFetch = `${baseUrl}/instances/${instanceId}/retrigger`;
+      expect(fetch).toHaveBeenCalledWith(expectedUrlToFetch, {
+        method: 'POST',
+        body: JSON.stringify(inputData),
+        headers: { 'content-type': 'application/json' },
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should throw a ResponseError when retriggering instance fails', async () => {
+      // Given
+      const instanceId = 'instance123';
+      const inputData = { key: 'value' };
+
+      // Mock fetch to simulate a failed response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      // When
+      const promise = orchestratorClient.retriggerInstanceInError({
+        instanceId,
+        inputData,
+      });
+
+      // Then
+      await expect(promise).rejects.toThrow();
+    });
+  });
 });

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -435,4 +435,43 @@ describe('OrchestratorClient', () => {
       await expect(promise).rejects.toThrow();
     });
   });
+  describe('getWorkflowOverview', () => {
+    it('should return workflow overview when successful', async () => {
+      // Given
+      const workflowId = 'workflow123';
+      const mockOverview = { id: workflowId, name: 'Workflow 1' };
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockOverview),
+      });
+
+      // When
+      const result = await orchestratorClient.getWorkflowOverview(workflowId);
+
+      // Then
+      const expectedEndpoint = `${baseUrl}/workflows/${workflowId}/overview`;
+      expect(fetch).toHaveBeenCalledWith(expectedEndpoint);
+      expect(result).toEqual(mockOverview);
+    });
+
+    it('should throw a ResponseError when fetching the workflow overview fails', async () => {
+      // Given
+      const workflowId = 'workflow123';
+
+      // Mock fetch to simulate a failed response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      // When
+      const promise = orchestratorClient.getWorkflowOverview(workflowId);
+
+      // Then
+      await expect(promise).rejects.toThrow();
+    });
+  });
 });

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -192,4 +192,42 @@ describe('OrchestratorClient', () => {
       await expect(promise).rejects.toThrow();
     });
   });
+  describe('getWorkflowDefinition', () => {
+    it('should return a workflow definition when successful', async () => {
+      // Given
+      const workflowId = 'workflow123';
+      const mockWorkflowDefinition = { id: workflowId, name: 'Workflow 1' };
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockWorkflowDefinition),
+      });
+
+      // When
+      const result = await orchestratorClient.getWorkflowDefinition(workflowId);
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(`${baseUrl}/workflows/${workflowId}`);
+      expect(result).toEqual(mockWorkflowDefinition);
+    });
+
+    it('should throw a ResponseError when fetching the workflow definition fails', async () => {
+      // Given
+      const workflowId = 'workflow123';
+
+      // Mock fetch to simulate a failed response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      // When
+      const promise = orchestratorClient.getWorkflowDefinition(workflowId);
+
+      // Then
+      await expect(promise).rejects.toThrow();
+    });
+  });
 });

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -269,4 +269,43 @@ describe('OrchestratorClient', () => {
       await expect(promise).rejects.toThrow();
     });
   });
+  describe('listWorkflowOverviews', () => {
+    it('should return workflow overviews when successful', async () => {
+      // Given
+      const mockWorkflowOverviews = [
+        { id: 'workflow123', name: 'Workflow 1' },
+        { id: 'workflow456', name: 'Workflow 2' },
+      ];
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockWorkflowOverviews),
+      });
+
+      // When
+      const result = await orchestratorClient.listWorkflowOverviews();
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(`${baseUrl}/workflows/overview`);
+      expect(result).toEqual(mockWorkflowOverviews);
+    });
+
+    it('should throw a ResponseError when listing workflow overviews fails', async () => {
+      // Given
+
+      // Mock fetch to simulate a failed response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      // When
+      const promise = orchestratorClient.listWorkflowOverviews();
+
+      // Then
+      await expect(promise).rejects.toThrow();
+    });
+  });
 });

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -308,4 +308,39 @@ describe('OrchestratorClient', () => {
       await expect(promise).rejects.toThrow();
     });
   });
+  describe('listInstances', () => {
+    it('should return instances when successful', async () => {
+      // Given
+      const mockInstances = [{ id: 'instance123', name: 'Instance 1' }];
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockInstances),
+      });
+
+      // When
+      const result = await orchestratorClient.listInstances();
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(`${baseUrl}/instances`);
+      expect(result).toEqual(mockInstances);
+    });
+
+    it('should throw a ResponseError when listing instances fails', async () => {
+      // Given
+      // Mock fetch to simulate a failed response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      // When
+      const promise = orchestratorClient.listInstances();
+
+      // Then
+      await expect(promise).rejects.toThrow();
+    });
+  });
 });

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -1,4 +1,5 @@
 import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { ResponseError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
 
 import { WorkflowExecutionResponse } from '@janus-idp/backstage-plugin-orchestrator-common';
@@ -11,6 +12,8 @@ import {
 describe('OrchestratorClient', () => {
   let mockDiscoveryApi: jest.Mocked<DiscoveryApi>;
   let orchestratorClientOptions: jest.Mocked<OrchestratorClientOptions>;
+  let orchestratorClient: OrchestratorClient;
+  const baseUrl = 'https://api.example.com';
 
   const mockFetch = jest.fn();
   (global as any).fetch = mockFetch; // Cast global to any to avoid TypeScript errors
@@ -26,127 +29,167 @@ describe('OrchestratorClient', () => {
     orchestratorClientOptions = {
       discoveryApi: mockDiscoveryApi,
     };
+    orchestratorClient = new OrchestratorClient(orchestratorClientOptions);
   });
-  it('should execute workflow with empty parameters', async () => {
-    // Given
-    const baseUrl = 'https://api.example.com';
-    const workflowId = 'workflow123';
-    const executionId = 'execId001';
-    const parameters: JsonObject = {};
-    const args = {
-      workflowId: workflowId,
-      parameters: {} as JsonObject,
-    };
+  describe('executeWorkflow', () => {
+    it('should execute workflow with empty parameters', async () => {
+      // Given
+      const workflowId = 'workflow123';
+      const executionId = 'execId001';
+      const parameters: JsonObject = {};
+      const args = {
+        workflowId: workflowId,
+        parameters: {} as JsonObject,
+      };
 
-    // Mock fetch to simulate a successful response
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: jest.fn().mockResolvedValue({
-        id: executionId,
-      }),
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          id: executionId,
+        }),
+      });
+
+      // When
+      const result: WorkflowExecutionResponse =
+        await orchestratorClient.executeWorkflow(args);
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(
+        `${baseUrl}/workflows/${workflowId}/execute`,
+        {
+          method: 'POST',
+          body: JSON.stringify(parameters),
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+
+      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+      expect(result.id).toEqual(executionId);
+    });
+    it('should execute workflow with business key', async () => {
+      // Given
+      const workflowId = 'workflow123';
+      const businessKey = 'business123';
+      const executionId = 'execId001';
+      const parameters: JsonObject = {};
+      const args = {
+        workflowId: workflowId,
+        parameters: {} as JsonObject,
+        businessKey: businessKey,
+      };
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          id: executionId,
+        }),
+      });
+
+      // When
+      const client = new OrchestratorClient(orchestratorClientOptions);
+      const result: WorkflowExecutionResponse =
+        await client.executeWorkflow(args);
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(
+        `${baseUrl}/workflows/${workflowId}/execute?businessKey=${businessKey}`,
+        {
+          method: 'POST',
+          body: JSON.stringify(parameters),
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+
+      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+      expect(result.id).toEqual(executionId);
+    });
+    it('should execute workflow with parameters and business key', async () => {
+      // Given
+      const workflowId = 'workflow123';
+      const businessKey = 'business123';
+      const executionId = 'execId001';
+      const parameters: JsonObject = {
+        param1: 'one',
+        param2: 2,
+        param3: true,
+      };
+      const args = {
+        workflowId: workflowId,
+        parameters: parameters,
+        businessKey: businessKey,
+      };
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          id: executionId,
+        }),
+      });
+
+      // When
+      const client = new OrchestratorClient(orchestratorClientOptions);
+      const result: WorkflowExecutionResponse =
+        await client.executeWorkflow(args);
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(
+        `${baseUrl}/workflows/${workflowId}/execute?businessKey=${businessKey}`,
+        {
+          method: 'POST',
+          body: JSON.stringify(parameters),
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+
+      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+      expect(result.id).toEqual(executionId);
+    });
+  });
+  describe('abortWorkflow', () => {
+    it('should abort a workflow instance successfully', async () => {
+      // Given
+      const instanceId = 'instance123';
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+      });
+
+      // When
+      await orchestratorClient.abortWorkflowInstance(instanceId);
+
+      // Assert
+      expect(fetch).toHaveBeenCalledWith(
+        `${baseUrl}/instances/${instanceId}/abort`,
+        {
+          method: 'DELETE',
+          headers: { 'content-type': 'application/json' },
+        },
+      );
     });
 
-    // When
-    const client = new OrchestratorClient(orchestratorClientOptions);
-    const result: WorkflowExecutionResponse =
-      await client.executeWorkflow(args);
+    it('should throw a ResponseError if aborting the workflow instance fails', async () => {
+      // Given
+      const instanceId = 'instance123';
 
-    // Then
-    expect(fetch).toHaveBeenCalledWith(
-      `${baseUrl}/workflows/${workflowId}/execute`,
-      {
-        method: 'POST',
-        body: JSON.stringify(parameters),
-        headers: { 'content-type': 'application/json' },
-      },
-    );
+      // Mock fetch to simulate a failed response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
 
-    expect(result).toBeDefined();
-    expect(result.id).toBeDefined();
-    expect(result.id).toEqual(executionId);
-  });
-  it('should execute workflow with business key', async () => {
-    // Given
-    const baseUrl = 'https://api.example.com';
-    const workflowId = 'workflow123';
-    const businessKey = 'business123';
-    const executionId = 'execId001';
-    const parameters: JsonObject = {};
-    const args = {
-      workflowId: workflowId,
-      parameters: {} as JsonObject,
-      businessKey: businessKey,
-    };
+      // When
+      const promise = orchestratorClient.abortWorkflowInstance(instanceId);
 
-    // Mock fetch to simulate a successful response
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: jest.fn().mockResolvedValue({
-        id: executionId,
-      }),
+      // Then
+      await expect(promise).rejects.toThrow();
     });
-
-    // When
-    const client = new OrchestratorClient(orchestratorClientOptions);
-    const result: WorkflowExecutionResponse =
-      await client.executeWorkflow(args);
-
-    // Then
-    expect(fetch).toHaveBeenCalledWith(
-      `${baseUrl}/workflows/${workflowId}/execute?businessKey=${businessKey}`,
-      {
-        method: 'POST',
-        body: JSON.stringify(parameters),
-        headers: { 'content-type': 'application/json' },
-      },
-    );
-
-    expect(result).toBeDefined();
-    expect(result.id).toBeDefined();
-    expect(result.id).toEqual(executionId);
-  });
-  it('should execute workflow with parameters and business key', async () => {
-    // Given
-    const baseUrl = 'https://api.example.com';
-    const workflowId = 'workflow123';
-    const businessKey = 'business123';
-    const executionId = 'execId001';
-    const parameters: JsonObject = {
-      param1: 'one',
-      param2: 2,
-      param3: true,
-    };
-    const args = {
-      workflowId: workflowId,
-      parameters: parameters,
-      businessKey: businessKey,
-    };
-
-    // Mock fetch to simulate a successful response
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: jest.fn().mockResolvedValue({
-        id: executionId,
-      }),
-    });
-
-    // When
-    const client = new OrchestratorClient(orchestratorClientOptions);
-    const result: WorkflowExecutionResponse =
-      await client.executeWorkflow(args);
-
-    // Then
-    expect(fetch).toHaveBeenCalledWith(
-      `${baseUrl}/workflows/${workflowId}/execute?businessKey=${businessKey}`,
-      {
-        method: 'POST',
-        body: JSON.stringify(parameters),
-        headers: { 'content-type': 'application/json' },
-      },
-    );
-
-    expect(result).toBeDefined();
-    expect(result.id).toBeDefined();
-    expect(result.id).toEqual(executionId);
   });
 });

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -1,5 +1,4 @@
 import { DiscoveryApi } from '@backstage/core-plugin-api';
-import { ResponseError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
 
 import { WorkflowExecutionResponse } from '@janus-idp/backstage-plugin-orchestrator-common';
@@ -225,6 +224,46 @@ describe('OrchestratorClient', () => {
 
       // When
       const promise = orchestratorClient.getWorkflowDefinition(workflowId);
+
+      // Then
+      await expect(promise).rejects.toThrow();
+    });
+  });
+  describe('getWorkflowSource', () => {
+    it('should return workflow source when successful', async () => {
+      // Given
+      const workflowId = 'workflow123';
+      const mockWorkflowSource = 'test workflow source';
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockWorkflowSource),
+      });
+
+      // When
+      const result = await orchestratorClient.getWorkflowSource(workflowId);
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(
+        `${baseUrl}/workflows/${workflowId}/source`,
+      );
+      expect(result).toEqual(mockWorkflowSource);
+    });
+
+    it('should throw a ResponseError when fetching the workflow source fails', async () => {
+      // Given
+      const workflowId = 'workflow123';
+
+      // Mock fetch to simulate a failed response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      // When
+      const promise = orchestratorClient.getWorkflowSource(workflowId);
 
       // Then
       await expect(promise).rejects.toThrow();

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -1,0 +1,152 @@
+import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { JsonObject } from '@backstage/types';
+
+import { WorkflowExecutionResponse } from '@janus-idp/backstage-plugin-orchestrator-common';
+
+import {
+  OrchestratorClient,
+  OrchestratorClientOptions,
+} from './OrchestratorClient';
+
+describe('OrchestratorClient', () => {
+  let mockDiscoveryApi: jest.Mocked<DiscoveryApi>;
+  let orchestratorClientOptions: jest.Mocked<OrchestratorClientOptions>;
+
+  const mockFetch = jest.fn();
+  (global as any).fetch = mockFetch; // Cast global to any to avoid TypeScript errors
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Create a mock DiscoveryApi with a mocked implementation of getBaseUrl
+    mockDiscoveryApi = {
+      getBaseUrl: jest.fn().mockResolvedValue('https://api.example.com'),
+    } as jest.Mocked<DiscoveryApi>;
+
+    // Create OrchestratorClientOptions with the mocked DiscoveryApi
+    orchestratorClientOptions = {
+      discoveryApi: mockDiscoveryApi,
+    };
+  });
+  it('should execute workflow with empty parameters', async () => {
+    // Given
+    const baseUrl = 'https://api.example.com';
+    const workflowId = 'workflow123';
+    const executionId = 'execId001';
+    const parameters: JsonObject = {};
+    const args = {
+      workflowId: workflowId,
+      parameters: {} as JsonObject,
+    };
+
+    // Mock fetch to simulate a successful response
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        id: executionId,
+      }),
+    });
+
+    // When
+    const client = new OrchestratorClient(orchestratorClientOptions);
+    const result: WorkflowExecutionResponse =
+      await client.executeWorkflow(args);
+
+    // Then
+    expect(fetch).toHaveBeenCalledWith(
+      `${baseUrl}/workflows/${workflowId}/execute`,
+      {
+        method: 'POST',
+        body: JSON.stringify(parameters),
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+
+    expect(result).toBeDefined();
+    expect(result.id).toBeDefined();
+    expect(result.id).toEqual(executionId);
+  });
+  it('should execute workflow with business key', async () => {
+    // Given
+    const baseUrl = 'https://api.example.com';
+    const workflowId = 'workflow123';
+    const businessKey = 'business123';
+    const executionId = 'execId001';
+    const parameters: JsonObject = {};
+    const args = {
+      workflowId: workflowId,
+      parameters: {} as JsonObject,
+      businessKey: businessKey,
+    };
+
+    // Mock fetch to simulate a successful response
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        id: executionId,
+      }),
+    });
+
+    // When
+    const client = new OrchestratorClient(orchestratorClientOptions);
+    const result: WorkflowExecutionResponse =
+      await client.executeWorkflow(args);
+
+    // Then
+    expect(fetch).toHaveBeenCalledWith(
+      `${baseUrl}/workflows/${workflowId}/execute?businessKey=${businessKey}`,
+      {
+        method: 'POST',
+        body: JSON.stringify(parameters),
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+
+    expect(result).toBeDefined();
+    expect(result.id).toBeDefined();
+    expect(result.id).toEqual(executionId);
+  });
+  it('should execute workflow with parameters and business key', async () => {
+    // Given
+    const baseUrl = 'https://api.example.com';
+    const workflowId = 'workflow123';
+    const businessKey = 'business123';
+    const executionId = 'execId001';
+    const parameters: JsonObject = {
+      param1: 'one',
+      param2: 2,
+      param3: true,
+    };
+    const args = {
+      workflowId: workflowId,
+      parameters: parameters,
+      businessKey: businessKey,
+    };
+
+    // Mock fetch to simulate a successful response
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        id: executionId,
+      }),
+    });
+
+    // When
+    const client = new OrchestratorClient(orchestratorClientOptions);
+    const result: WorkflowExecutionResponse =
+      await client.executeWorkflow(args);
+
+    // Then
+    expect(fetch).toHaveBeenCalledWith(
+      `${baseUrl}/workflows/${workflowId}/execute?businessKey=${businessKey}`,
+      {
+        method: 'POST',
+        body: JSON.stringify(parameters),
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+
+    expect(result).toBeDefined();
+    expect(result.id).toBeDefined();
+    expect(result.id).toEqual(executionId);
+  });
+});

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -343,4 +343,48 @@ describe('OrchestratorClient', () => {
       await expect(promise).rejects.toThrow();
     });
   });
+  describe('getInstance', () => {
+    it('should return instance when successful', async () => {
+      // Given
+      const instanceId = 'instance123';
+      const includeAssessment = false;
+      const mockInstance = { id: instanceId, name: 'Instance 1' };
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockInstance),
+      });
+
+      // When
+      const result = await orchestratorClient.getInstance(
+        instanceId,
+        includeAssessment,
+      );
+
+      // Then
+      const expectedEndpoint = `${baseUrl}/instances/${instanceId}?includeAssessment=false`;
+
+      expect(fetch).toHaveBeenCalledWith(expectedEndpoint);
+      expect(result).toEqual(mockInstance);
+    });
+
+    it('should throw a ResponseError when fetching the instance fails', async () => {
+      // Given
+      const instanceId = 'instance123';
+
+      // Mock fetch to simulate a failed response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      // When
+      const promise = orchestratorClient.getInstance(instanceId);
+
+      // Then
+      await expect(promise).rejects.toThrow();
+    });
+  });
 });

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -363,7 +363,7 @@ describe('OrchestratorClient', () => {
       );
 
       // Then
-      const expectedEndpoint = `${baseUrl}/instances/${instanceId}?includeAssessment=false`;
+      const expectedEndpoint = `${baseUrl}/instances/${instanceId}?includeAssessment=${includeAssessment}`;
 
       expect(fetch).toHaveBeenCalledWith(expectedEndpoint);
       expect(result).toEqual(mockInstance);
@@ -382,6 +382,54 @@ describe('OrchestratorClient', () => {
 
       // When
       const promise = orchestratorClient.getInstance(instanceId);
+
+      // Then
+      await expect(promise).rejects.toThrow();
+    });
+  });
+  describe('getWorkflowDataInputSchema', () => {
+    it('should return workflow input schema when successful', async () => {
+      // Given
+      const workflowId = 'workflow123';
+      const instanceId = 'instance123';
+      const assessmentInstanceId = 'assessment123';
+      const mockInputSchema = { id: 'schemaId', name: 'schemaName' };
+
+      // Mock fetch to simulate a successful response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockInputSchema),
+      });
+
+      // When
+      const result = await orchestratorClient.getWorkflowDataInputSchema({
+        workflowId,
+        instanceId,
+        assessmentInstanceId,
+      });
+
+      // Then
+      const expectedEndpoint = `${baseUrl}/workflows/${workflowId}/inputSchema?instanceId=${instanceId}&assessmentInstanceId=${assessmentInstanceId}`;
+
+      expect(fetch).toHaveBeenCalledWith(expectedEndpoint);
+      expect(result).toEqual(mockInputSchema);
+    });
+
+    it('should throw a ResponseError when fetching the workflow input schema fails', async () => {
+      // Given
+      const workflowId = 'workflow123';
+
+      // Mock fetch to simulate a failed response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      // When
+      const promise = orchestratorClient.getWorkflowDataInputSchema({
+        workflowId,
+      });
 
       // Then
       await expect(promise).rejects.toThrow();

--- a/plugins/orchestrator/src/utils/UrlUtils.test.ts
+++ b/plugins/orchestrator/src/utils/UrlUtils.test.ts
@@ -1,0 +1,32 @@
+import { QUERY_PARAM_BUSINESS_KEY } from '@janus-idp/backstage-plugin-orchestrator-common';
+
+import { buildUrl } from './UrlUtils';
+
+describe('UrlUtils', () => {
+  const baseUrl = 'https://my.base.url.com';
+  it('should return the base URL', async () => {
+    const res = buildUrl(baseUrl);
+    expect(res).toBeDefined();
+    expect(res).toEqual(baseUrl);
+  });
+  it('should return the base URL with the query params', async () => {
+    const queryParams: Record<string, any> = {
+      param1: 1,
+      param2: 'two',
+      param3: true,
+    };
+    const res = buildUrl(baseUrl, queryParams);
+    expect(res).toBeDefined();
+    expect(res).not.toEqual(`${baseUrl}`);
+    expect(res).toEqual(`${baseUrl}?param1=1&param2=two&param3=true`);
+  });
+  it('should return the base URL with business key param', async () => {
+    const queryParams: Record<string, any> = {
+      [QUERY_PARAM_BUSINESS_KEY]: 'businessKey1',
+    };
+    const res = buildUrl(baseUrl, queryParams);
+    expect(res).toBeDefined();
+    expect(res).not.toEqual(`${baseUrl}`);
+    expect(res).toEqual(`${baseUrl}?${QUERY_PARAM_BUSINESS_KEY}=businessKey1`);
+  });
+});


### PR DESCRIPTION
This PR introduces unit tests for the `OrchestratorClient` methods. These tests have been added as part of the work related to the introduction of a new endpoint defined via OpenAPI (v2) and the deprecation of the current endpoint (v1).
[FLPATH-1125](https://issues.redhat.com/browse/FLPATH-1125)

*Why These Changes Are Necessary*

With the introduction of the v2 OpenAPI endpoint and the deprecation of the current endpoint (v1), these unit tests serve as a safeguard against regressions and help early detect any issues that may arise due to changes in the endpoints.