### PR TITLE
chore(renovate): add additional configs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,8 @@
     "minimumReleaseAge": "1 day"
   },
   "dependencyDashboardApproval": true,
+  "recreateWhen": "never",
+  "prCreation": "status-success",
   "packageRules": [
     {
       "description": "Do automerge and pin actions in GH workflows, except for versions starting with 0",
@@ -134,6 +136,43 @@
       "matchCurrentVersion": "0.26.1",
       "groupName": "Keycloak dependency"
     },
+    {
+      "description": "disable updates to the kubernetes client. Lock it down to the same version as Backstage",
+      "enabled": false,
+      "matchDatasources": [
+        "npm"
+      ],
+      "matchCurrentVersion": "0.20.0",
+      "matchPackageNames": [
+        "@kubernetes/client-node"
+      ],
+      "groupName": "Kubernetes client dependency"
+    },    
+    {
+      "description": "disable updates playwright.  Breaking changes in 1.44.1",
+      "enabled": false,
+      "matchDatasources": [
+        "npm"
+      ],
+      "matchCurrentVersion": "1.41.2",
+      "matchPackageNames": [
+        "@playwright/test"
+      ],
+      "groupName": "Playwright test dependency"
+    },    
+    {
+      "description": "disable updates to storybook.  Breaking changes in 7.6.19",
+      "enabled": false,
+      "matchDatasources": [
+        "npm"
+      ],
+      "matchCurrentVersion": "7.5.3",
+      "matchPackageNames": [
+        "@storybook/react-webpack5"
+      ],
+      "groupName": "Storybook react webpack5 dependency"
+    },    
+
     {
       "matchFileNames": [
         "plugins/orchestrator*/**"


### PR DESCRIPTION
Temp settings to manage the noise for now:

* prevent immortal PRs from re-opening
* only create prs if tests pass 
* disable updates to kubernetes-client  since it'll be a while before backstage updates this
* disable updates to test packages that break existing tests