### PR TITLE
fix(release): change problematic plugins to private

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,11 +9,7 @@
     "role": "cli"
   },
   "homepage": "https://janus-idp.io",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/janus-idp/backstage-plugins",
-    "directory": "packages/cli"
-  },
+  "repository": "github:janus-idp/backstage-plugins",
   "keywords": [
     "backstage"
   ],

--- a/plugins/acr/package.json
+++ b/plugins/acr/package.json
@@ -30,7 +30,7 @@
     "@backstage/core-plugin-api": "^1.9.2",
     "@backstage/plugin-catalog-react": "^1.11.3",
     "@backstage/theme": "^0.5.3",
-    "@janus-idp/shared-react": "2.6.3",
+    "@janus-idp/shared-react": "2.6.2",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.45",

--- a/plugins/argocd/package.json
+++ b/plugins/argocd/package.json
@@ -75,11 +75,7 @@
     }
   },
   "configSchema": "config.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/janus-idp/backstage-plugins",
-    "directory": "plugins/argocd"
-  },
+  "repository": "github:janus-idp/backstage-plugins",
   "keywords": [
     "backstage",
     "plugin"

--- a/plugins/audit-log-node/package.json
+++ b/plugins/audit-log-node/package.json
@@ -2,6 +2,7 @@
   "name": "@janus-idp/backstage-plugin-audit-log-node",
   "description": "Node.js library for the audit-log plugin",
   "version": "0.1.0",
+  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/audit-log-node/package.json
+++ b/plugins/audit-log-node/package.json
@@ -33,11 +33,7 @@
   "files": [
     "dist"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/janus-idp/backstage-plugins",
-    "directory": "plugins/audit-log-node"
-  },
+  "repository": "github:janus-idp/backstage-plugins",
   "keywords": [
     "backstage",
     "plugin"

--- a/plugins/catalog-backend-module-scaffolder-relation-processor/dist-dynamic/package.json
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/dist-dynamic/package.json
@@ -34,11 +34,7 @@
     "alpha"
   ],
   "configSchema": "config.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/janus-idp/backstage-plugins",
-    "directory": "plugins/catalog"
-  },
+  "repository": "github:janus-idp/backstage-plugins",
   "keywords": [
     "backstage",
     "plugin"

--- a/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -2,6 +2,7 @@
   "name": "@janus-idp/backstage-plugin-catalog-backend-module-scaffolder-relation-processor",
   "description": "The scaffolder-relation-processor backend module for the catalog plugin.",
   "version": "0.1.0",
+  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -65,7 +66,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/janus-idp/backstage-plugins",
-    "directory": "plugins/catalog"
+    "directory": "plugins/catalog-backend-module-scaffolder-relation-processor"
   },
   "keywords": [
     "backstage",

--- a/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -63,11 +63,7 @@
     "app-config.janus-idp.yaml"
   ],
   "configSchema": "config.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/janus-idp/backstage-plugins",
-    "directory": "plugins/catalog-backend-module-scaffolder-relation-processor"
-  },
+  "repository": "github:janus-idp/backstage-plugins",
   "keywords": [
     "backstage",
     "plugin"

--- a/plugins/jfrog-artifactory/package.json
+++ b/plugins/jfrog-artifactory/package.json
@@ -33,7 +33,7 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.45",
-    "@janus-idp/shared-react": "2.6.3",
+    "@janus-idp/shared-react": "2.6.2",
     "react-use": "^17.4.0"
   },
   "peerDependencies": {

--- a/plugins/orchestrator-swf-editor-envelope/package.json
+++ b/plugins/orchestrator-swf-editor-envelope/package.json
@@ -54,11 +54,7 @@
   "files": [
     "dist"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/janus-idp/backstage-plugins",
-    "directory": "plugins/orchestrator-swf-editor-envelope"
-  },
+  "repository": "github:janus-idp/backstage-plugins",
   "keywords": [
     "backstage",
     "plugin"

--- a/plugins/topology-common/package.json
+++ b/plugins/topology-common/package.json
@@ -30,11 +30,7 @@
   "files": [
     "dist"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/janus-idp/backstage-plugins",
-    "directory": "plugins/topology"
-  },
+  "repository": "github:janus-idp/backstage-plugins",
   "keywords": [
     "backstage",
     "plugin"


### PR DESCRIPTION
- Changes `@janus-idp/backstage-plugin-catalog-backend-module-scaffolder-relation-processor` to private temporarily
- Changes `@janus-idp/audit-log-node` to private temporarily
- Uniformly updates `repository` location
- Reverts `@janus-idp/shared-react` issue