### PR TITLE
chore(renovate): required dashboard approval for everything

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,9 +17,7 @@
   "npm": {
     "minimumReleaseAge": "1 day"
   },
-  "major": {
-    "dependencyDashboardApproval": true
-  },
+  "dependencyDashboardApproval": true,
   "packageRules": [
     {
       "description": "Do automerge and pin actions in GH workflows, except for versions starting with 0",


### PR DESCRIPTION
Temporarily disable renovate PRs to reduce GH actions jobs