### PR TITLE
fix(orchestrator): fixed broken workflow viewer

### DIFF
--- a/plugins/orchestrator-backend/src/OrchestratorPlugin.ts
+++ b/plugins/orchestrator-backend/src/OrchestratorPlugin.ts
@@ -45,6 +45,14 @@ export const orchestratorPlugin = createBackendPlugin({
           httpAuth: httpAuth,
         });
         httpRouter.use(router);
+        httpRouter.addAuthPolicy({
+          path: '/static/generated/envelope',
+          allow: 'unauthenticated',
+        });
+        httpRouter.addAuthPolicy({
+          path: '/health',
+          allow: 'unauthenticated',
+        });
       },
     });
   },


### PR DESCRIPTION
[FLPATH-1331](https://issues.redhat.com/browse/FLPATH-1331)

Issue:
Following upgrade to backstage 1.26, authentication is required by default. This causes the API for retrieving the workflow editor envelope files to fail with "401 unauthorised"

Solution:
Follow [upstream documentation](https://backstage.io/docs/tutorials/auth-service-migration/#adding-auth-policies) for adding an exception for this policy for the workflow editor files API.

Includes also exception of the /health API
