### PR TITLE
docs(orchestrator): removes instructions related to the editor

### DIFF
--- a/plugins/orchestrator-backend/app-config.janus-idp.yaml
+++ b/plugins/orchestrator-backend/app-config.janus-idp.yaml
@@ -1,5 +1,3 @@
 orchestrator:
   dataIndexService:
     url: http://sonataflow-platform-data-index-service.sonataflow-infra
-  editor:
-    path: https://sandbox.kie.org/swf-chrome-extension/0.32.0

--- a/plugins/orchestrator-common/config.d.ts
+++ b/plugins/orchestrator-common/config.d.ts
@@ -63,17 +63,6 @@ export interface Config {
       url: string;
     };
     /**
-     * Configuration for the workflow editor.
-     */
-    editor?: {
-      /**
-       * Path to the envelope context (either a remote url or a local path under app/public folder).
-       * Default: https://sandbox.kie.org/swf-chrome-extension/0.32.0
-       * @visibility frontend
-       */
-      path?: string;
-    };
-    /**
      * Configuration for the integration with Jira API.
      * Note: This is a temporary solution. We should probably use the JIRA integration config instead.
      */

--- a/plugins/orchestrator-swf-editor-envelope/README.md
+++ b/plugins/orchestrator-swf-editor-envelope/README.md
@@ -29,8 +29,4 @@ The Orchestrator plugin uses these assets when it renders the Serverless Workflo
        script-src: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
        script-src-elem: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
        connect-src: ["'self'", 'http:', 'https:', 'data:']
-   orchestrator:
-     editor:
-       path: http://localhost:7007/api/orchestrator/static/envelope
    ```
-   The `orchestrator.editor.path` corresponds to the endpoint from where the static files are served (in the example above the `dist` folder has been renamed to `envelope` and placed inside `plugins/orchestrator-backend/static/`).

--- a/plugins/orchestrator/README.md
+++ b/plugins/orchestrator/README.md
@@ -71,8 +71,6 @@ backend:
     script-src-elem: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
     connect-src: ["'self'", 'http:', 'https:', 'data:']
 orchestrator:
-  editor:
-    path: http://localhost:7007/api/orchestrator/static/envelope
   sonataFlowService:
     baseUrl: http://localhost
     port: 8899


### PR DESCRIPTION
Removes deprecated documentation related to the editor settings 