### PR TITLE
fix(kiali): removing unnecessary afterAll hook

### DIFF
--- a/plugins/kiali/tests/kiali.spec.ts
+++ b/plugins/kiali/tests/kiali.spec.ts
@@ -16,10 +16,6 @@ test.describe('Kiali plugin', () => {
       await page.locator('[data-test="Kiali Errors"]');
     });
 
-    test.afterAll(async ({ browser }) => {
-      await browser.close();
-    });
-
     test('Networking error', async () => {
       await expect(
         page.locator('[data-test="Warning: Error reaching Kiali"]'),


### PR DESCRIPTION
the `afterAll` hook in test file is not needed. It causing troubles when another file is executed after specific file with the ` await browser.close();` method. From the playwright docs
> The [Browser](https://playwright.dev/docs/api/class-browser) object itself is considered to be disposed and cannot be used anymore.

This is simplest fix for now. If test starts to flake again, lets reiterate and create more robust bootstrap and cleanup methods. Tested, working with multiple test files.