### PR TITLE
chore(orchestrator): add missing dev dependencies

### DIFF
--- a/plugins/orchestrator-common/package.json
+++ b/plugins/orchestrator-common/package.json
@@ -48,6 +48,8 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.4",
-    "@hey-api/openapi-ts": "0.34.5"
+    "@hey-api/openapi-ts": "0.34.5",
+    "@openapitools/openapi-generator-cli": "2.7.0",
+    "js-yaml-cli": "0.6.0"
   }
 }

--- a/plugins/orchestrator-common/scripts/openapi.sh
+++ b/plugins/orchestrator-common/scripts/openapi.sh
@@ -19,7 +19,7 @@ openapi_generate() {
     awk '/\/{\(.*?\)}\/g/ {print $0 " // NOSONAR"} !/\/{\(.*?\)}\/g/ {print}' "${REQ_FILE}" > ${TMPFILE} && mv ${TMPFILE} "${REQ_FILE}"
 
     # Docs generation
-    npx --yes @openapitools/openapi-generator-cli@v2.13.1 generate -g asciidoc -i ./src/openapi/openapi.yaml -o ./src/generated/docs/index.adoc
+    npx --yes @openapitools/openapi-generator-cli@v2.7.0 generate -g asciidoc -i ./src/openapi/openapi.yaml -o ./src/generated/docs/index.adoc
     
     npx --yes --package=js-yaml-cli@0.6.0 -- yaml2json -f ${OPENAPI_SPEC_FILE}
 


### PR DESCRIPTION
`script.sh` uses libraries that aren't listed in package.json