### PR TITLE
chore(tests): do not run unit tests in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:storybook": "yarn --cwd packages/storybook build",
     "tsc": "turbo run tsc",
     "clean": "turbo run clean",
-    "test": "turbo run test",
+    "test": "turbo run test --concurrency=1",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint -- --fix",
     "lint-staged": "lint-staged",

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": [
+    ".prettierrc.js",
+    ".eslintrc.js",
+    "tsconfig.json",
+    "yarn.lock"
+  ],
   "pipeline": {
     "start": {
       "cache": false,
@@ -30,6 +36,5 @@
       "outputs": ["../../dist-types/**"],
       "dependsOn": ["^tsc"]
     }
-  },
-  "globalDependencies": ["prettierrc.js"]
+  }
 }


### PR DESCRIPTION
Turbo supports caching for tasks, including build(ing), lint(ing), and even test(ing).

While investigating why #1480 failed multiple times, I noticed that **different** tests fail our GitHub Actions and on my local machine. But when I tried to run the tests for a single workspace/plugin these tests pass...

I could reproduce this when disable the cache. The currency is 10 by default and many different workspaces fail:

```
yarn turbo test --force # default is --concurrency=10

...

@janus-idp/backstage-plugin-rbac#test: command (/home/christoph/git/janus-idp/backstage-plugins/plugins/rbac) yarn run test exited (1)

 Tasks:    12 successful, 47 total
Cached:    0 cached, 47 total
  Time:    1m3.393s 
Failed:    @janus-idp/backstage-plugin-rbac#test

 ERROR  run failed: command  exited (1)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

```
yarn turbo test --force --concurrency=47 # my PC is lagging with this option ;)

...

@janus-idp/backstage-plugin-web-terminal:test: ERROR: command finished with error: command (/home/christoph/git/janus-idp/backstage-plugins/plugins/web-terminal) yarn run test exited (1)
@janus-idp/backstage-plugin-web-terminal#test: command (/home/christoph/git/janus-idp/backstage-plugins/plugins/web-terminal) yarn run test exited (1)

 Tasks:    25 successful, 47 total
Cached:    0 cached, 47 total
  Time:    2m57.077s 
Failed:    @janus-idp/backstage-plugin-web-terminal#test

 ERROR  run failed: command  exited (1)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

But when running all workspaces in a sequence, the test runs successfully:

```
yarn turbo test --force --concurrency=1

...

 Tasks:    47 successful, 47 total
Cached:    0 cached, 47 total
  Time:    4m2.405s 

Done in 242.85s.
```

Of course, it would be nice to investigate whether we can run all or more tests in parallel. But for now, I want to ensure that the tests run sequentially / successfully.

But will this increase the test time? Yes, but only if all tests run, for example, when the package.json is changed. Tests of untouched workspaces will (still) not run! In my machine running all tests takes ~ 4 min.

I also added the `yarn.lock` to the `globalDependencies` to ensure that we rerun builds and tests if any dependency changes!