### PR TITLE
fix(orchestrator): temporarily disable plugins/orchestrator-swf-editor-envelope build

### DIFF
--- a/plugins/orchestrator-swf-editor-envelope/package.json
+++ b/plugins/orchestrator-swf-editor-envelope/package.json
@@ -16,7 +16,7 @@
     "role": "web-library"
   },
   "scripts": {
-    "build": "webpack --progress",
+    "build": "scripts/build",
     "postbuild": "scripts/postbuild copy",
     "clean": "backstage-cli package clean",
     "lint": "backstage-cli package lint",

--- a/plugins/orchestrator-swf-editor-envelope/scripts/build
+++ b/plugins/orchestrator-swf-editor-envelope/scripts/build
@@ -4,4 +4,4 @@
 // disabling building temporarily to not break backstage plugins release job
 // https://github.com/janus-idp/backstage-plugins/actions/runs/9255511136/job/25459744222#step:4:4465
 // command should be: webpack --progress
-console.log('building temporarily disabled');
+echo "build temporarily disabled"; mkdir -p dist/

--- a/plugins/orchestrator-swf-editor-envelope/scripts/build
+++ b/plugins/orchestrator-swf-editor-envelope/scripts/build
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+// disabling building temporarily to not break backstage plugins release job
+// https://github.com/janus-idp/backstage-plugins/actions/runs/9255511136/job/25459744222#step:4:4465
+// command should be: webpack --progress
+console.log('building temporarily disabled');

--- a/plugins/orchestrator-swf-editor-envelope/scripts/build
+++ b/plugins/orchestrator-swf-editor-envelope/scripts/build
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/bash
 /* eslint-disable no-console */
 
 // disabling building temporarily to not break backstage plugins release job


### PR DESCRIPTION
Issue: 
The build of the the orchestrator-swf-editor-envelope breaks the [release pipeline](https://github.com/janus-idp/backstage-plugins/actions/runs/9255511136/job/25459744222#step:4:4465) 
It'll take time to investigate.

Resolution:
Since we have the [build results](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator-backend/static/generated/envelope) in orchestrator-backend and since the code there rarely changes if at all, we don't need this build job to be enabled