### PR TITLE
chore(rbac-common): add Unauthorized error

### DIFF
--- a/plugins/rbac-common/package.json
+++ b/plugins/rbac-common/package.json
@@ -24,7 +24,8 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/plugin-permission-common": "^0.7.13"
+    "@backstage/plugin-permission-common": "^0.7.13",
+    "@backstage/errors": "^1.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.26.4"

--- a/plugins/rbac-common/src/types.ts
+++ b/plugins/rbac-common/src/types.ts
@@ -1,3 +1,4 @@
+import { NotAllowedError } from '@backstage/errors';
 import { ConditionalPolicyDecision } from '@backstage/plugin-permission-common';
 
 export type Source =
@@ -65,3 +66,10 @@ export type RoleConditionalPolicyDecision<
 
   permissionMapping: T[];
 };
+
+// UnauthorizedError should be uniformely used for authorization errors.
+export class UnauthorizedError extends NotAllowedError {
+  constructor() {
+    super('Unauthorized');
+  }
+}


### PR DESCRIPTION
A convenience authorization error instead of continuously creating
NotAllowedError('Unauthorized')

Fixes: https://issues.redhat.com/browse/RHIDP-2411

Signed-off-by: Roy Golan <rgolan@redhat.com>
