### PR TITLE
fix(deps): upgrade devex plugins to mui v5

### DIFF
--- a/plugins/feedback-backend/dist-dynamic/package.json
+++ b/plugins/feedback-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-feedback-backend-dynamic",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -42,7 +42,6 @@
     "config.d.ts",
     "app-config.janus-idp.yaml",
     "migrations/**/*.{js,d.ts}",
-    "dist-dynamic",
     "alpha"
   ],
   "configSchema": "config.d.ts",
@@ -56,6 +55,7 @@
   "bundleDependencies": true,
   "peerDependencies": {
     "@backstage/backend-common": "^0.21.7",
+    "@backstage/backend-dynamic-feature-service": "^0.2.10",
     "@backstage/backend-plugin-api": "^0.6.17",
     "@backstage/backend-test-utils": "^0.3.7",
     "@backstage/catalog-client": "^1.6.4",

--- a/plugins/feedback-backend/dist-dynamic/yarn.lock
+++ b/plugins/feedback-backend/dist-dynamic/yarn.lock
@@ -55,9 +55,9 @@
     "@types/node" "*"
 
 "@types/express-serve-static-core@^4.17.33":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.0.tgz#3ae8ab3767d98d0b682cda063c3339e1e86ccfaa"
-  integrity sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.1.tgz#57d34698bb580720fd6e3c360d4b2fdef579b979"
+  integrity sha512-ej0phymbFLoCB26dbbq5PGScsf2JAJ4IJHjG10LalgUV36XKTmA4GdA+PVllKvRk0sEKt64X8975qFnkSi0hqA==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -152,9 +152,9 @@ asynckit@^0.4.0:
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 axios@^1.6.4:
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
-  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
+  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"

--- a/plugins/feedback-backend/package.json
+++ b/plugins/feedback-backend/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.21.7",
+    "@backstage/backend-dynamic-feature-service": "^0.2.10",
     "@backstage/backend-plugin-api": "^0.6.17",
     "@backstage/backend-test-utils": "^0.3.7",
     "@backstage/catalog-client": "^1.6.4",
@@ -69,7 +70,9 @@
     "config.d.ts",
     "app-config.janus-idp.yaml",
     "migrations/**/*.{js,d.ts}",
-    "dist-dynamic"
+    "dist-dynamic/*.*",
+    "dist-dynamic/dist/**",
+    "dist-dynamic/alpha/*"
   ],
   "configSchema": "config.d.ts",
   "repository": "github:janus-idp/backstage-plugins",

--- a/plugins/feedback-backend/src/dynamic/inedx.ts
+++ b/plugins/feedback-backend/src/dynamic/inedx.ts
@@ -1,0 +1,8 @@
+import { BackendDynamicPluginInstaller } from '@backstage/backend-dynamic-feature-service';
+
+import { feedbackPlugin } from '../plugin';
+
+export const dynamicPluginInstaller: BackendDynamicPluginInstaller = {
+  kind: 'new',
+  install: () => feedbackPlugin(),
+};

--- a/plugins/feedback/package.json
+++ b/plugins/feedback/package.json
@@ -31,9 +31,8 @@
     "@backstage/core-plugin-api": "^1.9.2",
     "@backstage/plugin-catalog-react": "^1.11.3",
     "@backstage/theme": "^0.5.3",
-    "@material-ui/core": "^4.9.13",
-    "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "^4.0.0-alpha.61",
+    "@mui/icons-material": "^5.15.18",
+    "@mui/material": "^5.15.18",
     "@one-platform/opc-feedback": "0.1.1-alpha",
     "axios": "^1.6.4",
     "react-use": "^17.2.4"

--- a/plugins/feedback/src/components/CreateFeedbackModal/CreateFeedbackModal.tsx
+++ b/plugins/feedback/src/components/CreateFeedbackModal/CreateFeedbackModal.tsx
@@ -2,64 +2,74 @@ import React, { useState } from 'react';
 
 import { configApiRef, useAnalytics, useApi } from '@backstage/core-plugin-api';
 
-import {
-  Button,
-  Chip,
-  createStyles,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  FormControlLabel,
-  Grid,
-  IconButton,
-  makeStyles,
-  Paper,
-  Radio,
-  RadioGroup,
-  TextField,
-  Theme,
-  Typography,
-} from '@material-ui/core';
-import BugReportOutlined from '@material-ui/icons/BugReportOutlined';
-import BugReportTwoToneIcon from '@material-ui/icons/BugReportTwoTone';
-import CloseRounded from '@material-ui/icons/CloseRounded';
-import SmsOutlined from '@material-ui/icons/SmsOutlined';
-import SmsTwoTone from '@material-ui/icons/SmsTwoTone';
-import { Alert } from '@material-ui/lab';
+import BugReportOutlined from '@mui/icons-material/BugReportOutlined';
+import BugReportTwoToneIcon from '@mui/icons-material/BugReportTwoTone';
+import CloseRounded from '@mui/icons-material/CloseRounded';
+import SmsOutlined from '@mui/icons-material/SmsOutlined';
+import SmsTwoTone from '@mui/icons-material/SmsTwoTone';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
+import Paper from '@mui/material/Paper';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import { styled, Theme } from '@mui/material/styles';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 
 import { feedbackApiRef } from '../../api';
 import { FeedbackCategory } from '../../models/feedback.model';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      '& > * > *': {
-        margin: theme.spacing(1),
-        width: '100%',
-      },
-      padding: '0.5rem',
+const PREFIX = 'CreateFeedbackModal';
+
+const classes = {
+  root: `${PREFIX}-root`,
+  actions: `${PREFIX}-actions`,
+  container: `${PREFIX}-container`,
+  dialogTitle: `${PREFIX}-dialogTitle`,
+  closeButton: `${PREFIX}-closeButton`,
+  radioGroup: `${PREFIX}-radioGroup`,
+};
+
+const StyledPaper = styled(Paper)(({ theme }: { theme: Theme }) => ({
+  [`& .${classes.root}`]: {
+    '& > * > *': {
+      margin: theme.spacing(1),
+      width: '100%',
     },
-    actions: {
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-      paddingRight: '1rem',
+    padding: '0.5rem',
+  },
+
+  [`& .${classes.actions}`]: {
+    '& > *': {
+      margin: theme.spacing(1),
     },
-    container: {
-      padding: '1rem',
-    },
-    dialogTitle: {},
-    closeButton: {
-      position: 'absolute',
-      right: theme.spacing(1),
-      top: theme.spacing(1),
-      color: theme.palette.grey[500],
-    },
-    radioGroup: {
-      gap: theme.spacing(3),
-    },
-  }),
-);
+    paddingRight: '1rem',
+  },
+
+  [`& .${classes.container}`]: {
+    padding: '1rem',
+  },
+
+  [`& .${classes.dialogTitle}`]: {},
+
+  [`& .${classes.closeButton}`]: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+
+  [`& .${classes.radioGroup}`]: {
+    gap: theme.spacing(3),
+  },
+}));
 
 const issueTags = [
   'Slow Loading',
@@ -70,255 +80,250 @@ const issueTags = [
 ];
 const feedbackTags = ['Excellent', 'Good', 'Needs Improvement', 'Other'];
 
-export const CreateFeedbackModal = React.forwardRef(
-  (
-    props: {
-      projectEntity: string;
-      userEntity: string;
-      serverType: string;
-      handleModalCloseFn: (respObj?: any) => void;
-    },
-    ref,
-  ) => {
-    const classes = useStyles();
-    const api = useApi(feedbackApiRef);
-    const analytics = useAnalytics();
-    const [feedbackType, setFeedbackType] = useState('BUG');
-    const [selectedTag, setSelectedTag] = useState(issueTags[0]);
-    const app = useApi(configApiRef);
-    const summaryLimit = app.getOptionalNumber('feedback.summaryLimit') ?? 240;
+export const CreateFeedbackModal = (props: {
+  projectEntity: string;
+  userEntity: string;
+  serverType: string;
+  handleModalCloseFn: (respObj?: any) => void;
+}) => {
+  const api = useApi(feedbackApiRef);
+  const analytics = useAnalytics();
+  const [feedbackType, setFeedbackType] = useState('BUG');
+  const [selectedTag, setSelectedTag] = useState(issueTags[0]);
+  const app = useApi(configApiRef);
+  const summaryLimit = app.getOptionalNumber('feedback.summaryLimit') ?? 240;
 
-    const [summary, setSummary] = useState({
-      value: '',
-      error: false,
-      errorMessage: 'Enter some summary',
+  const [summary, setSummary] = useState({
+    value: '',
+    error: false,
+    errorMessage: 'Enter some summary',
+  });
+  const [description, setDescription] = useState({
+    value: '',
+    error: false,
+    errorMessage: 'Enter some description',
+  });
+
+  const projectEntity = props.projectEntity;
+  const userEntity = props.userEntity;
+
+  function handleCategoryClick(event: any) {
+    setFeedbackType(event.target.value);
+    setSelectedTag(
+      event.target.value === 'FEEDBACK' ? feedbackTags[0] : issueTags[0],
+    );
+  }
+
+  function handleChipSlection(tag: string) {
+    if (tag === selectedTag) {
+      return;
+    }
+    setSelectedTag(tag);
+  }
+
+  async function handleSubmitClick() {
+    const resp = await api.createFeedback({
+      summary: summary.value,
+      description: description.value,
+      projectId: projectEntity,
+      url: window.location.href,
+      userAgent: navigator.userAgent,
+      createdBy: userEntity,
+      feedbackType:
+        feedbackType === 'BUG'
+          ? FeedbackCategory.BUG
+          : FeedbackCategory.FEEDBACK,
+      tag: selectedTag,
     });
-    const [description, setDescription] = useState({
-      value: '',
-      error: false,
-      errorMessage: 'Enter some description',
-    });
+    props.handleModalCloseFn(resp);
+    analytics.captureEvent('click', `submit - ${summary.value}`);
+  }
 
-    const projectEntity = props.projectEntity;
-    const userEntity = props.userEntity;
-
-    function handleCategoryClick(event: any) {
-      setFeedbackType(event.target.value);
-      setSelectedTag(
-        event.target.value === 'FEEDBACK' ? feedbackTags[0] : issueTags[0],
-      );
-    }
-
-    function handleChipSlection(tag: string) {
-      if (tag === selectedTag) {
-        return;
-      }
-      setSelectedTag(tag);
-    }
-
-    async function handleSubmitClick() {
-      const resp = await api.createFeedback({
-        summary: summary.value,
-        description: description.value,
-        projectId: projectEntity,
-        url: window.location.href,
-        userAgent: navigator.userAgent,
-        createdBy: userEntity,
-        feedbackType:
-          feedbackType === 'BUG'
-            ? FeedbackCategory.BUG
-            : FeedbackCategory.FEEDBACK,
-        tag: selectedTag,
-      });
-      props.handleModalCloseFn(resp);
-      analytics.captureEvent('click', `submit - ${summary.value}`);
-    }
-
-    function handleInputChange(
-      event: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>,
-    ) {
-      if (event.target.id === 'summary') {
-        const _summary = event.target.value;
-        if (_summary.trim().length === 0) {
-          return setSummary({
-            ...summary,
-            value: '',
-            errorMessage: 'Provide summary',
-            error: true,
-          });
-        } else if (_summary.length > summaryLimit) {
-          return setSummary({
-            ...summary,
-            value: _summary,
-            error: true,
-            errorMessage: `Summary should be less than ${summaryLimit} characters.`,
-          });
-        }
-        return setSummary({ ...summary, value: _summary, error: false });
-      }
-      if (event.target.id === 'description') {
-        return setDescription({
-          ...description,
-          value: event.target.value,
-          error: false,
-        });
-      }
-      return 0;
-    }
-
-    function handleValidation(
-      event: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>,
-    ) {
-      if (event.target.id === 'summary') {
-        if (event.target.value.length === 0) {
-          return setSummary({ ...summary, error: true });
-        }
+  function handleInputChange(
+    event: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>,
+  ) {
+    if (event.target.id === 'summary') {
+      const _summary = event.target.value;
+      if (_summary.trim().length === 0) {
         return setSummary({
           ...summary,
-          value: event.target.value.trim(),
-          error: event.target.value.trim().length > summaryLimit,
+          value: '',
+          errorMessage: 'Provide summary',
+          error: true,
+        });
+      } else if (_summary.length > summaryLimit) {
+        return setSummary({
+          ...summary,
+          value: _summary,
+          error: true,
+          errorMessage: `Summary should be less than ${summaryLimit} characters.`,
         });
       }
-      if (event.target.id === 'description' && event.target.value.length > 0) {
-        setDescription({ ...description, value: description.value.trim() });
-      }
-      return 0;
+      return setSummary({ ...summary, value: _summary, error: false });
     }
+    if (event.target.id === 'description') {
+      return setDescription({
+        ...description,
+        value: event.target.value,
+        error: false,
+      });
+    }
+    return 0;
+  }
 
-    return (
-      <Paper innerRef={ref}>
-        <DialogTitle>
-          {`Feedback for ${projectEntity.split('/').pop()}`}
-          {props.handleModalCloseFn ? (
-            <IconButton
-              aria-label="close"
-              className={classes.closeButton}
-              onClick={props.handleModalCloseFn}
-            >
-              <CloseRounded />
-            </IconButton>
-          ) : null}
-        </DialogTitle>
-        <DialogContent dividers>
-          <Grid container justifyContent="flex-start" className={classes.root}>
-            <Grid item xs={4}>
-              <Typography variant="h6">Select type</Typography>
-              <RadioGroup className={classes.radioGroup} row>
-                <FormControlLabel
-                  value="BUG"
-                  checked={feedbackType === 'BUG'}
-                  onChange={handleCategoryClick}
-                  label="Bug"
-                  control={
-                    <Radio
-                      icon={<BugReportOutlined />}
-                      checkedIcon={<BugReportTwoToneIcon />}
-                      color="secondary"
-                    />
-                  }
-                />
-                <FormControlLabel
-                  value="FEEDBACK"
-                  onChange={handleCategoryClick}
-                  label="Feedback"
-                  control={
-                    <Radio
-                      icon={<SmsOutlined />}
-                      checkedIcon={<SmsTwoTone />}
-                      color="primary"
-                    />
-                  }
-                />
-              </RadioGroup>
-            </Grid>
-            <Grid item xs={12}>
-              <Typography variant="subtitle1">
-                Select {feedbackType === 'FEEDBACK' ? 'Feedback' : 'Bug'}
-                :&nbsp;
-                {feedbackType === 'BUG'
-                  ? issueTags.map(issueTitle => (
-                      <Chip
-                        key={issueTitle.toLowerCase()}
-                        clickable
-                        variant={
-                          selectedTag === issueTitle ? 'default' : 'outlined'
-                        }
-                        color="secondary"
-                        onClick={() => handleChipSlection(issueTitle)}
-                        label={issueTitle}
-                      />
-                    ))
-                  : feedbackTags.map(feedbackTitle => (
-                      <Chip
-                        key={feedbackTitle.toLowerCase()}
-                        clickable
-                        variant={
-                          selectedTag === feedbackTitle ? 'default' : 'outlined'
-                        }
-                        color="primary"
-                        onClick={() => handleChipSlection(feedbackTitle)}
-                        label={feedbackTitle}
-                      />
-                    ))}
-              </Typography>
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                autoComplete="off"
-                id="summary"
-                label="Summary"
-                value={summary.value}
-                variant="outlined"
-                placeholder="Enter Summary"
-                onChange={handleInputChange}
-                onBlur={handleValidation}
-                error={summary.error}
-                helperText={
-                  summary.error
-                    ? summary.errorMessage
-                    : `${summary.value.length}/${summaryLimit}`
-                }
-                required
-              />
-            </Grid>
+  function handleValidation(
+    event: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>,
+  ) {
+    if (event.target.id === 'summary') {
+      if (event.target.value.length === 0) {
+        return setSummary({ ...summary, error: true });
+      }
+      return setSummary({
+        ...summary,
+        value: event.target.value.trim(),
+        error: event.target.value.trim().length > summaryLimit,
+      });
+    }
+    if (event.target.id === 'description' && event.target.value.length > 0) {
+      setDescription({ ...description, value: description.value.trim() });
+    }
+    return 0;
+  }
 
-            <Grid item xs={12}>
-              <TextField
-                inputMode="text"
-                autoComplete="off"
-                id="description"
-                label="Description"
-                value={description.value}
-                variant="outlined"
-                placeholder="Enter description"
-                multiline
-                minRows={6}
-                maxRows={10}
-                onChange={handleInputChange}
-              />
-            </Grid>
-          </Grid>
-        </DialogContent>
-        <DialogActions className={classes.actions}>
-          <Button onClick={props.handleModalCloseFn}>Cancel</Button>
-          <Button
-            onClick={handleSubmitClick}
-            color={feedbackType === 'FEEDBACK' ? 'primary' : 'secondary'}
-            variant="contained"
-            disabled={summary.error || summary.value.length === 0}
+  return (
+    <StyledPaper>
+      <DialogTitle>
+        {`Feedback for ${projectEntity.split('/').pop()}`}
+        {props.handleModalCloseFn ? (
+          <IconButton
+            aria-label="close"
+            className={classes.closeButton}
+            onClick={props.handleModalCloseFn}
+            size="large"
           >
-            {feedbackType === 'FEEDBACK' ? 'Send Feedback' : 'Report Bug'}
-          </Button>
-        </DialogActions>
-        {props.serverType.toLowerCase() !== 'mail' &&
-        !selectedTag.match(/(Excellent|Good)/g) ? (
-          <Alert severity="warning" variant="outlined">
-            Note: By submitting&nbsp;
-            {feedbackType === 'FEEDBACK' ? 'feedback' : 'bug'} with this tag, it
-            will create an issue in {props.serverType.toLowerCase()}
-          </Alert>
+            <CloseRounded />
+          </IconButton>
         ) : null}
-      </Paper>
-    );
-  },
-);
+      </DialogTitle>
+      <DialogContent dividers>
+        <Grid container justifyContent="flex-start" className={classes.root}>
+          <Grid item xs={4}>
+            <Typography variant="h6">Select type</Typography>
+            <RadioGroup className={classes.radioGroup} row>
+              <FormControlLabel
+                value="BUG"
+                checked={feedbackType === 'BUG'}
+                onChange={handleCategoryClick}
+                label="Bug"
+                control={
+                  <Radio
+                    icon={<BugReportOutlined />}
+                    checkedIcon={<BugReportTwoToneIcon />}
+                    color="secondary"
+                  />
+                }
+              />
+              <FormControlLabel
+                value="FEEDBACK"
+                onChange={handleCategoryClick}
+                label="Feedback"
+                control={
+                  <Radio
+                    icon={<SmsOutlined />}
+                    checkedIcon={<SmsTwoTone />}
+                    color="primary"
+                  />
+                }
+              />
+            </RadioGroup>
+          </Grid>
+          <Grid item xs={12}>
+            <Typography variant="subtitle1">
+              Select {feedbackType === 'FEEDBACK' ? 'Feedback' : 'Bug'}
+              :&nbsp;
+              {feedbackType === 'BUG'
+                ? issueTags.map(issueTitle => (
+                    <Chip
+                      key={issueTitle.toLowerCase()}
+                      clickable
+                      variant={
+                        selectedTag === issueTitle ? 'filled' : 'outlined'
+                      }
+                      color="secondary"
+                      onClick={() => handleChipSlection(issueTitle)}
+                      label={issueTitle}
+                    />
+                  ))
+                : feedbackTags.map(feedbackTitle => (
+                    <Chip
+                      key={feedbackTitle.toLowerCase()}
+                      clickable
+                      variant={
+                        selectedTag === feedbackTitle ? 'filled' : 'outlined'
+                      }
+                      color="primary"
+                      onClick={() => handleChipSlection(feedbackTitle)}
+                      label={feedbackTitle}
+                    />
+                  ))}
+            </Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <TextField
+              autoComplete="off"
+              id="summary"
+              label="Summary"
+              value={summary.value}
+              variant="outlined"
+              placeholder="Enter Summary"
+              onChange={handleInputChange}
+              onBlur={handleValidation}
+              error={summary.error}
+              helperText={
+                summary.error
+                  ? summary.errorMessage
+                  : `${summary.value.length}/${summaryLimit}`
+              }
+              required
+            />
+          </Grid>
+
+          <Grid item xs={12}>
+            <TextField
+              inputMode="text"
+              autoComplete="off"
+              id="description"
+              label="Description"
+              value={description.value}
+              variant="outlined"
+              placeholder="Enter description"
+              multiline
+              minRows={6}
+              maxRows={10}
+              onChange={handleInputChange}
+            />
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions className={classes.actions}>
+        <Button onClick={props.handleModalCloseFn}>Cancel</Button>
+        <Button
+          onClick={handleSubmitClick}
+          color={feedbackType === 'FEEDBACK' ? 'primary' : 'secondary'}
+          variant="contained"
+          disabled={summary.error || summary.value.length === 0}
+        >
+          {feedbackType === 'FEEDBACK' ? 'Send Feedback' : 'Report Bug'}
+        </Button>
+      </DialogActions>
+      {props.serverType.toLowerCase() !== 'mail' &&
+      !selectedTag.match(/(Excellent|Good)/g) ? (
+        <Alert severity="warning" variant="outlined">
+          Note: By submitting&nbsp;
+          {feedbackType === 'FEEDBACK' ? 'feedback' : 'bug'} with this tag, it
+          will create an issue in {props.serverType.toLowerCase()}
+        </Alert>
+      ) : null}
+    </StyledPaper>
+  );
+};

--- a/plugins/feedback/src/components/EntityFeedbackPage/CustomEmptyState/CustomEmptyState.tsx
+++ b/plugins/feedback/src/components/EntityFeedbackPage/CustomEmptyState/CustomEmptyState.tsx
@@ -2,62 +2,71 @@ import React from 'react';
 
 import { CodeSnippet, EmptyState } from '@backstage/core-components';
 
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  createStyles,
-  makeStyles,
-  Theme,
-  Typography,
-} from '@material-ui/core';
-import ExpandMoreRounded from '@material-ui/icons/ExpandMoreRounded';
+import ExpandMoreRounded from '@mui/icons-material/ExpandMoreRounded';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import { styled, Theme } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    code: {
-      width: '100%',
-      borderRadius: 6,
-      margin: theme.spacing(0, 0),
-      background: theme.palette.background.paper,
-    },
-    accordionGroup: {
-      '& > *': {
-        marginTop: theme.spacing(2),
-        marginBottom: theme.spacing(1),
-        background: theme.palette.type === 'dark' ? '#333' : '#eee',
-      },
-    },
-    heading: {
-      width: '50%',
-      fontSize: '1.2rem',
-      fontWeight: 600,
-    },
-    subHeading: {
-      color: theme.palette.textSubtle,
-    },
-    embeddedVideo: {
-      top: '50%',
-      left: '50%',
-      zIndex: 2,
-      position: 'relative',
-      transform: 'translate(-50%, 15%)',
-      '& > iframe': {
-        [theme.breakpoints.up('sm')]: {
-          width: '100%',
-          height: '280px',
-        },
-        [theme.breakpoints.up('xl')]: {
-          width: '768px',
-          height: '482px',
-        },
+const PREFIX = 'CustomEmptyState';
 
-        border: '0',
-        borderRadius: theme.spacing(1),
-      },
+const classes = {
+  code: `${PREFIX}-code`,
+  accordionGroup: `${PREFIX}-accordionGroup`,
+  heading: `${PREFIX}-heading`,
+  subHeading: `${PREFIX}-subHeading`,
+  embeddedVideo: `${PREFIX}-embeddedVideo`,
+};
+
+// TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
+const Root = styled('div')(({ theme }: { theme: Theme }) => ({
+  [`& .${classes.code}`]: {
+    width: '100%',
+    borderRadius: 6,
+    margin: theme.spacing(0, 0),
+    background: theme.palette.background.paper,
+  },
+
+  [`& .${classes.accordionGroup}`]: {
+    '& > *': {
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(1),
+      background: theme.palette.mode === 'dark' ? '#333' : '#eee',
     },
-  }),
-);
+  },
+
+  [`& .${classes.heading}`]: {
+    width: '50%',
+    fontSize: '1.2rem',
+    fontWeight: 600,
+  },
+
+  [`& .${classes.subHeading}`]: {
+    color: '#9e9e9e',
+  },
+
+  [`& .${classes.embeddedVideo}`]: {
+    top: '50%',
+    left: '50%',
+    zIndex: 2,
+    position: 'relative',
+    transform: 'translate(-50%, 15%)',
+    '& > iframe': {
+      [theme.breakpoints.up('sm')]: {
+        width: '100%',
+        height: '280px',
+      },
+      [theme.breakpoints.up('xl')]: {
+        width: '768px',
+        height: '482px',
+      },
+
+      border: '0',
+      borderRadius: theme.spacing(1),
+    },
+  },
+}));
 
 const EMAIL_YAML = `metadata:
   annotations:    
@@ -86,7 +95,6 @@ const JIRA_YAML = `metadata:
     feedback/email-to: 'example@example.com';`;
 
 export const CustomEmptyState = (props: { [key: string]: string }) => {
-  const classes = useStyles();
   const [expanded, setExpanded] = React.useState<string | false>('jira');
 
   const handleChange =
@@ -106,7 +114,7 @@ export const CustomEmptyState = (props: { [key: string]: string }) => {
         </Typography>
       }
       action={
-        <>
+        <Root>
           <Typography variant="body1">
             Add the annotation to your component YAML as shown in the
             highlighted example below:
@@ -159,7 +167,7 @@ export const CustomEmptyState = (props: { [key: string]: string }) => {
               </AccordionDetails>
             </Accordion>
           </div>
-        </>
+        </Root>
       }
       missing="field"
     />

--- a/plugins/feedback/src/components/EntityFeedbackPage/EntityFeedbackPage.test.tsx
+++ b/plugins/feedback/src/components/EntityFeedbackPage/EntityFeedbackPage.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { ConfigReader } from '@backstage/config';
 import {
   BackstageUserIdentity,
   configApiRef,
@@ -11,7 +10,11 @@ import {
   EntityProvider,
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
-import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import {
+  MockConfigApi,
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/test-utils';
 
 import { FeedbackAPI, feedbackApiRef } from '../../api';
 import { mockEntity, mockFeedback } from '../../mocks';
@@ -41,7 +44,7 @@ describe('Entity Feedback Page', () => {
       }),
   };
 
-  const mockConfigApi = new ConfigReader({
+  const mockConfigApi = new MockConfigApi({
     feedback: { integrations: { jira: [{ host: 'https://jira-server-url' }] } },
   });
 
@@ -73,7 +76,9 @@ describe('Entity Feedback Page', () => {
   it('Should have buttons', async () => {
     const rendered = await render();
     expect(
-      rendered.getByRole('button', { name: 'Create' }),
+      rendered.getByRole('button', {
+        name: 'Give a feedback / Report a issue',
+      }),
     ).toBeInTheDocument();
     expect(
       rendered.getByRole('button', { name: 'Refresh' }),

--- a/plugins/feedback/src/components/EntityFeedbackPage/EntityFeedbackPage.tsx
+++ b/plugins/feedback/src/components/EntityFeedbackPage/EntityFeedbackPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { Progress } from '@backstage/core-components';
 import {
+  alertApiRef,
   configApiRef,
   identityApiRef,
   useAnalytics,
@@ -9,42 +10,41 @@ import {
 } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-import {
-  ButtonGroup,
-  CircularProgress,
-  createStyles,
-  Dialog,
-  makeStyles,
-  Snackbar,
-  Theme,
-  Tooltip,
-  Zoom,
-} from '@material-ui/core';
-import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
-import Add from '@material-ui/icons/Add';
-import ArrowForwardRounded from '@material-ui/icons/ArrowForwardRounded';
-import Sync from '@material-ui/icons/Sync';
-import { Alert } from '@material-ui/lab';
+import Add from '@mui/icons-material/Add';
+import ArrowForwardRounded from '@mui/icons-material/ArrowForwardRounded';
+import Sync from '@mui/icons-material/Sync';
+import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import Grid from '@mui/material/Grid';
+import { styled, Theme } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
+import Zoom from '@mui/material/Zoom';
 
 import { CreateFeedbackModal } from '../CreateFeedbackModal/CreateFeedbackModal';
 import { FeedbackDetailsModal } from '../FeedbackDetailsModal';
 import { FeedbackTable } from '../FeedbackTable';
 import { CustomEmptyState } from './CustomEmptyState';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    buttonGroup: {
-      textAlign: 'center',
-      whiteSpace: 'nowrap',
-      marginTop: theme.spacing(1),
-    },
-  }),
-);
+const PREFIX = 'EntityFeedbackPage';
+
+const classes = {
+  buttonGroup: `${PREFIX}-buttonGroup`,
+};
+
+const StyledGrid = styled(Grid)(({ theme }: { theme: Theme }) => ({
+  [`& .${classes.buttonGroup}`]: {
+    textAlign: 'center',
+    whiteSpace: 'nowrap',
+    marginTop: theme.spacing(1),
+  },
+}));
 
 export const EntityFeedbackPage = () => {
   const config = useApi(configApiRef);
-  const classes = useStyles();
+  const alertApi = useApi(alertApiRef);
+
   const { entity } = useEntity();
   const user = useApi(identityApiRef);
   const analytics = useAnalytics();
@@ -56,19 +56,11 @@ export const EntityFeedbackPage = () => {
   }>();
 
   const [modalOpen, setModalOpen] = useState(false);
-  const [snackbarOpen, setSnackbarOpen] = useState<{
-    message: string;
-    open: boolean;
-    severity: 'success' | 'error';
-  }>({
-    message: '',
-    open: false,
-    severity: 'success',
-  });
+
   const [reload, setReload] = useState(false);
   useEffect(() => {
     setReload(false);
-  }, [snackbarOpen, reload]);
+  }, [reload]);
 
   const projectEntity =
     `${entity.kind}:${entity.metadata.namespace}/${entity.metadata.name}`.toLowerCase();
@@ -102,30 +94,19 @@ export const EntityFeedbackPage = () => {
     if (respObj) {
       setReload(true);
       if (respObj.error) {
-        setSnackbarOpen({
+        alertApi.post({
           message: respObj.error,
           severity: 'error',
-          open: true,
+          display: 'transient',
         });
       } else if (respObj.message) {
-        setSnackbarOpen({
+        alertApi.post({
           message: respObj.message,
           severity: 'success',
-          open: true,
+          display: 'transient',
         });
       }
     }
-  };
-
-  const handleSnackbarClose = (
-    event?: React.SyntheticEvent,
-    reason?: string,
-  ) => {
-    event?.preventDefault();
-    if (reason === 'clickaway') {
-      return;
-    }
-    setSnackbarOpen({ ...snackbarOpen, open: false });
   };
 
   const handleResyncClick = () => {
@@ -133,10 +114,10 @@ export const EntityFeedbackPage = () => {
     setReload(true);
   };
 
-  return pluginConfig.feedbackEmailTo === undefined ? (
+  return pluginConfig.feedbackType === undefined ? (
     <CustomEmptyState {...pluginConfig} />
   ) : (
-    <Grid container justifyContent="flex-end">
+    <StyledGrid container justifyContent="flex-end">
       <FeedbackDetailsModal />
       <Grid item>
         <ButtonGroup
@@ -192,15 +173,6 @@ export const EntityFeedbackPage = () => {
       <Grid item xs={12}>
         {reload ? <Progress /> : <FeedbackTable projectId={projectEntity} />}
       </Grid>
-      <Snackbar
-        open={snackbarOpen?.open}
-        autoHideDuration={6000}
-        onClose={handleSnackbarClose}
-      >
-        <Alert severity={snackbarOpen.severity} onClose={handleSnackbarClose}>
-          {snackbarOpen?.message}
-        </Alert>
-      </Snackbar>
-    </Grid>
+    </StyledGrid>
   );
 };

--- a/plugins/feedback/src/components/FeedbackTable/FeedbackTable.tsx
+++ b/plugins/feedback/src/components/FeedbackTable/FeedbackTable.tsx
@@ -14,29 +14,32 @@ import {
   EntityRefLink,
 } from '@backstage/plugin-catalog-react';
 
-import {
-  Box,
-  Chip,
-  IconButton,
-  Link,
-  makeStyles,
-  Paper,
-  TableContainer,
-  TextField,
-  Theme,
-  Tooltip,
-  Typography,
-} from '@material-ui/core';
-import BugReportOutlined from '@material-ui/icons/BugReportOutlined';
-import Clear from '@material-ui/icons/Clear';
-import Search from '@material-ui/icons/Search';
-import TextsmsOutlined from '@material-ui/icons/TextsmsOutlined';
+import BugReportOutlined from '@mui/icons-material/BugReportOutlined';
+import Clear from '@mui/icons-material/Clear';
+import Search from '@mui/icons-material/Search';
+import TextsmsOutlined from '@mui/icons-material/TextsmsOutlined';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
+import Link from '@mui/material/Link';
+import Paper from '@mui/material/Paper';
+import { styled, Theme } from '@mui/material/styles';
+import TableContainer from '@mui/material/TableContainer';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 
 import { feedbackApiRef } from '../../api';
 import { FeedbackType } from '../../models/feedback.model';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  textField: {
+const PREFIX = 'FeedbackTable';
+
+const classes = {
+  textField: `${PREFIX}-textField`,
+};
+
+const StyledPaper = styled(Paper)(({ theme }: { theme: Theme }) => ({
+  [`& .${classes.textField}`]: {
     padding: 0,
     margin: theme.spacing(2),
     width: '70%',
@@ -46,9 +49,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export const FeedbackTable: React.FC<{ projectId?: string }> = (props: {
-  projectId?: string;
-}) => {
+export const FeedbackTable = (props: { projectId?: string }) => {
   const projectId = props.projectId ? props.projectId : 'all';
   const api = useApi(feedbackApiRef);
   const analytics = useAnalytics();
@@ -61,7 +62,6 @@ export const FeedbackTable: React.FC<{ projectId?: string }> = (props: {
   const [queryState, setQueryState] = useQueryParamState<string>('id');
   const [loading, setLoading] = useState(true);
   const [searchText, setSearchText] = useState<string>('');
-  const classes = useStyles();
 
   const columns: TableColumn[] = [
     {
@@ -248,7 +248,7 @@ export const FeedbackTable: React.FC<{ projectId?: string }> = (props: {
   }
 
   return (
-    <Paper>
+    <StyledPaper>
       <TextField
         onChange={handleSearch}
         variant="outlined"
@@ -263,7 +263,7 @@ export const FeedbackTable: React.FC<{ projectId?: string }> = (props: {
           ),
           endAdornment: (
             <Tooltip title="Clear search" arrow>
-              <IconButton onClick={() => setSearchText('')}>
+              <IconButton onClick={() => setSearchText('')} size="medium">
                 <Clear />
               </IconButton>
             </Tooltip>
@@ -293,6 +293,6 @@ export const FeedbackTable: React.FC<{ projectId?: string }> = (props: {
           page={tableConfig.page - 1}
         />
       </TableContainer>
-    </Paper>
+    </StyledPaper>
   );
 };

--- a/plugins/feedback/src/components/GlobalFeedbackPage/GlobalFeedbackPage.tsx
+++ b/plugins/feedback/src/components/GlobalFeedbackPage/GlobalFeedbackPage.tsx
@@ -3,16 +3,16 @@ import React from 'react';
 import { Content, Header, Page } from '@backstage/core-components';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
-import { Grid } from '@material-ui/core';
+import Grid from '@mui/material/Grid';
 
 import { FeedbackDetailsModal } from '../FeedbackDetailsModal';
 import { FeedbackTable } from '../FeedbackTable';
 
-export const GlobalFeedbackPage = () => {
+export const GlobalFeedbackPage = (props: { themeId?: string }) => {
   const app = useApi(configApiRef);
   const appTitle = app.getString('app.title');
   return (
-    <Page themeId="tool">
+    <Page themeId={props.themeId ? props.themeId : 'tool'}>
       <Header title="Feedback" subtitle={`on ${appTitle}`} />
       <Content>
         <FeedbackDetailsModal />

--- a/plugins/feedback/src/index.ts
+++ b/plugins/feedback/src/index.ts
@@ -1,4 +1,4 @@
-export { default as FeedbackIcon } from '@material-ui/icons/TextsmsOutlined';
+export { default as FeedbackIcon } from '@mui/icons-material/TextsmsOutlined';
 export {
   feedbackPlugin,
   GlobalFeedbackPage,

--- a/plugins/matomo-backend/README.md
+++ b/plugins/matomo-backend/README.md
@@ -74,5 +74,9 @@ Add the following configurations into your `app-config.yaml` file:
 ```yaml
 matomo:
   apiToken: ${MATOMO_API_TOKEN}
+
   apiUrl: ${MATOMO_API_URL}
+
+  # (OPTIONAL) Set to false if you get SSL certificate error
+  secure: ${MATOMO_SECURE_FLAG}
 ```

--- a/plugins/matomo-backend/app-config.janus-idp.yaml
+++ b/plugins/matomo-backend/app-config.janus-idp.yaml
@@ -1,3 +1,5 @@
 matomo:
   apiToken: ${MATOMO_API_TOKEN}
   apiUrl: ${MATOMO_API_URL}
+  # Set to false if you get SSL certificate error
+  secure: ${MATOMO_SECURE_FLAG}

--- a/plugins/matomo-backend/config.d.ts
+++ b/plugins/matomo-backend/config.d.ts
@@ -8,5 +8,10 @@ export interface Config {
      * @visibility backend
      */
     apiUrl: string;
+    /**
+     * Set to false if you get SSL certificate error
+     * @visibility backend
+     */
+    secure: boolean;
   };
 }

--- a/plugins/matomo-backend/src/plugin.ts
+++ b/plugins/matomo-backend/src/plugin.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { loggerToWinstonLogger } from '@backstage/backend-common';
 import {
   coreServices,
   createBackendPlugin,
@@ -32,9 +31,8 @@ export const matomoBackendPlugin = createBackendPlugin({
         config: coreServices.rootConfig,
       },
       async init({ http, logger, config }) {
-        const winstonLogger = loggerToWinstonLogger(logger);
+        logger.info('Matomo plugin is running');
         const router = await createRouter({
-          logger: winstonLogger,
           config,
         });
         http.use(router);

--- a/plugins/matomo-backend/src/service/standaloneServer.ts
+++ b/plugins/matomo-backend/src/service/standaloneServer.ts
@@ -23,7 +23,6 @@ export async function startStandaloneServer(
 
   logger.debug('Starting application server...');
   const router = await createRouter({
-    logger,
     config,
   });
 

--- a/plugins/matomo/README.md
+++ b/plugins/matomo/README.md
@@ -9,7 +9,7 @@ The matomo plugin shows the basic analytics from [Matomo](https://matomo.org/)
 1. Install the plugin
 
 ```bash
-yarn add @janus-idp/plugin-matomo
+yarn workspace app add @janus-idp/backstage-plugin-matomo
 ```
 
 2. Make sure the [Matomo backend plugin](../matomo-backend/README.md) is installed and configured

--- a/plugins/matomo/package.json
+++ b/plugins/matomo/package.json
@@ -34,6 +34,8 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.45",
+    "@mui/icons-material": "^5.15.18",
+    "@mui/material": "^5.15.18",
     "@tanstack/react-query": "^4.36.1",
     "axios": "^1.6.0",
     "react-use": "^17.4.0",

--- a/plugins/matomo/src/api/index.ts
+++ b/plugins/matomo/src/api/index.ts
@@ -1,4 +1,4 @@
-import { ConfigApi, createApiRef } from '@backstage/core-plugin-api';
+import { ConfigApi, createApiRef, FetchApi } from '@backstage/core-plugin-api';
 
 import {
   TActionByPageURLMetrics,
@@ -47,6 +47,7 @@ export type MatomoAPI = {
 
 type Options = {
   configApi: ConfigApi;
+  fetchApi: FetchApi;
 };
 
 export const matomoApiRef = createApiRef<MatomoAPI>({
@@ -75,9 +76,11 @@ export const transformVisitByTime = (
 
 export class MatomoApiClient implements MatomoAPI {
   private readonly configApi: ConfigApi;
+  private readonly fetchApi: FetchApi;
 
   constructor(options: Options) {
     this.configApi = options.configApi;
+    this.fetchApi = options.fetchApi;
   }
 
   async getUserVisitMetrics(
@@ -86,20 +89,23 @@ export class MatomoApiClient implements MatomoAPI {
     date: string,
   ): Promise<TUserVisitMetrics> {
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const res = await fetch(`${backendUrl}/api/matomo?module=API&format=json`, {
-      method: 'POST',
-      body: new URLSearchParams({
-        idSite,
-        method: 'API.getProcessedReport',
-        period,
-        date,
-        apiModule: 'VisitsSummary',
-        apiAction: 'get',
-      }).toString(),
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    const res = await this.fetchApi.fetch(
+      `${backendUrl}/api/matomo?module=API&format=json`,
+      {
+        method: 'POST',
+        body: new URLSearchParams({
+          idSite,
+          method: 'API.getProcessedReport',
+          period,
+          date,
+          apiModule: 'VisitsSummary',
+          apiAction: 'get',
+        }).toString(),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        },
       },
-    });
+    );
     return res.json();
   }
 
@@ -109,20 +115,23 @@ export class MatomoApiClient implements MatomoAPI {
     date: string,
   ): Promise<TGeoMetrics> {
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const res = await fetch(`${backendUrl}/api/matomo?module=API&format=json`, {
-      method: 'POST',
-      body: new URLSearchParams({
-        idSite,
-        method: 'API.getProcessedReport',
-        period,
-        date,
-        apiModule: 'UserCountry',
-        apiAction: 'getCountry',
-      }).toString(),
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    const res = await this.fetchApi.fetch(
+      `${backendUrl}/api/matomo?module=API&format=json`,
+      {
+        method: 'POST',
+        body: new URLSearchParams({
+          idSite,
+          method: 'API.getProcessedReport',
+          period,
+          date,
+          apiModule: 'UserCountry',
+          apiAction: 'getCountry',
+        }).toString(),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        },
       },
-    });
+    );
     return res.json();
   }
 
@@ -132,20 +141,23 @@ export class MatomoApiClient implements MatomoAPI {
     date: string,
   ): Promise<TDeviceMetrics> {
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const res = await fetch(`${backendUrl}/api/matomo?module=API&format=json`, {
-      method: 'POST',
-      body: new URLSearchParams({
-        idSite,
-        method: 'API.getProcessedReport',
-        period,
-        date,
-        apiModule: 'DevicesDetection',
-        apiAction: 'getType',
-      }).toString(),
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    const res = await this.fetchApi.fetch(
+      `${backendUrl}/api/matomo?module=API&format=json`,
+      {
+        method: 'POST',
+        body: new URLSearchParams({
+          idSite,
+          method: 'API.getProcessedReport',
+          period,
+          date,
+          apiModule: 'DevicesDetection',
+          apiAction: 'getType',
+        }).toString(),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        },
       },
-    });
+    );
     return res.json();
   }
 
@@ -161,20 +173,23 @@ export class MatomoApiClient implements MatomoAPI {
     >
   > {
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const res = await fetch(`${backendUrl}/api/matomo?module=API&format=json`, {
-      method: 'POST',
-      body: new URLSearchParams({
-        idSite,
-        method: 'API.getProcessedReport',
-        period,
-        date,
-        apiModule: 'Actions',
-        apiAction: 'getPageUrls',
-      }).toString(),
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    const res = await this.fetchApi.fetch(
+      `${backendUrl}/api/matomo?module=API&format=json`,
+      {
+        method: 'POST',
+        body: new URLSearchParams({
+          idSite,
+          method: 'API.getProcessedReport',
+          period,
+          date,
+          apiModule: 'Actions',
+          apiAction: 'getPageUrls',
+        }).toString(),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        },
       },
-    });
+    );
     const data = (await res.json()) as TActionByPageURLMetrics;
     return data.reportData.map(({ bounce_rate, avg_time_on_page, ...el }) => {
       const avgTimeStr = avg_time_on_page.split(':');
@@ -197,20 +212,23 @@ export class MatomoApiClient implements MatomoAPI {
     date: string,
   ): Promise<Metric[]> {
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const res = await fetch(`${backendUrl}/api/matomo?module=API&format=json`, {
-      method: 'POST',
-      body: new URLSearchParams({
-        idSite,
-        method: 'API.getProcessedReport',
-        period,
-        date,
-        apiModule: 'Actions',
-        apiAction: 'get',
-      }).toString(),
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    const res = await this.fetchApi.fetch(
+      `${backendUrl}/api/matomo?module=API&format=json`,
+      {
+        method: 'POST',
+        body: new URLSearchParams({
+          idSite,
+          method: 'API.getProcessedReport',
+          period,
+          date,
+          apiModule: 'Actions',
+          apiAction: 'get',
+        }).toString(),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        },
       },
-    });
+    );
     const { reportData, columns } = (await res.json()) as TActionMetrics;
     return Object.keys(columns).map(metric => ({
       metric: columns[metric as keyof TActionMetrics['reportData']],

--- a/plugins/matomo/src/components/MatomoPage/MatomoPage.tsx
+++ b/plugins/matomo/src/components/MatomoPage/MatomoPage.tsx
@@ -12,21 +12,19 @@ import {
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-import {
-  Box,
-  Card,
-  CardContent,
-  CircularProgress,
-  FormControl,
-  Grid,
-  InputLabel,
-  MenuItem,
-  Tooltip as MuiTooltip,
-  Select,
-  Typography,
-} from '@material-ui/core';
-import Assessment from '@material-ui/icons/Assessment';
-import ContactMail from '@material-ui/icons/ContactMail';
+import Assessment from '@mui/icons-material/Assessment';
+import ContactMail from '@mui/icons-material/ContactMail';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CircularProgress from '@mui/material/CircularProgress';
+import FormControl from '@mui/material/FormControl';
+import Grid from '@mui/material/Grid';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import MuiTooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   CartesianGrid,

--- a/plugins/matomo/src/components/MatomoPage/StatsCard.tsx
+++ b/plugins/matomo/src/components/MatomoPage/StatsCard.tsx
@@ -1,11 +1,9 @@
 import React, { ReactNode } from 'react';
 
-import {
-  Card,
-  CardContent,
-  CircularProgress,
-  Typography,
-} from '@material-ui/core';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
 
 type Props = {
   title: string;

--- a/plugins/matomo/src/plugin.ts
+++ b/plugins/matomo/src/plugin.ts
@@ -3,6 +3,7 @@ import {
   createApiFactory,
   createPlugin,
   createRoutableExtension,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 
 import { MatomoApiClient, matomoApiRef } from './api';
@@ -18,8 +19,10 @@ export const matomoPlugin = createPlugin({
       api: matomoApiRef,
       deps: {
         configApi: configApiRef,
+        fetchApi: fetchApiRef,
       },
-      factory: ({ configApi }) => new MatomoApiClient({ configApi }),
+      factory: ({ configApi, fetchApi }) =>
+        new MatomoApiClient({ configApi, fetchApi }),
     }),
   ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,6 +2363,49 @@
     winston "^3.2.1"
     winston-transport "^4.5.0"
 
+"@backstage/backend-app-api@^0.7.3":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-app-api/-/backend-app-api-0.7.5.tgz#b3a52da8924825f8b132e4b7380e421762e08377"
+  integrity sha512-Ggo8IVdfcEPWrsw92UNZ3rYyIAL+5KReszKO2P2P7+qGV2aZLNdl772RG2+NgIRaUW66sxr0qSQzyFKsyXYHlg==
+  dependencies:
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/backend-tasks" "^0.5.23"
+    "@backstage/cli-common" "^0.1.13"
+    "@backstage/cli-node" "^0.2.5"
+    "@backstage/config" "^1.2.0"
+    "@backstage/config-loader" "^1.8.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/plugin-auth-node" "^0.4.13"
+    "@backstage/plugin-permission-node" "^0.7.29"
+    "@backstage/types" "^1.1.1"
+    "@manypkg/get-packages" "^1.1.3"
+    "@types/cors" "^2.8.6"
+    "@types/express" "^4.17.6"
+    compression "^1.7.4"
+    cookie "^0.6.0"
+    cors "^2.8.5"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    fs-extra "^11.2.0"
+    helmet "^6.0.0"
+    jose "^5.0.0"
+    knex "^3.0.0"
+    lodash "^4.17.21"
+    logform "^2.3.2"
+    luxon "^3.0.0"
+    minimatch "^9.0.0"
+    minimist "^1.2.5"
+    morgan "^1.10.0"
+    node-forge "^1.3.1"
+    path-to-regexp "^6.2.1"
+    selfsigned "^2.0.0"
+    stoppable "^1.1.0"
+    triple-beam "^1.4.1"
+    uuid "^9.0.0"
+    winston "^3.2.1"
+    winston-transport "^4.5.0"
+
 "@backstage/backend-common@0.21.7", "@backstage/backend-common@^0.21.6", "@backstage/backend-common@^0.21.7":
   version "0.21.7"
   resolved "https://registry.yarnpkg.com/@backstage/backend-common/-/backend-common-0.21.7.tgz#5ae796d8adccebc484edeeb2326464c28e14849e"
@@ -2426,6 +2469,69 @@
     yauzl "^3.0.0"
     yn "^4.0.0"
 
+"@backstage/backend-common@^0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-common/-/backend-common-0.22.0.tgz#d57a0eff218dc7cd8e227b989eaa13834040d322"
+  integrity sha512-puremJU59ILyWOSnmm8FegnlxZyu7sKaYjWCop2HmoMuFeEdYxJhPysZOQf1G7N3JootJXGEn6HB/EXy8kAipA==
+  dependencies:
+    "@aws-sdk/abort-controller" "^3.347.0"
+    "@aws-sdk/client-codecommit" "^3.350.0"
+    "@aws-sdk/client-s3" "^3.350.0"
+    "@aws-sdk/credential-providers" "^3.350.0"
+    "@aws-sdk/types" "^3.347.0"
+    "@backstage/backend-app-api" "^0.7.3"
+    "@backstage/backend-dev-utils" "^0.1.4"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/cli-common" "^0.1.13"
+    "@backstage/config" "^1.2.0"
+    "@backstage/config-loader" "^1.8.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/integration" "^1.11.0"
+    "@backstage/integration-aws-node" "^0.1.12"
+    "@backstage/plugin-auth-node" "^0.4.13"
+    "@backstage/types" "^1.1.1"
+    "@google-cloud/storage" "^7.0.0"
+    "@keyv/memcache" "^1.3.5"
+    "@keyv/redis" "^2.5.3"
+    "@kubernetes/client-node" "0.20.0"
+    "@manypkg/get-packages" "^1.1.3"
+    "@octokit/rest" "^19.0.3"
+    "@types/cors" "^2.8.6"
+    "@types/dockerode" "^3.3.0"
+    "@types/express" "^4.17.6"
+    "@types/luxon" "^3.0.0"
+    "@types/webpack-env" "^1.15.2"
+    archiver "^6.0.0"
+    base64-stream "^1.0.0"
+    compression "^1.7.4"
+    concat-stream "^2.0.0"
+    cors "^2.8.5"
+    dockerode "^4.0.0"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    fs-extra "^11.2.0"
+    git-url-parse "^14.0.0"
+    helmet "^6.0.0"
+    isomorphic-git "^1.23.0"
+    jose "^5.0.0"
+    keyv "^4.5.2"
+    knex "^3.0.0"
+    lodash "^4.17.21"
+    logform "^2.3.2"
+    luxon "^3.0.0"
+    minimatch "^9.0.0"
+    mysql2 "^3.0.0"
+    node-fetch "^2.6.7"
+    p-limit "^3.1.0"
+    pg "^8.11.3"
+    raw-body "^2.4.1"
+    tar "^6.1.12"
+    uuid "^9.0.0"
+    winston "^3.2.1"
+    winston-transport "^4.5.0"
+    yauzl "^3.0.0"
+    yn "^4.0.0"
+
 "@backstage/backend-defaults@^0.2.17":
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/@backstage/backend-defaults/-/backend-defaults-0.2.17.tgz#cbb2b7e0ac2c9b340513e38d762f7bc2d06e0ce0"
@@ -2438,6 +2544,39 @@
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@backstage/backend-dev-utils/-/backend-dev-utils-0.1.4.tgz#65d204939c49b5df6a2148e8ad4dc718ccd1df07"
   integrity sha512-5YgAPz4CRtnqdaUlYCHwGmXvpkGQ1jaUMoDtiQ81WDxQrf+0iYZCwS4ftVyQmB0Ga6BaGOUf6GG/OuFA56Y5mA==
+
+"@backstage/backend-dynamic-feature-service@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-dynamic-feature-service/-/backend-dynamic-feature-service-0.2.10.tgz#aef627570f82bc674dc5e8a91662f8db6cc5a1c9"
+  integrity sha512-VHMXpGDn6EflsFDedAV7Y+JOTagJknDeWcyBRtaVMRk812g2znZ5odW0u8vjckZy9/TVrSsfofjAYo36uevq4A==
+  dependencies:
+    "@backstage/backend-app-api" "^0.7.3"
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/backend-tasks" "^0.5.23"
+    "@backstage/cli-common" "^0.1.13"
+    "@backstage/cli-node" "^0.2.5"
+    "@backstage/config" "^1.2.0"
+    "@backstage/config-loader" "^1.8.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/plugin-app-node" "^0.1.18"
+    "@backstage/plugin-auth-node" "^0.4.13"
+    "@backstage/plugin-catalog-backend" "^1.22.0"
+    "@backstage/plugin-events-backend" "^0.3.5"
+    "@backstage/plugin-events-node" "^0.3.4"
+    "@backstage/plugin-permission-common" "^0.7.13"
+    "@backstage/plugin-permission-node" "^0.7.29"
+    "@backstage/plugin-scaffolder-node" "^0.4.4"
+    "@backstage/plugin-search-backend-node" "^1.2.22"
+    "@backstage/plugin-search-common" "^1.2.11"
+    "@backstage/types" "^1.1.1"
+    "@manypkg/get-packages" "^1.1.3"
+    "@types/express" "^4.17.6"
+    chokidar "^3.5.3"
+    express "^4.17.1"
+    fs-extra "^11.2.0"
+    lodash "^4.17.21"
+    winston "^3.2.1"
 
 "@backstage/backend-dynamic-feature-service@^0.2.8", "@backstage/backend-dynamic-feature-service@^0.2.9":
   version "0.2.9"
@@ -2489,6 +2628,23 @@
     openapi-merge "^1.3.2"
     openapi3-ts "^3.1.2"
 
+"@backstage/backend-openapi-utils@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-openapi-utils/-/backend-openapi-utils-0.1.11.tgz#1ac9ec6392d280d3d2420cda0f8dc27c4e595b4c"
+  integrity sha512-IHrfYYL7CtQOx4p/6vHMtoxvIdlt9b5npNh/7bzAfStYhBxmJ2kau/qqrJgQq6dBPPaQmRU4pLOp/q1HEIc6VQ==
+  dependencies:
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/errors" "^1.2.4"
+    "@types/express" "^4.17.6"
+    "@types/express-serve-static-core" "^4.17.5"
+    express "^4.17.1"
+    express-openapi-validator "^5.0.4"
+    express-promise-router "^4.1.0"
+    json-schema-to-ts "^3.0.0"
+    lodash "^4.17.21"
+    openapi-merge "^1.3.2"
+    openapi3-ts "^3.1.2"
+
 "@backstage/backend-plugin-api@0.6.17", "@backstage/backend-plugin-api@^0.6.16", "@backstage/backend-plugin-api@^0.6.17":
   version "0.6.17"
   resolved "https://registry.yarnpkg.com/@backstage/backend-plugin-api/-/backend-plugin-api-0.6.17.tgz#3d00b167cccb36e2341ae5cc4026352904938322"
@@ -2503,6 +2659,22 @@
     express "^4.17.1"
     knex "^3.0.0"
 
+"@backstage/backend-plugin-api@^0.6.18":
+  version "0.6.18"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-plugin-api/-/backend-plugin-api-0.6.18.tgz#0da77be39616ce4bb09c3fc55a3cdf9c973edba4"
+  integrity sha512-AAnLvQ8BBKEzFKenh+1sF9RaGNXLdxdNI9aCs6KpqOIQCZjWyRqXfFHO4SDY+iu/FSW5BzVlKWpe4irSk/wl3g==
+  dependencies:
+    "@backstage/backend-tasks" "^0.5.23"
+    "@backstage/cli-common" "^0.1.13"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/plugin-auth-node" "^0.4.13"
+    "@backstage/plugin-permission-common" "^0.7.13"
+    "@backstage/types" "^1.1.1"
+    "@types/express" "^4.17.6"
+    express "^4.17.1"
+    knex "^3.0.0"
+
 "@backstage/backend-tasks@^0.5.21", "@backstage/backend-tasks@^0.5.22":
   version "0.5.22"
   resolved "https://registry.yarnpkg.com/@backstage/backend-tasks/-/backend-tasks-0.5.22.tgz#67c464f5fdccdcc161e609154c671596b642c868"
@@ -2510,6 +2682,25 @@
   dependencies:
     "@backstage/backend-common" "^0.21.7"
     "@backstage/backend-plugin-api" "^0.6.17"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/types" "^1.1.1"
+    "@opentelemetry/api" "^1.3.0"
+    "@types/luxon" "^3.0.0"
+    cron "^3.0.0"
+    knex "^3.0.0"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+    uuid "^9.0.0"
+    zod "^3.22.4"
+
+"@backstage/backend-tasks@^0.5.23":
+  version "0.5.23"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-tasks/-/backend-tasks-0.5.23.tgz#85c14fff99189d0540d6bd5be4cc81faf0617620"
+  integrity sha512-nLdRG6RkzbpiDH0BQDmz8ZFebP4FNffDfxT9VX50+UJC2Q+0qJirqpbZKcQmHIYT66u7NNeJtsOJBSn/S23P6A==
+  dependencies:
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-plugin-api" "^0.6.18"
     "@backstage/config" "^1.2.0"
     "@backstage/errors" "^1.2.4"
     "@backstage/types" "^1.1.1"
@@ -2576,6 +2767,16 @@
   integrity sha512-sItchBGNqZBCXqTu/U+EZhimhiKdZBEJOQ28fFeFYGJ+wm8Kfz82d2KbwVPgK41aN20gftChN5ZXBkcyddiUFQ==
   dependencies:
     "@backstage/catalog-model" "^1.4.5"
+    "@backstage/errors" "^1.2.4"
+    cross-fetch "^4.0.0"
+    uri-template "^2.0.0"
+
+"@backstage/catalog-client@^1.6.5":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-1.6.5.tgz#f27c933abf8c7bf8bcbd090b4b550a7eb1957686"
+  integrity sha512-powm86JuibW0GtxtVYwO/xj3SjwV8AWMbL/D9C3Yl3mZ+4sp8lwXTTlKR+IdNHnFlDfwHiNH7LKT4BMgtTZbtA==
+  dependencies:
+    "@backstage/catalog-model" "^1.5.0"
     "@backstage/errors" "^1.2.4"
     cross-fetch "^4.0.0"
     uri-template "^2.0.0"
@@ -3057,6 +3258,21 @@
     lodash "^4.17.21"
     luxon "^3.0.0"
 
+"@backstage/integration@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@backstage/integration/-/integration-1.11.0.tgz#0a04b6d3e15569c1074b7f39a7a3a17eefd1b89b"
+  integrity sha512-RRci3a/uEmfYCCFxuw+8GgLPuWeCxt7iGOJYUZlyDEPfvUL+GSIdB2GQm4nzktRCUrNaJPd7QxaagmQgPCaIzg==
+  dependencies:
+    "@azure/identity" "^4.0.0"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@octokit/auth-app" "^4.0.0"
+    "@octokit/rest" "^19.0.3"
+    cross-fetch "^4.0.0"
+    git-url-parse "^14.0.0"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+
 "@backstage/plugin-api-docs@^0.11.4":
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-api-docs/-/plugin-api-docs-0.11.4.tgz#0d4d47f8ed9d4550a1f2b00b2e6ad0c57da85500"
@@ -3114,6 +3330,17 @@
   integrity sha512-uYE/p/gIilOP+BHU5gzyBxEsw24vpeA99NYvU3sqD9r7rRYOjrGIb51ynAYvpBWsooIOjEt0wiEOJVrfuac2vQ==
   dependencies:
     "@backstage/backend-plugin-api" "^0.6.17"
+    "@backstage/config-loader" "^1.8.0"
+    "@types/express" "^4.17.6"
+    express "^4.17.1"
+    fs-extra "^11.2.0"
+
+"@backstage/plugin-app-node@^0.1.18":
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-app-node/-/plugin-app-node-0.1.18.tgz#d3c79135432497acf434b0e6ed03dd504300f8de"
+  integrity sha512-v7Yk9/IykyVJChhio8wtGQaoEqOWaDX7sXBxkqP8+Z1Yy584TIaaJv4cofc1csJGZBzGWoZ//EVlWD7FfbwOog==
+  dependencies:
+    "@backstage/backend-plugin-api" "^0.6.18"
     "@backstage/config-loader" "^1.8.0"
     "@types/express" "^4.17.6"
     express "^4.17.1"
@@ -3377,6 +3604,29 @@
     zod "^3.22.4"
     zod-to-json-schema "^3.21.4"
 
+"@backstage/plugin-auth-node@^0.4.13":
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-node/-/plugin-auth-node-0.4.13.tgz#df54d69b0f6cbce91526937cfb21a7c732630787"
+  integrity sha512-i+41bNGQGY8JWFq/9GO08mylaAlSTn4vxiVpj3BYG1BZdtqpHT45MqpnVZ3s1i+/49gLoAo+PquLks9WNvmU0A==
+  dependencies:
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/catalog-client" "^1.6.5"
+    "@backstage/catalog-model" "^1.5.0"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/types" "^1.1.1"
+    "@types/express" "*"
+    "@types/passport" "^1.0.3"
+    express "^4.17.1"
+    jose "^5.0.0"
+    lodash "^4.17.21"
+    node-fetch "^2.6.7"
+    passport "^0.7.0"
+    winston "^3.2.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.21.4"
+
 "@backstage/plugin-auth-react@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-react/-/plugin-auth-react-0.1.1.tgz#8307b83c6d1958c2a0c790bed5d9d9c3f6598670"
@@ -3420,6 +3670,48 @@
     "@backstage/plugin-permission-common" "^0.7.13"
     "@backstage/plugin-permission-node" "^0.7.28"
     "@backstage/plugin-search-backend-module-catalog" "^0.1.22"
+    "@backstage/types" "^1.1.1"
+    "@opentelemetry/api" "^1.3.0"
+    "@types/express" "^4.17.6"
+    codeowners-utils "^1.0.2"
+    core-js "^3.6.5"
+    express "^4.17.1"
+    fast-json-stable-stringify "^2.1.0"
+    fs-extra "^11.2.0"
+    git-url-parse "^14.0.0"
+    glob "^7.1.6"
+    knex "^3.0.0"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+    minimatch "^9.0.0"
+    node-fetch "^2.6.7"
+    p-limit "^3.0.2"
+    prom-client "^15.0.0"
+    uuid "^9.0.0"
+    yaml "^2.0.0"
+    yn "^4.0.0"
+    zod "^3.22.4"
+
+"@backstage/plugin-catalog-backend@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-backend/-/plugin-catalog-backend-1.22.0.tgz#7199e5b29abf121c7af0e917cb9b2c149482fec8"
+  integrity sha512-iuMGNNyhmYTbysH1La7tI8/mQWevFq2aHHVqD800QUCyxqYfXfESAGJRXlqUtmzxxetQLwq7CF/MgvTNZD5bCw==
+  dependencies:
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-openapi-utils" "^0.1.11"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/backend-tasks" "^0.5.23"
+    "@backstage/catalog-client" "^1.6.5"
+    "@backstage/catalog-model" "^1.5.0"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/integration" "^1.11.0"
+    "@backstage/plugin-catalog-common" "^1.0.23"
+    "@backstage/plugin-catalog-node" "^1.12.0"
+    "@backstage/plugin-events-node" "^0.3.4"
+    "@backstage/plugin-permission-common" "^0.7.13"
+    "@backstage/plugin-permission-node" "^0.7.29"
+    "@backstage/plugin-search-backend-module-catalog" "^0.1.24"
     "@backstage/types" "^1.1.1"
     "@opentelemetry/api" "^1.3.0"
     "@types/express" "^4.17.6"
@@ -3526,6 +3818,20 @@
     "@backstage/plugin-permission-node" "^0.7.28"
     "@backstage/types" "^1.1.1"
 
+"@backstage/plugin-catalog-node@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-node/-/plugin-catalog-node-1.12.0.tgz#513bd374d48c605c664aa77c7350c8585eb9e56e"
+  integrity sha512-y+MsHc94Sepnqhg6pMTCMJBNEWhnCfoKhsl79/a+lsK3Hi+g6e+fNDfTJbg8shhMVnnvwwvfY/UWySZm1B02QQ==
+  dependencies:
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/catalog-client" "^1.6.5"
+    "@backstage/catalog-model" "^1.5.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/plugin-catalog-common" "^1.0.23"
+    "@backstage/plugin-permission-common" "^0.7.13"
+    "@backstage/plugin-permission-node" "^0.7.29"
+    "@backstage/types" "^1.1.1"
+
 "@backstage/plugin-catalog-react@^1.11.3":
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-react/-/plugin-catalog-react-1.11.3.tgz#e83948f3c921791066499d30ef487a9f4ce5964b"
@@ -3603,12 +3909,33 @@
     express-promise-router "^4.1.0"
     winston "^3.2.1"
 
+"@backstage/plugin-events-backend@^0.3.5":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-events-backend/-/plugin-events-backend-0.3.5.tgz#beb43af13e4db963ec188183447c2d2f4604283e"
+  integrity sha512-6PoYpNr2HBQISB+O8Us7QCG+6QoHTRI6msIQt9pKz/V30JtlGtfkjPaId9/OotiPo2csgp1p83ILRyknfmknjQ==
+  dependencies:
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/config" "^1.2.0"
+    "@backstage/plugin-events-node" "^0.3.4"
+    "@types/express" "^4.17.6"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    winston "^3.2.1"
+
 "@backstage/plugin-events-node@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-events-node/-/plugin-events-node-0.3.3.tgz#4881730ed0889439b6366b27defb3e6ea6ba8fcf"
   integrity sha512-xlo8a1ZMdnnQJbwbc8TAj0SYgN4tRfoLE1ATEQvksJPy3FCGbFDHSvDNtZFqA8VO2eB0/QGTBHFewLzLRB8I4A==
   dependencies:
     "@backstage/backend-plugin-api" "^0.6.17"
+
+"@backstage/plugin-events-node@^0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-events-node/-/plugin-events-node-0.3.4.tgz#9d56b47edf9fc0d71f94b46ff91333fb10aad0f4"
+  integrity sha512-vALPBLIqlqAxGohbHat/z4qtvmUcC7+AyWUy+mn84O9OFB+L/v53m79qPjAJhUB9rzPZu8ClsVCfmhm/84j52Q==
+  dependencies:
+    "@backstage/backend-plugin-api" "^0.6.18"
 
 "@backstage/plugin-home-react@^0.1.12":
   version "0.1.12"
@@ -3784,6 +4111,23 @@
     "@backstage/config" "^1.2.0"
     "@backstage/errors" "^1.2.4"
     "@backstage/plugin-auth-node" "^0.4.12"
+    "@backstage/plugin-permission-common" "^0.7.13"
+    "@types/express" "^4.17.6"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.20.4"
+
+"@backstage/plugin-permission-node@^0.7.29":
+  version "0.7.29"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-node/-/plugin-permission-node-0.7.29.tgz#9545fe0fce26ca191beff5e458b920e4445a0a03"
+  integrity sha512-Bjvuk9m3a2qCqoQKIuTA2Lm1zQwf+zVRJWVDIGtK+gJl1xR/gEdyEDDzIa9jX6YjfXRZ3RVsuQVA7jUg8DMw+Q==
+  dependencies:
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/plugin-auth-node" "^0.4.13"
     "@backstage/plugin-permission-common" "^0.7.13"
     "@types/express" "^4.17.6"
     express "^4.17.1"
@@ -4001,6 +4345,15 @@
     "@backstage/plugin-permission-common" "^0.7.13"
     "@backstage/types" "^1.1.1"
 
+"@backstage/plugin-scaffolder-common@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder-common/-/plugin-scaffolder-common-1.5.2.tgz#f16d88a3594e02961bd2facd13bf7fc013cab3a2"
+  integrity sha512-lBet98Oxx+sLsKv84Ke8yF+47svpfzOmGdK8H0YBg+/BQ5M8SrfE05VNXF6VQw5NLsRundgcPMSIrpwKNGJxmQ==
+  dependencies:
+    "@backstage/catalog-model" "^1.5.0"
+    "@backstage/plugin-permission-common" "^0.7.13"
+    "@backstage/types" "^1.1.1"
+
 "@backstage/plugin-scaffolder-node-test-utils@0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder-node-test-utils/-/plugin-scaffolder-node-test-utils-0.1.3.tgz#3594943c05c8c60f7f2e197d352d94d19fba6038"
@@ -4025,6 +4378,27 @@
     "@backstage/types" "^1.1.1"
     fs-extra "^11.2.0"
     globby "^11.0.0"
+    jsonschema "^1.2.6"
+    p-limit "^3.1.0"
+    winston "^3.2.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.20.4"
+
+"@backstage/plugin-scaffolder-node@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder-node/-/plugin-scaffolder-node-0.4.4.tgz#4d90476b5c69341eba21c9fb164edb0ad3f2894e"
+  integrity sha512-8IEAntAutYZvyETC750yIly13d2WMaCXwIXxMOA3M0bGPfqnYj9rca4rJFBBS1sSlvYmWu+U4I16+5FO13xXKA==
+  dependencies:
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/catalog-model" "^1.5.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/integration" "^1.11.0"
+    "@backstage/plugin-scaffolder-common" "^1.5.2"
+    "@backstage/types" "^1.1.1"
+    fs-extra "^11.2.0"
+    globby "^11.0.0"
+    isomorphic-git "^1.23.0"
     jsonschema "^1.2.6"
     p-limit "^3.1.0"
     winston "^3.2.1"
@@ -4136,6 +4510,24 @@
     "@backstage/plugin-search-backend-node" "^1.2.21"
     "@backstage/plugin-search-common" "^1.2.11"
 
+"@backstage/plugin-search-backend-module-catalog@^0.1.24":
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-search-backend-module-catalog/-/plugin-search-backend-module-catalog-0.1.24.tgz#450db10a30f56f729322b72aa8385db2ca78b071"
+  integrity sha512-05lHb677OfCN26RwxspNYC8C5xJHfC+tyH7C7iEfJWtKNT2gknYBjpscHTSDwHrw7SzXjPP2hpfYGXhyD/0kyQ==
+  dependencies:
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/backend-tasks" "^0.5.23"
+    "@backstage/catalog-client" "^1.6.5"
+    "@backstage/catalog-model" "^1.5.0"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/plugin-catalog-common" "^1.0.23"
+    "@backstage/plugin-catalog-node" "^1.12.0"
+    "@backstage/plugin-permission-common" "^0.7.13"
+    "@backstage/plugin-search-backend-node" "^1.2.22"
+    "@backstage/plugin-search-common" "^1.2.11"
+
 "@backstage/plugin-search-backend-module-techdocs@^0.1.22":
   version "0.1.22"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-search-backend-module-techdocs/-/plugin-search-backend-module-techdocs-0.1.22.tgz#aaeafd653603b54f6c618adc765572612c6af451"
@@ -4165,6 +4557,24 @@
     "@backstage/backend-common" "^0.21.7"
     "@backstage/backend-plugin-api" "^0.6.17"
     "@backstage/backend-tasks" "^0.5.22"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/plugin-permission-common" "^0.7.13"
+    "@backstage/plugin-search-common" "^1.2.11"
+    "@types/lunr" "^2.3.3"
+    lodash "^4.17.21"
+    lunr "^2.3.9"
+    ndjson "^2.0.0"
+    uuid "^9.0.0"
+
+"@backstage/plugin-search-backend-node@^1.2.22":
+  version "1.2.23"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-search-backend-node/-/plugin-search-backend-node-1.2.23.tgz#45e64389a6a2f8f09ca4f3f093a8d002352b5b7c"
+  integrity sha512-r1X9l72/jF6eQazVR3KR7/MZRknO2XGKXjvKLgSR7vxhwBi8DDE/4bg6nQaN8Okan9ll/Ng9jxjF/XRLc4plwQ==
+  dependencies:
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/backend-tasks" "^0.5.23"
     "@backstage/config" "^1.2.0"
     "@backstage/errors" "^1.2.4"
     "@backstage/plugin-permission-common" "^0.7.13"
@@ -7021,10 +7431,22 @@
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.17.tgz#ce8f3dff6ec11c8294d346997f6065eb23fa99be"
   integrity sha512-DVAejDQkjNnIac7MfP8sLzuo7fyrBPxNdXe+6bYqOqg1z2OPTlfFAejSNzWe7UenRMuFu9/AyFXj/X2vN2w6dA==
 
+"@mui/core-downloads-tracker@^5.15.18":
+  version "5.15.18"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.18.tgz#0f9426409a82f78423bdf504b2a5a3788656d612"
+  integrity sha512-/9pVk+Al8qxAjwFUADv4BRZgMpZM4m5E+2Q/20qhVPuIJWqKp4Ie4tGExac6zu93rgPTYVQGgu+1vjiT0E+cEw==
+
 "@mui/icons-material@5.15.17", "@mui/icons-material@^5.15.16", "@mui/icons-material@^5.15.3", "@mui/icons-material@^5.15.8":
   version "5.15.17"
   resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.15.17.tgz#518c02354036f7df28c8f9890b1db6a3269fcc2f"
   integrity sha512-xVzl2De7IY36s/keHX45YMiCpsIx3mNv2xwDgtBkRSnZQtVk+Gqufwj1ktUxEyjzEhBl0+PiNJqYC31C+n1n6A==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+
+"@mui/icons-material@^5.15.18":
+  version "5.15.18"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.15.18.tgz#51e42958ed671589f7a1af19b59372df884bcd61"
+  integrity sha512-jGhyw02TSLM0NgW+MDQRLLRUD/K4eN9rlK2pTBTL1OtzyZmQ8nB060zK1wA0b7cVrIiG+zyrRmNAvGWXwm2N9Q==
   dependencies:
     "@babel/runtime" "^7.23.9"
 
@@ -7036,6 +7458,24 @@
     "@babel/runtime" "^7.23.9"
     "@mui/base" "5.0.0-beta.40"
     "@mui/core-downloads-tracker" "^5.15.17"
+    "@mui/system" "^5.15.15"
+    "@mui/types" "^7.2.14"
+    "@mui/utils" "^5.15.14"
+    "@types/react-transition-group" "^4.4.10"
+    clsx "^2.1.0"
+    csstype "^3.1.3"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+    react-transition-group "^4.4.5"
+
+"@mui/material@^5.15.18":
+  version "5.15.18"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.15.18.tgz#1184e88cebb5c58625ca799531c0611c1fd9a2a8"
+  integrity sha512-n+/dsiqux74fFfcRUJjok+ieNQ7+BEk6/OwX9cLcLvriZrZb+/7Y8+Fd2HlUUbn5N0CDurgAHm0VH1DqyJ9HAw==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@mui/base" "5.0.0-beta.40"
+    "@mui/core-downloads-tracker" "^5.15.18"
     "@mui/system" "^5.15.15"
     "@mui/types" "^7.2.14"
     "@mui/utils" "^5.15.14"
@@ -33512,7 +33952,7 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-triple-beam@^1.3.0:
+triple-beam@^1.3.0, triple-beam@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.4.1.tgz#6fde70271dc6e5d73ca0c3b24e2d92afb7441984"
   integrity sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -14473,18 +14473,18 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.21.0.tgz#205724c5123a8fef7ecd195075fa6e85bac3436d"
   integrity sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==
 
-"@typescript-eslint/types@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.9.0.tgz#b58e485e4bfba055659c7e683ad4f5f0821ae2ec"
-  integrity sha512-oZQD9HEWQanl9UfsbGVcZ2cGaR0YT5476xfWE0oE5kQa2sNK2frxOlkeacLOTh9po4AlUT5rtkGyYM5kew0z5w==
+"@typescript-eslint/types@7.10.0":
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.10.0.tgz#da92309c97932a3a033762fd5faa8b067de84e3b"
+  integrity sha512-7fNj+Ya35aNyhuqrA1E/VayQX9Elwr8NKZ4WueClR3KwJ7Xx9jcCdOrLW04h51de/+gNbyFMs+IDxh5xIwfbNg==
 
 "@typescript-eslint/typescript-estree@5.62.0", "@typescript-eslint/typescript-estree@6.21.0", "@typescript-eslint/typescript-estree@^7.3.1":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.9.0.tgz#3395e27656060dc313a6b406c3a298b729685e07"
-  integrity sha512-zBCMCkrb2YjpKV3LA0ZJubtKCDxLttxfdGmwZvTqqWevUPN0FZvSI26FalGFFUZU/9YQK/A4xcQF9o/VVaCKAg==
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.10.0.tgz#6dcdc5de3149916a6a599fa89dde5c471b88b8bb"
+  integrity sha512-LXFnQJjL9XIcxeVfqmNj60YhatpRLt6UhdlFwAkjNc6jSUlK8zQOl1oktAP8PlWFzPQC1jny/8Bai3/HPuvN5g==
   dependencies:
-    "@typescript-eslint/types" "7.9.0"
-    "@typescript-eslint/visitor-keys" "7.9.0"
+    "@typescript-eslint/types" "7.10.0"
+    "@typescript-eslint/visitor-keys" "7.10.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -14535,12 +14535,12 @@
     "@typescript-eslint/types" "6.21.0"
     eslint-visitor-keys "^3.4.1"
 
-"@typescript-eslint/visitor-keys@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.9.0.tgz#82162656e339c3def02895f5c8546f6888d9b9ea"
-  integrity sha512-iESPx2TNLDNGQLyjKhUvIKprlP49XNEK+MvIf9nIO7ZZaZdbnfWKHnXAgufpxqfA0YryH8XToi4+CjBgVnFTSQ==
+"@typescript-eslint/visitor-keys@7.10.0":
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.10.0.tgz#2af2e91e73a75dd6b70b4486c48ae9d38a485a78"
+  integrity sha512-9ntIVgsi6gg6FIq9xjEO4VQJvwOqA3jaBFQJ/6TK5AvEup2+cECI6Fh7QiBxmfMHXU0V0J4RyPeOU1VDNzl9cg==
   dependencies:
-    "@typescript-eslint/types" "7.9.0"
+    "@typescript-eslint/types" "7.10.0"
     eslint-visitor-keys "^3.4.3"
 
 "@uiw/codemirror-extensions-basic-setup@4.22.0":


### PR DESCRIPTION
feat(feedback): upgrade to mui v5
- switch to backstage `AlertApi` instead of MUI Snackbars
- use mui 5 styled components
- add `themeId` prop to GlobalFeedback component

Signed-off-by: Yash Oswal <yashoswal18@gmail.com>

feat(matomo): upgrade to mui v5
- added `secure` flag to matomo-backend plugin
- use backstage fetchApi for new backend system

Signed-off-by: Yash Oswal <yashoswal18@gmail.com>