### PR TITLE
fix(release): change problematic plugins to...

### DIFF
--- a/plugins/topology-common/package.json
+++ b/plugins/topology-common/package.json
@@ -2,6 +2,7 @@
   "name": "@janus-idp/backstage-plugin-topology-common",
   "description": "Common functionalities for the topology plugin",
   "version": "1.0.0",
+  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What does this PR do?

fix(release): change problematic plugins to private - topology-common 1.0.0 is already released but keeps trying to include 2000 release note items and borks the git commit

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
same borkaround as in https://github.com/janus-idp/backstage-plugins/commit/69176bd75ccd842a313445e096223ecc339b655b

problem looks like this, as MSR tries to cram 300 lines of release note content into a single git commit message: https://github.com/janus-idp/backstage-plugins/actions/runs/9308359875/job/25622259866
(lines 1672 - 1972)
```
@janus-idp/backstage-plugin-topology-common
v1.0.0
[8:36:28 PM] [@janus-idp/backstage-plugin-topology-common] › ✖  Failed step "prepare" of plugin "Inline plugin"
[8:36:28 PM] [@janus-idp/backstage-plugin-topology-common] › ✖  An error occurred while running semantic-release: Error: Command failed with E2BIG: git commit -m chore(release): 1.0.0 [skip ci]
## 1.0.0 (2024-05-30)
### ⚠ BREAKING CHANGES
* **rbac:** remove token manager for auth service (#1632)
* **ocm:** add basic permissions to ocm backend plugin (#1528)
* **rbac:** add support for multiple policies CRUD (#984)
* **tekton:** update tekton UX (#839)
* **tekton:** enable tekton related features when the tekton annotation is present (#741)
* **ocm:** remake OCM UX (#386)
* **ocm-backend:** The scheduler for the entity provider is now
configurable by changing the `app-config.yaml` or by changing code in
`catalog.ts`. The old configuration for entity provider in `catalog.ts`
is no longer valid.
Signed-off-by: SamoKopecky <skopecky@redhat.com>
Signed-off-by: Tomas Coufal <tcoufal@redhat.com>
* **ocm:** Relocate OCM config and support multiple hubs (#145)
### Features
* **#1019:** implemented feedback plugin ([#1045](https://github.com/janus-idp/backstage-plugins/issues/1045)) ([34c312e](https://github.com/janus-idp/backstage-plugins/commit/34c312e3c8522e81d04621abdcb174c0ecb25733)), closes [#1019](https://github.com/janus-idp/backstage-plugins/issues/1019)
... 
* do not fail release on missing dist-dynamic ([#966](https://github.com/janus-idp/backstage-plugins/issues/966)) ([647f7b7](https://github.com/janus-idp/backstage-plugins/commit/647f7b7c04db6b694a0a0c16279dd4d18667b86a))
* **feedback-backend:** fix the feedback url for mail and jira ([#1435](https://github.com/janus-idp/backstage-plugins/issues/1435)) ([f3564c1]error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.
```
Turns out manually releasing 1.0.0 ...

```
npm publish --cwd . --access public -w .
```

(see https://issues.redhat.com/browse/RHIDP-2455)

and then manually bumping to 1.0.0...

https://github.com/janus-idp/backstage-plugins/commit/aca1a02f428751932d04452df042b225a5b36201

will not satify the MSR gods :(

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.