### PR TITLE
fix(argocd): make refreshInterval configuration as optional

### DIFF
--- a/plugins/argocd/config.d.ts
+++ b/plugins/argocd/config.d.ts
@@ -20,7 +20,7 @@ export interface Config {
      * Polling interval timeout
      * @visibility frontend
      */
-    refreshInterval: number;
+    refreshInterval?: number;
     /**
      * The base url of the ArgoCD instance.
      * @visibility frontend


### PR DESCRIPTION
**Description:**

Since we have a fallback value for refreshInterval config, marking it as optional field.