### PR TITLE
fix(cli): fix entrypoint validation on backstage 1.24.0 and above.

### DIFF
--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -796,21 +796,41 @@ function validatePluginEntryPoints(target: string): string {
     Task.log(
       `  adding typescript extension support to enable entry point validation`,
     );
-    let tsNode: string | undefined;
+
+    let nodeTransform: string | undefined;
     try {
-      tsNode = dynamicPluginRequire.resolve('ts-node');
+      nodeTransform = dynamicPluginRequire.resolve(
+        '@backstage/cli/config/nodeTransform.cjs',
+      );
     } catch (e) {
-      Task.log(`    => unable to find 'ts-node' in the plugin context`);
+      Task.log(
+        `    => unable to find '@backstage/cli/config/nodeTransform.cjs' in the plugin context`,
+      );
     }
 
-    if (tsNode) {
-      dynamicPluginRequire(tsNode).register({
-        transpileOnly: true,
-        project: path.resolve(paths.targetRoot, 'tsconfig.json'),
-        compilerOptions: {
-          module: 'CommonJS',
-        },
-      });
+    if (nodeTransform) {
+      dynamicPluginRequire(nodeTransform);
+    } else {
+      Task.log(
+        `    => searching for 'ts-node' (legacy mode before backage 1.24.0)`,
+      );
+
+      let tsNode: string | undefined;
+      try {
+        tsNode = dynamicPluginRequire.resolve('ts-node');
+      } catch (e) {
+        Task.log(`    => unable to find 'ts-node' in the plugin context`);
+      }
+
+      if (tsNode) {
+        dynamicPluginRequire(tsNode).register({
+          transpileOnly: true,
+          project: path.resolve(paths.targetRoot, 'tsconfig.json'),
+          compilerOptions: {
+            module: 'CommonJS',
+          },
+        });
+      }
     }
 
     // Retry requiring the plugin main module after adding typescript extensions


### PR DESCRIPTION
Starting with backstage release 1.24.0, the use of `ts-node` to manage the typescript compilation has been replaced by the use of the `@backstage/cli/config/nodeTransform.cjs` script based on `pirates` and `@swc/core`  (see commit https://github.com/backstage/backstage/commit/2c2f705fe169f72fdac4da84c154d7118598d06f).

We should adapt to this in the the validation of the entrypoints part of the Janus CLI `expot-dynamic-plugin` command new implementation for backend plugins.