### PR TITLE
fix(rbac): improve criteria toggle button readability on dark themes

### DIFF
--- a/plugins/rbac/src/components/ConditionalAccess/ConditionsFormRow.tsx
+++ b/plugins/rbac/src/components/ConditionalAccess/ConditionsFormRow.tsx
@@ -7,7 +7,8 @@ import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import ButtonGroup from '@mui/material/ButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 
 import { ConditionsFormRowFields } from './ConditionsFormRowFields';
 import { conditionButtons, criterias } from './const';
@@ -30,7 +31,7 @@ const useStyles = makeStyles(theme => ({
   criteriaButton: {
     width: '100%',
     textTransform: 'none',
-    color: theme.palette.grey[700],
+    padding: theme.spacing(1),
   },
   addRuleButton: {
     color: theme.palette.primary.light,
@@ -129,10 +130,16 @@ export const ConditionsFormRow = ({
 
   return (
     <Box className={classes.conditionRow} data-testid="conditions-row">
-      <ButtonGroup size="large" className={classes.criteriaButtonGroup}>
+      <ToggleButtonGroup
+        exclusive
+        value={criteria}
+        onChange={(_event, newCriteria) => handleCriteriaChange(newCriteria)}
+        className={classes.criteriaButtonGroup}
+      >
         {conditionButtons.map(({ val, label }) => (
-          <Button
-            variant="outlined"
+          <ToggleButton
+            key={val}
+            value={val}
             style={
               val === criteria
                 ? {
@@ -141,15 +148,13 @@ export const ConditionsFormRow = ({
                   }
                 : {}
             }
-            key={val}
             className={classes.criteriaButton}
-            onClick={() => handleCriteriaChange(val)}
             size="large"
           >
             {label}
-          </Button>
+          </ToggleButton>
         ))}
-      </ButtonGroup>
+      </ToggleButtonGroup>
       {(criteria === criterias.allOf || criteria === criterias.anyOf) && (
         <Box>
           {criteria === criterias.allOf &&


### PR DESCRIPTION
The criteria toggle button (ButtonGroup or ToggleButtonGroup) sets a custom style for the inactive options with a too low contrast.

When removing the color, these button colors were blue by default because all buttons have a blue color by default.

To remove that, I switched to the semantic, more matching ToggleButtonGroup and ToggleButton here so that it matches almost automatically our design.

Here is the sidebar design change (with the latest theme already):

| Before | After |
|---|---|
| ![backstage-light-before](https://github.com/janus-idp/backstage-plugins/assets/139310/adb9f12d-1887-422d-9ae7-df87545cf386) | ![backstage-light-after](https://github.com/janus-idp/backstage-plugins/assets/139310/c3e02906-60c5-46f5-8523-1ddb5f045d61) |
| ![backstage-dark-before](https://github.com/janus-idp/backstage-plugins/assets/139310/b5887dd9-9345-45e4-8ea0-2eaf3fa99346) | ![backstage-dark-after](https://github.com/janus-idp/backstage-plugins/assets/139310/8f9f40fe-0bc4-4b71-ad2f-fa67cc03e1f7) |
| ![rhdh-light-before](https://github.com/janus-idp/backstage-plugins/assets/139310/c1d26fe1-ca94-4146-9b92-29c42ec488bc) | ![rhdh-light-after](https://github.com/janus-idp/backstage-plugins/assets/139310/563e5778-d737-4d53-887b-f2619e6e58ac) |
| ![rhdh-dark-before](https://github.com/janus-idp/backstage-plugins/assets/139310/a0d108f1-857a-44ed-8159-bc42d9a65e7c) | ![rhdh-dark-after](https://github.com/janus-idp/backstage-plugins/assets/139310/bccc488e-d387-43e9-9d8f-2780989973a0) |

/cc @divyanshiGupta @debsmita1 