### PR TITLE
fix(rbac): add proper empty page for RBAC plugin

### DIFF
--- a/plugins/rbac/src/components/Router.test.tsx
+++ b/plugins/rbac/src/components/Router.test.tsx
@@ -32,6 +32,10 @@ jest.mock('./CreateRole/EditRolePage', () => ({
   EditRolePage: () => <div>EditRole</div>,
 }));
 
+jest.mock('@backstage/core-components', () => ({
+  ErrorPage: jest.fn().mockImplementation(() => <div>Mocked ErrorPage</div>),
+}));
+
 jest.mock('@backstage/plugin-permission-react', () => ({
   RequirePermission: jest
     .fn()
@@ -65,6 +69,17 @@ describe('Router component', () => {
       </MemoryRouter>,
     );
     expect(screen.queryByText('RBAC')).not.toBeInTheDocument();
+  });
+
+  it('should render ErrorPage when rbac-backend plugin is disabled', () => {
+    configMock.getOptionalBoolean.mockReturnValueOnce(false);
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Router />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('Mocked ErrorPage')).toBeInTheDocument();
   });
 
   it('renders RoleOverviewPage when path matches roleRouteRef', () => {

--- a/plugins/rbac/src/components/Router.tsx
+++ b/plugins/rbac/src/components/Router.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 
+import { ErrorPage } from '@backstage/core-components';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 
@@ -25,7 +26,13 @@ export const Router = ({ useHeader = true }: { useHeader?: boolean }) => {
   const isRBACPluginEnabled = config.getOptionalBoolean('permission.enabled');
 
   if (!isRBACPluginEnabled) {
-    return null;
+    return (
+      <ErrorPage
+        status="404"
+        statusMessage={'RBAC-backend plugin is not enabled.'}
+        additionalInfo={'Set `permission.enabled` to `true` in the app-config.'}
+      />
+    );
   }
 
   return (

--- a/plugins/rbac/src/components/Router.tsx
+++ b/plugins/rbac/src/components/Router.tsx
@@ -29,8 +29,8 @@ export const Router = ({ useHeader = true }: { useHeader?: boolean }) => {
     return (
       <ErrorPage
         status="404"
-        statusMessage={'RBAC-backend plugin is not enabled.'}
-        additionalInfo={'Set `permission.enabled` to `true` in the app-config.'}
+        statusMessage="Enable the RBAC backend plugin to use this feature."
+        additionalInfo="To enable RBAC, set `permission.enabled` to `true` in the app-config file."
       />
     );
   }


### PR DESCRIPTION
For [RHIDP-2344](https://issues.redhat.com/browse/RHIDP-2344): Show empty state when rbac frontend is not available
(Updated on 5/30)
```
      <ErrorPage
        status="404"
        statusMessage="Enable the RBAC backend plugin to use this feature."
        additionalInfo="To enable RBAC, set `permission.enabled` to `true` in the app-config file."
      />
```

@ShiranHi @divyanshiGupta Let me know if I need to update the `statusMessage` or the `addtionalInfo` content.

Screenshot(updated on 5/30):
![image](https://github.com/janus-idp/backstage-plugins/assets/26255262/910cbbdf-dad1-49dc-93e4-6259b8088f04)

