### PR TITLE
feat: switch defaults of the `--embed-as-dependencies` and `in-place` options.

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -123,16 +123,16 @@ export function registerScriptCommand(program: Command) {
     )
     .option(
       '--embed-as-dependencies',
-      'Include embedded packages as private dependencies of backend plugins, instead of merging them with the generated code. Experimental for now, but expected to become the default.',
-      false,
-    )
-    .option('--no-embed-as-dependencies', undefined, true)
-    .option(
-      '--in-place',
-      'Adds the frontend dynamic plugin assets to the `dist-scalprum` folder of the original plugin package. When value is `false` (using `--no-in-place`), it produces the assets in a distinct package located in the `dist-dynamic` sub-folder, as for backend plugins. `true` by default for now, it is expected to become `false` by default.',
+      'Include embedded packages as private dependencies of backend plugins. When value is `false` (using `--no-embed-as-dependencies`), source code of embedded plugins is merged with the generated code, so that the embedded plugin packages are completly erased (only available for legacy reasons: use with care).',
       true,
     )
-    .option('--no-in-place', undefined, false)
+    .option('--no-embed-as-dependencies', undefined, false)
+    .option(
+      '--in-place',
+      'Adds the frontend dynamic plugin assets to the `dist-scalprum` folder of the original plugin package, instead of producing the assets in a distinct package located in the `dist-dynamic` sub-folder, as for backend plugins.',
+      false,
+    )
+    .option('--no-in-place', undefined, true)
     .option(
       '--scalprum-config <file>',
       'Allows retrieving scalprum configuration from an external JSON file, instead of using a `scalprum` field of the `package.json`. Frontend plugins only.',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6307,18 +6307,6 @@
     yml-loader "^2.1.0"
     yn "^4.0.0"
 
-"@janus-idp/shared-react@2.6.3":
-  version "2.6.3"
-  resolved "https://registry.npmjs.org/@janus-idp/shared-react/-/shared-react-2.6.3.tgz#de98b434d19b96197f053095e0c412e3eabc1155"
-  integrity sha512-kQzY4+WXTtArAy9breW7PuWonlT6GbgZEEA+oClkOY5ETl9AW7QKgymNHSdemkIZrx+qJro/xF2yt70skIrBdg==
-  dependencies:
-    "@kubernetes/client-node" "^0.20.0"
-    classnames "^2.3.2"
-    date-fns "^2.30.0"
-    file-saver "^2.0.5"
-    lodash "^4.17.21"
-    mathjs "^11.11.2"
-
 "@jest/console@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.7.0.tgz#cd4822dbdb84529265c5a2bdb529a3c9cc950ffc"


### PR DESCRIPTION
This PR switches the default values of the `--embed-as-dependencies` and `in-place` options:

- `--embed-as-dependencies` becomes `true` by default,
- `--in-place` becomes `false` by default.

These new default values will enable by default the new implementation of the `export-dynamic-plugin` command for both frontend and backend plugins, which brings many usability, validation and robustness enhancements, and has been tested and validated widely while in experimental mode. 

However since the CI builds of the [`backstage-plugins`](https://github.com/janus-idp/backstage-plugins) and [`backstage-showcase`](https://github.com/janus-idp/backstage-showcase) repositories still rely on the old CLI behavior for both frontend and backend plugins, all the calls to the `export-dynamic-plugin` CLI command have already been modified to explicitly keep the old legacy implementation, by adding the `--no-embed-as-dependencies` option for backend plugins and the `--in-place` option for frontend plugins.

So this change here will have no impact on the export process of plugins and wrappers in both [`backstage-plugins`](https://github.com/janus-idp/backstage-plugins) and [`backstage-showcase`](https://github.com/janus-idp/backstage-showcase) GH repositories, but will bring all the enhancements of the CLI command to community users who export their static backstage plugins as dynamic plugins.
 