### PR TITLE
fix(config): enable guest provider by default

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -59,7 +59,7 @@ techdocs:
 
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
-  providers: {}
+  providers: { guest: {} }
 
 scaffolder:
   {}


### PR DESCRIPTION
Current Issue:
When running yarn start:backstage, the application encounters a critical problem where all backend calls fail with a "401 Unauthorized" error. The issue stems from missing credentials, as indicated by the stack trace's "AuthenticationError: Missing credentials" message.

Proposed Solution:
This pull request addresses the issue by including the guest authentication provider by default, effectively resolving the authentication problem.

Note: 
Running "npx @backstage/create-app@latest" to bootstrap a new backstage app, includes this config.