### PR TITLE
feat(rbac): improve conditional policy validation

### DIFF
--- a/plugins/rbac-backend/docs/apis.md
+++ b/plugins/rbac-backend/docs/apis.md
@@ -705,6 +705,34 @@ Based on the above schema:
 }
 ```
 
+**NOTE**: We do not support the ability to run conditions in parallel during creation. An example can be found below, notice that `anyOf` and `not` are on the same level. Consider making separate condition requests, or nest your conditions based on the available criteria.
+
+```json
+{
+  "anyOf": [
+    {
+      "rule": "IS_ENTITY_OWNER",
+      "resourceType": "catalog-entity",
+      "params": {
+        "claims": ["group:default/team-a"]
+      }
+    },
+    {
+      "rule": "IS_ENTITY_KIND",
+      "resourceType": "catalog-entity",
+      "params": {
+        "kinds": ["Group"]
+      }
+    }
+  ],
+  "not": {
+    "rule": "IS_ENTITY_KIND",
+    "resourceType": "catalog-entity",
+    "params": { "kinds": ["Api"] }
+  }
+}
+```
+
 To utilize this condition to the RBAC REST api you need to wrap it with more info:
 
 ```json

--- a/plugins/rbac-backend/docs/conditions.md
+++ b/plugins/rbac-backend/docs/conditions.md
@@ -1,0 +1,353 @@
+# Conditional Permission Policies
+
+The Backstage permission framework provides conditions, and the RBAC backend plugin supports this feature. Conditions work like content filters for Backstage resources (provided by plugins). The RBAC backend API stores conditions assigned to the role in the database. When a user requests access to the frontend resources, the RBAC backend API searches for corresponding conditions and delegates the condition for this resource to the corresponding plugin by its plugin ID. If a user was assigned to multiple roles, and each of these roles contains its own condition, the RBAC backend merges conditions using the anyOf criteria.
+
+The corresponding plugin analyzes conditional parameters and makes a decision about which part of the content the user should see. Consequently, the user can view not all resource content but only some allowed parts. The RBAC backend plugin supports conditions bounded to the RBAC role.
+
+A Backstage condition can be a simple condition with a rule and parameters. But also a Backstage condition could consists of a parameter or an array of parameters joined by criteria. The list of supported conditional criteria includes:
+
+- allOf
+- anyOf
+- not
+
+The plugin defines the supported condition parameters. API users can retrieve the conditional object schema from the RBAC API endpoint to determine how to build a condition JSON object and utilize it through the RBAC backend plugin API.
+
+The structure of the condition JSON object is as follows:
+
+| Json field        | Description                                                           | Type         |
+| ----------------- | --------------------------------------------------------------------- | ------------ |
+| result            | Always has the value "CONDITIONAL"                                    | String       |
+| roleEntityRef     | String entity reference to the RBAC role ('role:default/dev')         | String       |
+| pluginId          | Corresponding plugin ID (e.g., "catalog")                             | String       |
+| permissionMapping | Array permission actions (['read', 'update', 'delete'])               | String array |
+| resourceType      | Resource type provided by the plugin (e.g., "catalog-entity")         | String       |
+| conditions        | Condition JSON with parameters or array parameters joined by criteria | JSON         |
+
+To get the available conditional rules that can be used to create conditional permission policies, use the GET API request `api/plugins/condition-rules` as seen below.
+
+GET <api/plugins/condition-rules>
+
+Provides condition parameters schemas.
+
+```json
+[
+   {
+      "pluginId": "catalog",
+      "rules": [
+         {
+            "name": "HAS_ANNOTATION",
+            "description": "Allow entities with the specified annotation",
+            "resourceType": "catalog-entity",
+            "paramsSchema": {
+               "type": "object",
+               "properties": {
+                  "annotation": {
+                     "type": "string",
+                     "description": "Name of the annotation to match on"
+                  },
+                  "value": {
+                     "type": "string",
+                     "description": "Value of the annotation to match on"
+                  }
+               },
+               "required": [
+                  "annotation"
+               ],
+               "additionalProperties": false,
+               "$schema": "http://json-schema.org/draft-07/schema#"
+            }
+         },
+         {
+            "name": "HAS_LABEL",
+            "description": "Allow entities with the specified label",
+            "resourceType": "catalog-entity",
+            "paramsSchema": {
+               "type": "object",
+               "properties": {
+                  "label": {
+                     "type": "string",
+                     "description": "Name of the label to match on"
+                  }
+               },
+               "required": [
+                  "label"
+               ],
+               "additionalProperties": false,
+               "$schema": "http://json-schema.org/draft-07/schema#"
+            }
+         },
+         {
+            "name": "HAS_METADATA",
+            "description": "Allow entities with the specified metadata subfield",
+            "resourceType": "catalog-entity",
+            "paramsSchema": {
+               "type": "object",
+               "properties": {
+                  "key": {
+                     "type": "string",
+                     "description": "Property within the entities metadata to match on"
+                  },
+                  "value": {
+                     "type": "string",
+                     "description": "Value of the given property to match on"
+                  }
+               },
+               "required": [
+                  "key"
+               ],
+               "additionalProperties": false,
+               "$schema": "http://json-schema.org/draft-07/schema#"
+            }
+         },
+         {
+            "name": "HAS_SPEC",
+            "description": "Allow entities with the specified spec subfield",
+            "resourceType": "catalog-entity",
+            "paramsSchema": {
+               "type": "object",
+               "properties": {
+                  "key": {
+                     "type": "string",
+                     "description": "Property within the entities spec to match on"
+                  },
+                  "value": {
+                     "type": "string",
+                     "description": "Value of the given property to match on"
+                  }
+               },
+               "required": [
+                  "key"
+               ],
+               "additionalProperties": false,
+               "$schema": "http://json-schema.org/draft-07/schema#"
+            }
+         },
+         {
+            "name": "IS_ENTITY_KIND",
+            "description": "Allow entities matching a specified kind",
+            "resourceType": "catalog-entity",
+            "paramsSchema": {
+               "type": "object",
+               "properties": {
+                  "kinds": {
+                     "type": "array",
+                     "items": {
+                        "type": "string"
+                     },
+                     "description": "List of kinds to match at least one of"
+                  }
+               },
+               "required": [
+                  "kinds"
+               ],
+               "additionalProperties": false,
+               "$schema": "http://json-schema.org/draft-07/schema#"
+            }
+         },
+         {
+            "name": "IS_ENTITY_OWNER",
+            "description": "Allow entities owned by a specified claim",
+            "resourceType": "catalog-entity",
+            "paramsSchema": {
+               "type": "object",
+               "properties": {
+                  "claims": {
+                     "type": "array",
+                     "items": {
+                        "type": "string"
+                     },
+                     "description": "List of claims to match at least one on within ownedBy"
+                  }
+               },
+               "required": [
+                  "claims"
+               ],
+               "additionalProperties": false,
+               "$schema": "http://json-schema.org/draft-07/schema#"
+            }
+         }
+      ]
+   }
+   ... <another plugin condition parameter schemas>
+]
+```
+
+From this condition schema, the RBAC backend API user can determine how to build a condition JSON object.
+
+For example, consider a condition without criteria: displaying catalogs only if the user is a member of the owner group. The Catalog plugin schema "IS_ENTITY_OWNER" can be utilized to achieve this goal. To construct the condition JSON object based on this schema, the following information should be used:
+
+- rule: the parameter name is "IS_ENTITY_OWNER" in this case
+- resourceType: "catalog-entity"
+- criteria: in this example, criteria are not used since we need to use only one conditional parameter
+- params: from the schema, it is evident that it should be an object named "claims" with a string array. This string array constitutes a list of user or group string entity references.
+
+Based on the above schema condition is:
+
+```json
+{
+  "rule": "IS_ENTITY_OWNER",
+  "resourceType": "catalog-entity",
+  "params": {
+    "claims": ["group:default/team-a"]
+  }
+}
+```
+
+To utilize this condition to the RBAC REST api you need to wrap it with more info
+
+```json
+{
+  "result": "CONDITIONAL",
+  "roleEntityRef": "role:default/test",
+  "pluginId": "catalog",
+  "resourceType": "catalog-entity",
+  "permissionMapping": ["read"],
+  "conditions": {
+    "rule": "IS_ENTITY_OWNER",
+    "resourceType": "catalog-entity",
+    "params": {
+      "claims": ["group:default/team-a"]
+    }
+  }
+}
+```
+
+**Example condition with criteria**: display catalogs only if user is a member of owner group "OR" display list of all catalog user groups.
+
+We can reuse previous condition parameter to display catalogs only for owner. Also we can use one more condition "IS_ENTITY_KIND" to display catalog groups for any user:
+
+- rule - the parameter name is "IS_ENTITY_KIND" in this case.
+- resource type: "catalog-entity".
+- criteria - "anyOf".
+- params - from the schema, it is evident that it should be an object named "kinds" with string array. This string array is a list of catalog kinds. It should be array with single element "Group" in our case.
+
+Based on the above schema:
+
+```json
+{
+  "anyOf": [
+    {
+      "rule": "IS_ENTITY_OWNER",
+      "resourceType": "catalog-entity",
+      "params": {
+        "claims": ["group:default/team-a"]
+      }
+    },
+    {
+      "rule": "IS_ENTITY_KIND",
+      "resourceType": "catalog-entity",
+      "params": {
+        "kinds": ["Group"]
+      }
+    }
+  ]
+}
+```
+
+**NOTE**: We do not support the ability to run conditions in parallel during creation. An example can be found below, notice that `anyOf` and `not` are on the same level. Consider making separate condition requests, or nest your conditions based on the available criteria.
+
+```json
+{
+  "anyOf": [
+    {
+      "rule": "IS_ENTITY_OWNER",
+      "resourceType": "catalog-entity",
+      "params": {
+        "claims": ["group:default/team-a"]
+      }
+    },
+    {
+      "rule": "IS_ENTITY_KIND",
+      "resourceType": "catalog-entity",
+      "params": {
+        "kinds": ["Group"]
+      }
+    }
+  ],
+  "not": {
+    "rule": "IS_ENTITY_KIND",
+    "resourceType": "catalog-entity",
+    "params": { "kinds": ["Api"] }
+  }
+}
+```
+
+To utilize this condition to the RBAC REST api you need to wrap it with more info:
+
+```json
+{
+  "result": "CONDITIONAL",
+  "roleEntityRef": "role:default/test",
+  "pluginId": "catalog",
+  "resourceType": "catalog-entity",
+  "permissionMapping": ["read"],
+  "conditions": {
+    "anyOf": [
+      {
+        "rule": "IS_ENTITY_OWNER",
+        "resourceType": "catalog-entity",
+        "params": {
+          "claims": ["group:default/team-a"]
+        }
+      },
+      {
+        "rule": "IS_ENTITY_KIND",
+        "resourceType": "catalog-entity",
+        "params": {
+          "kinds": ["Group"]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Examples of Conditional Policies
+
+Below are a few examples that can be used on some of the Janus IDP plugins. These can help in determining how based to define conditional policies
+
+### Keycloak plugin
+
+```JSON
+{
+  "result": "CONDITIONAL",
+  "roleEntityRef": "role:default/developer",
+  "pluginId": "catalog",
+  "resourceType": "catalog-entity",
+  "permissionMapping": ["update", "delete"],
+  "conditions": {
+    "not": {
+      "rule": "HAS_ANNOTATION",
+      "resourceType": "catalog-entity",
+      "params": { "annotation": "keycloak.org/realm", "value": "<YOUR_REALM>" }
+    }
+  }
+}
+```
+
+This example will prevent users in the role `role:default/developer` from updating or deleting users that ingested into the catalog from the Keycloak plugin.
+
+Notice the use of the annotation `keycloak.org/realm` requires the value of `<YOUR_REALM>`
+
+### Quay Actions
+
+```JSON
+{
+  "result": "CONDITIONAL",
+  "roleEntityRef": "role:default/developer",
+  "pluginId": "scaffolder",
+  "resourceType": "scaffolder-action",
+  "permissionMapping": ["use"],
+  "conditions": {
+    "not": {
+      "rule": "HAS_ACTION_ID",
+      "resourceType": "scaffolder-action",
+      "params": { "actionId": "quay:create-repository" }
+    }
+  }
+}
+```
+
+This example will prevent users from using the Quay scaffolder action if they are a part of the role `role:default/developer`.
+
+Notice, we use the `permissionMapping` field with `use`. This is because the `scaffolder-action` resource type permission does not have a permission policy. More information can be found in our documentation on [permissions](./permissions.md).

--- a/plugins/rbac-backend/docs/conditions.md
+++ b/plugins/rbac-backend/docs/conditions.md
@@ -244,34 +244,6 @@ Based on the above schema:
 }
 ```
 
-**NOTE**: We do not support the ability to run conditions in parallel during creation. An example can be found below, notice that `anyOf` and `not` are on the same level. Consider making separate condition requests, or nest your conditions based on the available criteria.
-
-```json
-{
-  "anyOf": [
-    {
-      "rule": "IS_ENTITY_OWNER",
-      "resourceType": "catalog-entity",
-      "params": {
-        "claims": ["group:default/team-a"]
-      }
-    },
-    {
-      "rule": "IS_ENTITY_KIND",
-      "resourceType": "catalog-entity",
-      "params": {
-        "kinds": ["Group"]
-      }
-    }
-  ],
-  "not": {
-    "rule": "IS_ENTITY_KIND",
-    "resourceType": "catalog-entity",
-    "params": { "kinds": ["Api"] }
-  }
-}
-```
-
 To utilize this condition to the RBAC REST api you need to wrap it with more info:
 
 ```json
@@ -351,3 +323,31 @@ Notice the use of the annotation `keycloak.org/realm` requires the value of `<YO
 This example will prevent users from using the Quay scaffolder action if they are a part of the role `role:default/developer`.
 
 Notice, we use the `permissionMapping` field with `use`. This is because the `scaffolder-action` resource type permission does not have a permission policy. More information can be found in our documentation on [permissions](./permissions.md).
+
+**NOTE**: We do not support the ability to run conditions in parallel during creation. An example can be found below, notice that `anyOf` and `not` are on the same level. Consider making separate condition requests, or nest your conditions based on the available criteria.
+
+```json
+{
+  "anyOf": [
+    {
+      "rule": "IS_ENTITY_OWNER",
+      "resourceType": "catalog-entity",
+      "params": {
+        "claims": ["group:default/team-a"]
+      }
+    },
+    {
+      "rule": "IS_ENTITY_KIND",
+      "resourceType": "catalog-entity",
+      "params": {
+        "kinds": ["Group"]
+      }
+    }
+  ],
+  "not": {
+    "rule": "IS_ENTITY_KIND",
+    "resourceType": "catalog-entity",
+    "params": { "kinds": ["Api"] }
+  }
+}
+```

--- a/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
@@ -19,7 +19,7 @@ import {
   checkForDuplicatePolicies,
   validateGroupingPolicy,
   validatePolicy,
-} from '../service/policies-validation';
+} from '../validation/policies-validation';
 
 export const CSV_PERMISSION_POLICY_FILE_AUTHOR = 'csv permission policy file';
 

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -29,8 +29,8 @@ import {
 } from '../database/role-metadata';
 import { CSVFileWatcher } from '../file-permissions/csv-file-watcher';
 import { metadataStringToPolicy, removeTheDifference } from '../helper';
+import { validateEntityReference } from '../validation/policies-validation';
 import { EnforcerDelegate } from './enforcer-delegate';
-import { validateEntityReference } from './policies-validation';
 
 export const ADMIN_ROLE_NAME = 'role:default/rbac_admin';
 export const ADMIN_ROLE_AUTHOR = 'application configuration';

--- a/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -148,7 +148,7 @@ const conditionalStorage = {
 };
 
 const validateRoleConditionMock = jest.fn().mockImplementation();
-jest.mock('./condition-validation', () => {
+jest.mock('../validation/condition-validation', () => {
   return {
     validateRoleCondition: jest
       .fn()

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -999,7 +999,8 @@ export class PoliciesServer {
       const perm = rule.permissions.find(
         permission =>
           permission.type === 'resource' &&
-          action === permission.attributes.action,
+          (action === permission.attributes.action ||
+            (action === 'use' && permission.attributes.action === undefined)),
       );
       if (!perm) {
         throw new Error(

--- a/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -52,14 +52,14 @@ import {
   RoleMetadataStorage,
 } from '../database/role-metadata';
 import { deepSortedEqual, isPermissionAction, policyToString } from '../helper';
-import { validateRoleCondition } from './condition-validation';
-import { EnforcerDelegate } from './enforcer-delegate';
-import { PluginPermissionMetadataCollector } from './plugin-endpoints';
+import { validateRoleCondition } from '../validation/condition-validation';
 import {
   validateEntityReference,
   validatePolicy,
   validateRole,
-} from './policies-validation';
+} from '../validation/policies-validation';
+import { EnforcerDelegate } from './enforcer-delegate';
+import { PluginPermissionMetadataCollector } from './plugin-endpoints';
 
 export class PoliciesServer {
   constructor(

--- a/plugins/rbac-backend/src/validation/condition-validation.test.ts
+++ b/plugins/rbac-backend/src/validation/condition-validation.test.ts
@@ -283,6 +283,30 @@ describe('condition-validation', () => {
       }
       expect(unexpectedErr).toBeUndefined();
     });
+
+    it('should validate role-condition.conditions with permission policy action of use without errors', () => {
+      const condition: any = {
+        pluginId: 'scaffolder',
+        resourceType: 'scaffolder-action',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['use'],
+        conditions: {
+          rule: 'HAS_ACTION_ID',
+          resourceType: 'scaffolder-action',
+          params: {
+            actionId: 'quay:create-repository',
+          },
+        },
+      };
+      let unexpectedErr;
+      try {
+        validateRoleCondition(condition);
+      } catch (err) {
+        unexpectedErr = err;
+      }
+      expect(unexpectedErr).toBeUndefined();
+    });
   });
 
   describe('validate "not" criteria', () => {


### PR DESCRIPTION
## Description

Adds some more validation to conditional policies. This validation ensures that conditional policies do not have criteria defined in parallel. Example can be found below. Also includes a new test for nested conditions. Updates documentation about nested conditions with a not about the lack of support for parallel condition criteria.

## Fixes

- Fixes: [RHIDP-2157](https://issues.redhat.com/browse/RHIDP-2157)

## Special notes to the reviewer

Example of a condition in parallel:
```
{
  "anyOf": [
    {
      "rule": "IS_ENTITY_OWNER",
      "resourceType": "catalog-entity",
      "params": {
        "claims": ["group:default/team-a"]
      }
    },
    {
      "rule": "IS_ENTITY_KIND",
      "resourceType": "catalog-entity",
      "params": {
        "kinds": ["Group"]
      }
    }
  ],
  "not": {
    "rule": "IS_ENTITY_KIND",
    "resourceType": "catalog-entity",
    "params": { "kinds": ["Api"] }
  }
}
```

Example of a nested condition:
```
{
  "anyOf": [
    {
      "rule": "IS_ENTITY_OWNER",
      "resourceType": "catalog-entity",
      "params": {"claims": ["group:default/team-a"]}
    },
    {
      "rule": "IS_ENTITY_KIND",
      "resourceType": "catalog-entity",
      "params": {"kinds": ["Group"]}
    },
    {
      "not": {
        "rule": "IS_ENTITY_KIND",
        "resourceType": "catalog-entity",
        "params": { "kinds": ["Api"] }
      }
    }
  ],
}
```

Some curl commands to see the following error and to see a successful conditional policy (remember to get your token for the commands):

Error: `"RBAC plugin does not support parallel conditions, consider reworking request to include nested condition criteria. Conditional criteria causing the error allOf,not.`

Failing curl command:
```
curl -X POST "http://localhost:7007/api/permission/roles/conditions" -d '{"result":"CONDITIONAL","roleEntityRef": "role:default/developer","pluginId":"catalog","resourceType":"catalog-entity","permissionMapping": ["read","update","delete"],"conditions": {"rule": "IS_ENTITY_OWNER",
"resourceType": "catalog-entity","params": {"claims": ["user:default/dev1"]},"allOf": [{"rule": "IS_ENTITY_OWNER","resourceType": "catalog-entity","params": {"claims": ["user:default/<YOUR_USER>"]}},{"rule": "HAS_LABEL","resourceType": "catalog-entity","params": {"label": "test"}}],"not":{"rule":"IS_ENTITY_KIND","resourceType":"catalog-entity","params":{"kinds":["Api"]}}}}' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
```

Successful curl command:
```
curl -X POST "http://localhost:7007/api/permission/roles/conditions" -d '{"result":"CONDITIONAL","roleEntityRef": "role:default/developer","pluginId":"catalog","resourceType":"catalog-entity","permissionMapping": ["read","update","delete"],"conditions": {"anyOf": [{"allOf": [{"rule": "IS_ENTITY_OWNER","resourceType": "catalog-entity","params": {"claims": ["user:default/<YOUR_USER>"]}},{"rule": "HAS_LABEL","resourceType": "catalog-entity","params": {"label": "test"}}]},{"not":{"rule":"IS_ENTITY_KIND","resourceType":"catalog-entity","params":{"kinds":["Api"]}}}]}}' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
```

### Edit

I have also fixed a bug that originally prevented us from being able to declare conditional permission policies with the permission policy action of `use`. This would have affected the scaffolder-action example that I included in the documentation. 

To test:
1. Add the quay actions plugin module
2. Import in the example location in the plugin's directory
3. Use the following curl command
```
curl -X POST "http://localhost:7007/api/permission/roles/conditions" -d '{"result":"CONDITIONAL","roleEntityRef": "role:default/developer","pluginId":"scaffolder","resourceType":"scaffolder-action","permissionMapping": ["use"],"conditions": {"not": {"rule": "HAS_ACTION_ID","resourceType": "scaffolder-action","params": {"actionId": "quay:create-repository"}}}}' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v
```
4. Attempt to use the quay actions scaffolder template