### PR TITLE
chore(topology-common): change package to public

### DIFF
--- a/plugins/topology-common/package.json
+++ b/plugins/topology-common/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",


### PR DESCRIPTION
### Description
Update the topology common `package.json` to be public

### What issue(s) does this fix
Fixes https://github.com/janus-idp/backstage-plugins/issues/1716