### PR TITLE
fix(rbac): fix to enable create and edit role buttons on having correct permissions

### DIFF
--- a/plugins/rbac/README.md
+++ b/plugins/rbac/README.md
@@ -30,6 +30,8 @@ p, role:default/team_a, policy-entity, create, allow
 g, user:default/<login-id/user-name>, role:default/team_a
 ```
 
+> Note: Even after applying above permissions if the create button is still disabled then please contact your administrator as you might be conditionally restricted to access the create button.
+
 - To fetch the permissions from other plugins like `Kubernetes` and `Jenkins` in the Role Form as mentioned [here](https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac-backend/docs/permissions.md), add the following configuration in your `app-config.yaml`:
 
 ```yaml title="app-config.yaml"

--- a/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
+++ b/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
@@ -107,6 +107,7 @@ export const AddMembersForm = ({
         renderOption={(option: SelectedMember, state) => (
           <MembersDropdownOption option={option} state={state} />
         )}
+        noOptionsText="No users and groups found."
         clearOnEscape
         renderInput={params => (
           <TextField

--- a/plugins/rbac/src/components/CreateRole/CreateRolePage.test.tsx
+++ b/plugins/rbac/src/components/CreateRole/CreateRolePage.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useAsync } from 'react-use';
 
 import { Content, Header, Page } from '@backstage/core-components';
-import { RequirePermission } from '@backstage/plugin-permission-react';
 
 import { render, screen } from '@testing-library/react';
 
@@ -21,16 +20,6 @@ jest.mock('react-use', () => ({
 jest.mock('./RoleForm', () => ({
   RoleForm: () => <div>RoleForm</div>,
 }));
-
-jest.mock('@backstage/plugin-permission-react', () => ({
-  RequirePermission: jest
-    .fn()
-    .mockImplementation(({ children }) => <div>{children}</div>),
-}));
-
-const mockedPrequirePermission = RequirePermission as jest.MockedFunction<
-  typeof RequirePermission
->;
 
 jest.mock('@backstage/core-components', () => ({
   Page: jest.fn().mockImplementation(({ children }) => (
@@ -67,13 +56,6 @@ describe('CreateRolePage', () => {
     });
 
     render(<CreateRolePage />);
-    expect(mockedPrequirePermission).toHaveBeenCalledWith(
-      expect.objectContaining({
-        permission: expect.objectContaining({ name: 'catalog.entity.read' }),
-        resourceRef: expect.stringContaining('catalog-entity'),
-      }),
-      expect.anything(),
-    );
     expect(mockedPage).toHaveBeenCalled();
     expect(mockedHeader).toHaveBeenCalled();
     expect(mockedContent).toHaveBeenCalled();

--- a/plugins/rbac/src/components/CreateRole/CreateRolePage.tsx
+++ b/plugins/rbac/src/components/CreateRole/CreateRolePage.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { useAsync } from 'react-use';
 
-import { Content, Header, Page } from '@backstage/core-components';
+import {
+  Content,
+  ErrorPage,
+  Header,
+  Page,
+  Progress,
+} from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
-import { RequirePermission } from '@backstage/plugin-permission-react';
 
 import { rbacApiRef } from '../../api/RBACBackendClient';
 import { MemberEntity } from '../../types';
@@ -15,12 +19,18 @@ import { RoleFormValues } from './types';
 export const CreateRolePage = () => {
   const rbacApi = useApi(rbacApiRef);
   const {
-    loading,
+    loading: membersLoading,
     value: members,
     error: membersError,
   } = useAsync(async () => {
     return await rbacApi.getMembers();
   });
+
+  const canReadUsersAndGroups =
+    !membersLoading &&
+    !membersError &&
+    Array.isArray(members) &&
+    members.length > 0;
 
   const initialValues: RoleFormValues = {
     name: '',
@@ -31,35 +41,34 @@ export const CreateRolePage = () => {
     permissionPoliciesRows: [initialPermissionPolicyRowValue],
   };
 
-  return (
-    <RequirePermission
-      permission={catalogEntityReadPermission}
-      resourceRef={catalogEntityReadPermission.resourceType}
-    >
-      <Page themeId="tool">
-        <Header title="Create role" type="RBAC" typeLink=".." />
-        <Content>
-          <RoleForm
-            initialValues={initialValues}
-            titles={{
-              formTitle: 'Create Role',
-              nameAndDescriptionTitle: 'Enter name and description of role ',
-              usersAndGroupsTitle: 'Add users and groups',
-              permissionPoliciesTitle: 'Add permission policies',
-            }}
-            membersData={{
-              members: Array.isArray(members)
-                ? members
-                : ([] as MemberEntity[]),
-              loading,
-              error: (membersError as Error) || {
-                name: (members as Response)?.status,
-                message: (members as Response)?.statusText,
-              },
-            }}
-          />
-        </Content>
-      </Page>
-    </RequirePermission>
+  if (membersLoading) {
+    return <Progress />;
+  }
+
+  return canReadUsersAndGroups ? (
+    <Page themeId="tool">
+      <Header title="Create role" type="RBAC" typeLink=".." />
+      <Content>
+        <RoleForm
+          initialValues={initialValues}
+          titles={{
+            formTitle: 'Create Role',
+            nameAndDescriptionTitle: 'Enter name and description of role ',
+            usersAndGroupsTitle: 'Add users and groups',
+            permissionPoliciesTitle: 'Add permission policies',
+          }}
+          membersData={{
+            members: Array.isArray(members) ? members : ([] as MemberEntity[]),
+            loading: membersLoading,
+            error: (membersError as unknown as Error) || {
+              name: (members as unknown as Response)?.status,
+              message: (members as unknown as Response)?.statusText,
+            },
+          }}
+        />
+      </Content>
+    </Page>
+  ) : (
+    <ErrorPage statusMessage="Unauthorized to create role" />
   );
 };

--- a/plugins/rbac/src/components/CreateRole/EditRolePage.test.tsx
+++ b/plugins/rbac/src/components/CreateRole/EditRolePage.test.tsx
@@ -47,17 +47,6 @@ jest.mock('./RoleForm', () => ({
   RoleForm: () => <div>RoleForm</div>,
 }));
 
-jest.mock('@backstage/plugin-permission-react', () => ({
-  RequirePermission: jest
-    .fn()
-    .mockImplementation(({ permission, resourceRef, children }) => (
-      <div>
-        {`${permission} ${resourceRef}`}
-        {children}
-      </div>
-    )),
-}));
-
 jest.mock('@backstage/core-components', () => ({
   useQueryParamState: () => ['roleName', jest.fn()],
   Progress: () => <div>MockedProgressComponent</div>,
@@ -117,6 +106,7 @@ describe('EditRolePage', () => {
       loading: false,
       roleError: { name: '', message: '' },
       membersError: new Error(''),
+      canReadUsersAndGroups: true,
     });
     render(<EditRolePage />);
     expect(screen.getByText('Edit Role Page')).toBeInTheDocument();
@@ -131,6 +121,7 @@ describe('EditRolePage', () => {
       role: undefined,
       membersError: { name: '', message: '' },
       roleError: { name: '', message: '' },
+      canReadUsersAndGroups: true,
     });
     render(<EditRolePage />);
     expect(screen.queryByText('MockedProgressComponent')).toBeInTheDocument();
@@ -144,6 +135,7 @@ describe('EditRolePage', () => {
       role: undefined,
       membersError: { name: 'Error', message: 'Error Message' },
       loading: false,
+      canReadUsersAndGroups: true,
     });
     render(<EditRolePage />);
     expect(screen.queryByText('MockedErrorPageComponent')).toBeInTheDocument();

--- a/plugins/rbac/src/components/CreateRole/EditRolePage.tsx
+++ b/plugins/rbac/src/components/CreateRole/EditRolePage.tsx
@@ -9,8 +9,6 @@ import {
   Progress,
   useQueryParamState,
 } from '@backstage/core-components';
-import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
-import { RequirePermission } from '@backstage/plugin-permission-react';
 
 import { usePermissionPolicies } from '../../hooks/usePermissionPolicies';
 import { useSelectedMembers } from '../../hooks/useSelectedMembers';
@@ -20,10 +18,17 @@ import { RoleFormValues } from './types';
 export const EditRolePage = () => {
   const { roleName, roleNamespace, roleKind } = useParams();
   const [queryParamState] = useQueryParamState<number>('activeStep');
-  const { selectedMembers, members, role, loading, roleError, membersError } =
-    useSelectedMembers(
-      roleName ? `${roleKind}:${roleNamespace}/${roleName}` : '',
-    );
+  const {
+    selectedMembers,
+    members,
+    role,
+    loading,
+    roleError,
+    membersError,
+    canReadUsersAndGroups,
+  } = useSelectedMembers(
+    roleName ? `${roleKind}:${roleNamespace}/${roleName}` : '',
+  );
 
   const { data: permissionPolicies, conditionsData } = usePermissionPolicies(
     `${roleKind}:${roleNamespace}/${roleName}`,
@@ -37,44 +42,35 @@ export const EditRolePage = () => {
     selectedMembers,
     permissionPoliciesRows: [...conditionsData, ...permissionPolicies],
   };
-  const renderPage = () => {
-    if (loading) {
-      return <Progress />;
-    } else if (roleError.name) {
-      return (
-        <ErrorPage status={roleError.name} statusMessage={roleError.message} />
-      );
-    }
-    return (
-      <>
-        <Header title="Edit role" type="RBAC" typeLink=".." />
-        <Content>
-          <RoleForm
-            initialValues={initialValues}
-            titles={{
-              formTitle: 'Edit Role',
-              nameAndDescriptionTitle: 'Edit name and description of role ',
-              usersAndGroupsTitle: 'Edit users and groups',
-              permissionPoliciesTitle: 'Edit permission policies',
-            }}
-            roleName={
-              roleName ? `${roleKind}:${roleNamespace}/${roleName}` : ''
-            }
-            step={Number(queryParamState)}
-            membersData={{ members, loading, error: membersError }}
-            submitLabel="Save"
-          />
-        </Content>
-      </>
-    );
-  };
 
-  return (
-    <RequirePermission
-      permission={catalogEntityReadPermission}
-      resourceRef={catalogEntityReadPermission.resourceType}
-    >
-      <Page themeId="tool">{renderPage()}</Page>
-    </RequirePermission>
+  if (loading) {
+    return <Progress />;
+  } else if (roleError.name) {
+    return (
+      <ErrorPage status={roleError.name} statusMessage={roleError.message} />
+    );
+  }
+
+  return canReadUsersAndGroups ? (
+    <Page themeId="tool">
+      <Header title="Edit role" type="RBAC" typeLink=".." />
+      <Content>
+        <RoleForm
+          initialValues={initialValues}
+          titles={{
+            formTitle: 'Edit Role',
+            nameAndDescriptionTitle: 'Edit name and description of role ',
+            usersAndGroupsTitle: 'Edit users and groups',
+            permissionPoliciesTitle: 'Edit permission policies',
+          }}
+          roleName={roleName ? `${roleKind}:${roleNamespace}/${roleName}` : ''}
+          step={Number(queryParamState)}
+          membersData={{ members, loading, error: membersError }}
+          submitLabel="Save"
+        />
+      </Content>
+    </Page>
+  ) : (
+    <ErrorPage statusMessage="Unauthorized to edit role" />
   );
 };

--- a/plugins/rbac/src/components/RoleOverview/MembersCard.test.tsx
+++ b/plugins/rbac/src/components/RoleOverview/MembersCard.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { usePermission } from '@backstage/plugin-permission-react';
 import { renderInTestApp } from '@backstage/test-utils';
 
-import { useMembers } from '../../hooks/useMembers';
 import { MembersData } from '../../types';
 import { MembersCard } from './MembersCard';
 
@@ -58,7 +57,6 @@ const useMembersMockData: MembersData[] = [
   },
 ];
 
-const mockMembers = useMembers as jest.MockedFunction<typeof useMembers>;
 const mockUsePermission = usePermission as jest.MockedFunction<
   typeof usePermission
 >;
@@ -66,14 +64,18 @@ const mockUsePermission = usePermission as jest.MockedFunction<
 describe('MembersCard', () => {
   it('should show list of Users and groups associated with the role when the data is loaded', async () => {
     mockUsePermission.mockReturnValue({ loading: false, allowed: true });
-    mockMembers.mockReturnValue({
+    const membersInfo = {
       loading: false,
       data: useMembersMockData,
       error: undefined,
       retry: { roleRetry: jest.fn(), membersRetry: jest.fn() },
-    });
+      canReadUsersAndGroups: true,
+    };
     const { queryByText } = await renderInTestApp(
-      <MembersCard roleName="role:default/rbac_admin" />,
+      <MembersCard
+        roleName="role:default/rbac_admin"
+        membersInfo={membersInfo}
+      />,
     );
     expect(queryByText('Users and groups (2 users, 2 groups)')).not.toBeNull();
     expect(queryByText('Calum Leavy')).not.toBeNull();
@@ -83,14 +85,18 @@ describe('MembersCard', () => {
 
   it('should show empty table when there are no users and groups', async () => {
     mockUsePermission.mockReturnValue({ loading: false, allowed: true });
-    mockMembers.mockReturnValue({
+    const membersInfo = {
       loading: false,
       data: [],
       error: undefined,
       retry: { roleRetry: jest.fn(), membersRetry: jest.fn() },
-    });
+      canReadUsersAndGroups: true,
+    };
     const { queryByText } = await renderInTestApp(
-      <MembersCard roleName="role:default/rbac_admin" />,
+      <MembersCard
+        roleName="role:default/rbac_admin"
+        membersInfo={membersInfo}
+      />,
     );
     expect(queryByText('Users and groups')).not.toBeNull();
     expect(queryByText('No records found')).not.toBeNull();
@@ -98,14 +104,18 @@ describe('MembersCard', () => {
 
   it('should show an error if api call fails', async () => {
     mockUsePermission.mockReturnValue({ loading: false, allowed: true });
-    mockMembers.mockReturnValue({
+    const membersInfo = {
       loading: false,
       data: [],
       error: { message: 'xyz' },
       retry: { roleRetry: jest.fn(), membersRetry: jest.fn() },
-    });
+      canReadUsersAndGroups: false,
+    };
     const { queryByText } = await renderInTestApp(
-      <MembersCard roleName="role:default/rbac_admin" />,
+      <MembersCard
+        roleName="role:default/rbac_admin"
+        membersInfo={membersInfo}
+      />,
     );
     expect(
       queryByText(
@@ -118,28 +128,36 @@ describe('MembersCard', () => {
 
   it('should show edit icon when the user is authorized to update roles', async () => {
     mockUsePermission.mockReturnValue({ loading: false, allowed: true });
-    mockMembers.mockReturnValue({
+    const membersInfo = {
       loading: false,
       data: useMembersMockData,
       error: undefined,
       retry: { roleRetry: jest.fn(), membersRetry: jest.fn() },
-    });
+      canReadUsersAndGroups: true,
+    };
     const { getByTestId } = await renderInTestApp(
-      <MembersCard roleName="role:default/rbac_admin" />,
+      <MembersCard
+        roleName="role:default/rbac_admin"
+        membersInfo={membersInfo}
+      />,
     );
     expect(getByTestId('update-members')).not.toBeNull();
   });
 
   it('should disable edit icon when the user is not authorized to update roles', async () => {
     mockUsePermission.mockReturnValue({ loading: false, allowed: false });
-    mockMembers.mockReturnValue({
+    const membersInfo = {
       loading: false,
       data: useMembersMockData,
       error: undefined,
       retry: { roleRetry: jest.fn(), membersRetry: jest.fn() },
-    });
+      canReadUsersAndGroups: false,
+    };
     const { queryByTestId } = await renderInTestApp(
-      <MembersCard roleName="role:default/rbac_admin" />,
+      <MembersCard
+        roleName="role:default/rbac_admin"
+        membersInfo={membersInfo}
+      />,
     );
     expect(queryByTestId('disable-update-members')).not.toBeNull();
   });

--- a/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
+++ b/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { Table, WarningPanel } from '@backstage/core-components';
-import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
 import { usePermission } from '@backstage/plugin-permission-react';
 
 import { Card, CardContent, makeStyles } from '@material-ui/core';
@@ -9,7 +8,7 @@ import CachedIcon from '@material-ui/icons/Cached';
 
 import { policyEntityUpdatePermission } from '@janus-idp/backstage-plugin-rbac-common';
 
-import { useMembers } from '../../hooks/useMembers';
+import { MembersInfo } from '../../hooks/useMembers';
 import { MembersData } from '../../types';
 import { getKindNamespaceName, getMembers } from '../../utils/rbac-utils';
 import EditRole from '../EditRole';
@@ -17,6 +16,7 @@ import { columns } from './MembersListColumns';
 
 type MembersCardProps = {
   roleName: string;
+  membersInfo: MembersInfo;
 };
 
 const useStyles = makeStyles(theme => ({
@@ -41,16 +41,12 @@ const getEditIcon = (isAllowed: boolean, roleName: string) => {
   );
 };
 
-export const MembersCard = ({ roleName }: MembersCardProps) => {
-  const { data, loading, retry, error } = useMembers(roleName);
+export const MembersCard = ({ roleName, membersInfo }: MembersCardProps) => {
+  const { data, loading, retry, error, canReadUsersAndGroups } = membersInfo;
   const [members, setMembers] = React.useState<MembersData[]>();
   const policyEntityPermissionResult = usePermission({
     permission: policyEntityUpdatePermission,
     resourceRef: policyEntityUpdatePermission.resourceType,
-  });
-  const catalogEntityPermissionResult = usePermission({
-    permission: catalogEntityReadPermission,
-    resourceRef: catalogEntityReadPermission.resourceType,
   });
 
   const classes = useStyles();
@@ -67,13 +63,11 @@ export const MembersCard = ({ roleName }: MembersCardProps) => {
     {
       icon: () =>
         getEditIcon(
-          policyEntityPermissionResult.allowed &&
-            catalogEntityPermissionResult.allowed,
+          policyEntityPermissionResult.allowed && canReadUsersAndGroups,
           roleName,
         ),
       tooltip:
-        catalogEntityPermissionResult.allowed &&
-        policyEntityPermissionResult.allowed
+        policyEntityPermissionResult.allowed && canReadUsersAndGroups
           ? 'Edit'
           : 'Unauthorized to edit',
       isFreeAction: true,

--- a/plugins/rbac/src/components/RoleOverview/PermissionsCard.test.tsx
+++ b/plugins/rbac/src/components/RoleOverview/PermissionsCard.test.tsx
@@ -55,7 +55,10 @@ describe('PermissionsCard', () => {
       error: new Error(''),
     });
     const { queryByText } = await renderInTestApp(
-      <PermissionsCard entityReference="user:default/debsmita1" />,
+      <PermissionsCard
+        entityReference="user:default/debsmita1"
+        canReadUsersAndGroups
+      />,
     );
     expect(queryByText('Permission Policies (3)')).not.toBeNull();
     expect(queryByText('Read, Create, Delete')).not.toBeNull();
@@ -71,7 +74,10 @@ describe('PermissionsCard', () => {
       error: new Error(''),
     });
     const { queryByText } = await renderInTestApp(
-      <PermissionsCard entityReference="user:default/debsmita1" />,
+      <PermissionsCard
+        entityReference="user:default/debsmita1"
+        canReadUsersAndGroups
+      />,
     );
     expect(queryByText('Permission Policies')).not.toBeNull();
     expect(queryByText('No records found')).not.toBeNull();
@@ -86,7 +92,10 @@ describe('PermissionsCard', () => {
       error: { message: '404', name: 'Not Found' },
     });
     const { queryByText } = await renderInTestApp(
-      <PermissionsCard entityReference="user:default/debsmita1" />,
+      <PermissionsCard
+        entityReference="user:default/debsmita1"
+        canReadUsersAndGroups
+      />,
     );
     expect(
       queryByText(
@@ -106,7 +115,10 @@ describe('PermissionsCard', () => {
       retry: { policiesRetry: jest.fn(), permissionPoliciesRetry: jest.fn() },
     });
     const { getByTestId } = await renderInTestApp(
-      <PermissionsCard entityReference="role:default/rbac_admin" />,
+      <PermissionsCard
+        entityReference="role:default/rbac_admin"
+        canReadUsersAndGroups
+      />,
     );
     expect(getByTestId('update-policies')).not.toBeNull();
   });
@@ -121,7 +133,10 @@ describe('PermissionsCard', () => {
       retry: { policiesRetry: jest.fn(), permissionPoliciesRetry: jest.fn() },
     });
     const { queryByTestId } = await renderInTestApp(
-      <PermissionsCard entityReference="role:default/rbac_admin" />,
+      <PermissionsCard
+        entityReference="role:default/rbac_admin"
+        canReadUsersAndGroups={false}
+      />,
     );
     expect(queryByTestId('disable-update-policies')).not.toBeNull();
   });

--- a/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
+++ b/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
@@ -24,6 +24,7 @@ const useStyles = makeStyles(theme => ({
 
 type PermissionsCardProps = {
   entityReference: string;
+  canReadUsersAndGroups: boolean;
 };
 
 const getRefreshIcon = () => <CachedIcon />;
@@ -40,7 +41,10 @@ const getEditIcon = (isAllowed: boolean, roleName: string) => {
   );
 };
 
-export const PermissionsCard = ({ entityReference }: PermissionsCardProps) => {
+export const PermissionsCard = ({
+  entityReference,
+  canReadUsersAndGroups,
+}: PermissionsCardProps) => {
   const { data, loading, retry, error } =
     usePermissionPolicies(entityReference);
   const [permissions, setPermissions] = React.useState<PermissionsData[]>();
@@ -71,8 +75,15 @@ export const PermissionsCard = ({ entityReference }: PermissionsCardProps) => {
       },
     },
     {
-      icon: () => getEditIcon(permissionResult.allowed, entityReference),
-      tooltip: !permissionResult.allowed ? 'Unauthorized to edit' : 'Edit',
+      icon: () =>
+        getEditIcon(
+          permissionResult.allowed && canReadUsersAndGroups,
+          entityReference,
+        ),
+      tooltip:
+        permissionResult.allowed && canReadUsersAndGroups
+          ? 'Edit'
+          : 'Unauthorized to edit',
       isFreeAction: true,
       onClick: () => {},
     },

--- a/plugins/rbac/src/components/RoleOverview/RoleOverviewPage.tsx
+++ b/plugins/rbac/src/components/RoleOverview/RoleOverviewPage.tsx
@@ -6,6 +6,7 @@ import { Header, Page, TabbedLayout } from '@backstage/core-components';
 import { Grid } from '@material-ui/core';
 
 import { useLocationToast } from '../../hooks/useLocationToast';
+import { useMembers } from '../../hooks/useMembers';
 import { SnackbarAlert } from '../SnackbarAlert';
 import { useToast } from '../ToastContext';
 import { AboutCard } from './AboutCard';
@@ -15,6 +16,7 @@ import { PermissionsCard } from './PermissionsCard';
 export const RoleOverviewPage = () => {
   const { roleName, roleNamespace, roleKind } = useParams();
   const { toastMessage, setToastMessage } = useToast();
+  const membersInfo = useMembers(`${roleKind}:${roleNamespace}/${roleName}`);
 
   useLocationToast(setToastMessage);
 
@@ -42,11 +44,13 @@ export const RoleOverviewPage = () => {
               <Grid item lg={6} xs={12}>
                 <MembersCard
                   roleName={`${roleKind}:${roleNamespace}/${roleName}`}
+                  membersInfo={membersInfo}
                 />
               </Grid>
               <Grid item lg={6} xs={12}>
                 <PermissionsCard
                   entityReference={`${roleKind}:${roleNamespace}/${roleName}`}
+                  canReadUsersAndGroups={membersInfo.canReadUsersAndGroups}
                 />
               </Grid>
             </Grid>

--- a/plugins/rbac/src/hooks/useMembers.ts
+++ b/plugins/rbac/src/hooks/useMembers.ts
@@ -8,6 +8,14 @@ import { rbacApiRef } from '../api/RBACBackendClient';
 import { MemberEntity, MembersData } from '../types';
 import { getKindNamespaceName, getMembersFromGroup } from '../utils/rbac-utils';
 
+export type MembersInfo = {
+  loading: boolean;
+  data: MembersData[];
+  retry: { roleRetry: () => void; membersRetry: () => void };
+  error?: { message: string };
+  canReadUsersAndGroups: boolean;
+};
+
 const getErrorText = (
   role: any,
   members: any,
@@ -58,7 +66,10 @@ const getMemberData = (
   };
 };
 
-export const useMembers = (roleName: string, pollInterval?: number) => {
+export const useMembers = (
+  roleName: string,
+  pollInterval?: number,
+): MembersInfo => {
   const rbacApi = useApi(rbacApiRef);
   let data: MembersData[] = [];
   const {
@@ -76,6 +87,9 @@ export const useMembers = (roleName: string, pollInterval?: number) => {
   } = useAsyncRetry(async () => {
     return await rbacApi.getMembers();
   });
+
+  const canReadUsersAndGroups =
+    !membersError && Array.isArray(members) && members.length > 0;
 
   const loading = !roleError && !membersError && !role && !members;
 
@@ -109,5 +123,6 @@ export const useMembers = (roleName: string, pollInterval?: number) => {
     data,
     retry: { roleRetry, membersRetry },
     error: getErrorText(role, members) || roleError || membersError,
+    canReadUsersAndGroups,
   };
 };

--- a/plugins/rbac/src/hooks/useSelectedMembers.ts
+++ b/plugins/rbac/src/hooks/useSelectedMembers.ts
@@ -20,6 +20,7 @@ export const useSelectedMembers = (
   membersError: Error;
   roleError: Error;
   loading: boolean;
+  canReadUsersAndGroups: boolean;
 } => {
   const rbacApi = useApi(rbacApiRef);
   const { role, loading: roleLoading, roleError } = useRole(roleName);
@@ -31,6 +32,12 @@ export const useSelectedMembers = (
   } = useAsync(async () => {
     return await rbacApi.getMembers();
   });
+
+  const canReadUsersAndGroups =
+    !membersLoading &&
+    !membersError &&
+    Array.isArray(members) &&
+    members.length > 0;
 
   const data: SelectedMember[] = role
     ? (role as Role).memberReferences.reduce((acc: SelectedMember[], ref) => {
@@ -54,5 +61,6 @@ export const useSelectedMembers = (
     },
     roleError: roleError,
     loading: roleLoading && membersLoading,
+    canReadUsersAndGroups,
   };
 };


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHIDP-1757

Currently `catalog.entity.read` permission auth was incorrect as it expects a complete resource ref for eg  `component:default/test` but `catalog-entity` was used instead and on applying any conditions to the admin role the create button was getting disabled as /api/permission/authorize returns 500 with this error for catalogEntityReadPermission :
"Entity reference \"catalog-entity\" had missing or empty kind (e.g. did not start with \"component:\" or similar)"

To fix this I have remove this permission check. If the user is authorised to read users and groups this /api/catalog/entities?filter=kind=user&filter=kind=group will return a list of users and groups otherwise it returns an empty array. So I have uitilised this to check if the user is authorised or not.

Now if the user doesnt have `catalog-entity, read, allow` or a condition is applied like below

<img width="1900" alt="Screenshot 2024-05-22 at 8 25 01 PM" src="https://github.com/janus-idp/backstage-plugins/assets/20724543/8577fbc3-55e7-419f-b9fb-51704350fe0c">

then the create button will be disabled

<img width="1900" alt="Screenshot 2024-05-22 at 8 29 11 PM" src="https://github.com/janus-idp/backstage-plugins/assets/20724543/4153b8b8-5965-4a85-9cec-8d686b681187">

Error page for route /rbac/role/new when user is not authorised to access users and groups
<img width="1900" alt="Screenshot 2024-05-22 at 8 29 48 PM" src="https://github.com/janus-idp/backstage-plugins/assets/20724543/c7a8fa7a-daf5-40e6-aac6-0f73974f5916">

Error page for route /rbac/role/role/default/div  when user is not authorised to access users and groups
<img width="1900" alt="Screenshot 2024-05-22 at 8 29 28 PM" src="https://github.com/janus-idp/backstage-plugins/assets/20724543/5bdbc50f-1e9c-490c-ae3b-40f7afb9c976">

