### PR TITLE
feat(kiali): add tests for the overview page

### DIFF
--- a/plugins/kiali/dev/__fixtures__/general/istioValidations.json
+++ b/plugins/kiali/dev/__fixtures__/general/istioValidations.json
@@ -32,8 +32,8 @@
     },
     "travel-control": {
       "errors": 0,
-      "objectCount": 0,
-      "warnings": 0
+      "objectCount": 1,
+      "warnings": 1
     },
     "travel-portal": {
       "errors": 0,

--- a/plugins/kiali/dev/__fixtures__/namespaces/travel-agency/health/app.json
+++ b/plugins/kiali/dev/__fixtures__/namespaces/travel-agency/health/app.json
@@ -50,7 +50,7 @@
         "desiredReplicas": 1,
         "currentReplicas": 1,
         "availableReplicas": 1,
-        "syncedProxies": 1
+        "syncedProxies": 0
       }
     ],
     "requests": {

--- a/plugins/kiali/dev/__fixtures__/namespaces/travel-control/health/app.json
+++ b/plugins/kiali/dev/__fixtures__/namespaces/travel-control/health/app.json
@@ -4,7 +4,7 @@
       {
         "name": "control",
         "desiredReplicas": 1,
-        "currentReplicas": 1,
+        "currentReplicas": 0,
         "availableReplicas": 1,
         "syncedProxies": 1
       }

--- a/plugins/kiali/src/components/About/AboutUIModal.tsx
+++ b/plugins/kiali/src/components/About/AboutUIModal.tsx
@@ -162,19 +162,19 @@ export const AboutUIModal = (props: AboutUIModalProps) => {
             <Grid item xs={4}>
               Kiali
             </Grid>
-            <Grid item xs={8} data-test={'Kiali'}>
+            <Grid item xs={8} data-test="Kiali">
               {coreVersion || 'Unknown'}
             </Grid>
             <Grid item xs={4}>
               Kiali Container
             </Grid>
-            <Grid item xs={8} data-test={'Kiali container'}>
+            <Grid item xs={8} data-test="Kiali container">
               {containerVersion || 'Unknown'}
             </Grid>
             <Grid item xs={4}>
               Service Mesh
             </Grid>
-            <Grid item xs={8} data-test={'Service Mesh'}>
+            <Grid item xs={8} data-test="Service Mesh">
               {meshVersion || 'Unknown'}
             </Grid>
           </Grid>

--- a/plugins/kiali/src/components/About/AboutUIModal.tsx
+++ b/plugins/kiali/src/components/About/AboutUIModal.tsx
@@ -86,7 +86,12 @@ export const AboutUIModal = (props: AboutUIModalProps) => {
         <Grid item xs={8} key={`component_${name}`}>
           {name}
         </Grid>
-        <Grid item xs={4} key={`component_version_${name}`}>
+        <Grid
+          data-test={`${externalService.name}`}
+          item
+          xs={4}
+          key={`component_version_${name}`}
+        >
           {additionalInfo}
         </Grid>
       </>
@@ -157,19 +162,19 @@ export const AboutUIModal = (props: AboutUIModalProps) => {
             <Grid item xs={4}>
               Kiali
             </Grid>
-            <Grid item xs={8}>
+            <Grid item xs={8} data-test={'Kiali'}>
               {coreVersion || 'Unknown'}
             </Grid>
             <Grid item xs={4}>
               Kiali Container
             </Grid>
-            <Grid item xs={8}>
+            <Grid item xs={8} data-test={'Kiali container'}>
               {containerVersion || 'Unknown'}
             </Grid>
             <Grid item xs={4}>
               Service Mesh
             </Grid>
-            <Grid item xs={8}>
+            <Grid item xs={8} data-test={'Service Mesh'}>
               {meshVersion || 'Unknown'}
             </Grid>
           </Grid>

--- a/plugins/kiali/src/components/MessageCenter/AlertDrawer.tsx
+++ b/plugins/kiali/src/components/MessageCenter/AlertDrawer.tsx
@@ -61,7 +61,7 @@ const noNotificationsMessage = (
 
 export const AlertDrawer = (props: AlertDrawerProps) => {
   return (
-    <Card className={drawer}>
+    <Card className={drawer} data-test={'message-center-modal'}>
       <CardMedia>
         <ItemCardHeader title="MessageCenter" subtitle="" />
       </CardMedia>
@@ -74,6 +74,7 @@ export const AlertDrawer = (props: AlertDrawerProps) => {
                   <AccordionSummary
                     key={`${group.id}_item`}
                     expandIcon={<ExpandMoreRounded />}
+                    data-test={'message-center-summary'}
                   >
                     <Typography>
                       {group.title} {getUnreadMessageLabel(group.messages)}

--- a/plugins/kiali/src/components/MessageCenter/AlertDrawer.tsx
+++ b/plugins/kiali/src/components/MessageCenter/AlertDrawer.tsx
@@ -61,7 +61,7 @@ const noNotificationsMessage = (
 
 export const AlertDrawer = (props: AlertDrawerProps) => {
   return (
-    <Card className={drawer} data-test={'message-center-modal'}>
+    <Card className={drawer} data-test="message-center-modal">
       <CardMedia>
         <ItemCardHeader title="MessageCenter" subtitle="" />
       </CardMedia>
@@ -74,7 +74,7 @@ export const AlertDrawer = (props: AlertDrawerProps) => {
                   <AccordionSummary
                     key={`${group.id}_item`}
                     expandIcon={<ExpandMoreRounded />}
-                    data-test={'message-center-summary'}
+                    data-test="message-center-summary"
                   >
                     <Typography>
                       {group.title} {getUnreadMessageLabel(group.messages)}

--- a/plugins/kiali/src/components/MessageCenter/AlertDrawerGroup.tsx
+++ b/plugins/kiali/src/components/MessageCenter/AlertDrawerGroup.tsx
@@ -59,7 +59,10 @@ export const AlertDrawerGroup = (props: AlertDrawerGroupProps) => {
 
   return (
     <Card elevation={0}>
-      <CardContent style={{ paddingTop: 0 }}>
+      <CardContent
+        style={{ paddingTop: 0 }}
+        data-test={'message-center-messages'}
+      >
         {group.messages.length === 0 && noNotificationsMessage}
         {getMessages().map(message => (
           <AlertDrawerMessage key={message.id} message={message} />
@@ -67,10 +70,18 @@ export const AlertDrawerGroup = (props: AlertDrawerGroupProps) => {
       </CardContent>
       {group.showActions && group.messages.length > 0 && (
         <CardActions>
-          <Button variant="text" onClick={() => markGroupAsRead(group.id)}>
+          <Button
+            data-test={'mark-as-read'}
+            variant="text"
+            onClick={() => markGroupAsRead(group.id)}
+          >
             Mark All Read
           </Button>
-          <Button variant="text" onClick={() => clearGroup(group.id)}>
+          <Button
+            data-test={'clear-all'}
+            variant="text"
+            onClick={() => clearGroup(group.id)}
+          >
             Clear All
           </Button>
         </CardActions>

--- a/plugins/kiali/src/components/MessageCenter/AlertDrawerGroup.tsx
+++ b/plugins/kiali/src/components/MessageCenter/AlertDrawerGroup.tsx
@@ -61,7 +61,7 @@ export const AlertDrawerGroup = (props: AlertDrawerGroupProps) => {
     <Card elevation={0}>
       <CardContent
         style={{ paddingTop: 0 }}
-        data-test={'message-center-messages'}
+        data-test="message-center-messages"
       >
         {group.messages.length === 0 && noNotificationsMessage}
         {getMessages().map(message => (
@@ -71,14 +71,14 @@ export const AlertDrawerGroup = (props: AlertDrawerGroupProps) => {
       {group.showActions && group.messages.length > 0 && (
         <CardActions>
           <Button
-            data-test={'mark-as-read'}
+            data-test="mark-as-read"
             variant="text"
             onClick={() => markGroupAsRead(group.id)}
           >
             Mark All Read
           </Button>
           <Button
-            data-test={'clear-all'}
+            data-test="clear-all"
             variant="text"
             onClick={() => clearGroup(group.id)}
           >

--- a/plugins/kiali/src/components/MessageCenter/AlertDrawerMessage.tsx
+++ b/plugins/kiali/src/components/MessageCenter/AlertDrawerMessage.tsx
@@ -46,7 +46,7 @@ export const AlertDrawerMessage = (props: AlertDrawerMessageProps) => {
 
   return (
     <Card>
-      <CardContent data-test={'drawer-message'}>
+      <CardContent data-test="drawer-message">
         {getIcon(props.message.type)}{' '}
         {props.message.seen ? (
           props.message.content
@@ -70,7 +70,7 @@ export const AlertDrawerMessage = (props: AlertDrawerMessageProps) => {
                 {props.message.showDetail ? 'Hide Detail' : 'Show Detail'}
               </Typography>
             </AccordionSummary>
-            <AccordionDetails data-test={'message-detail'}>
+            <AccordionDetails data-test="message-detail">
               <pre style={{ whiteSpace: 'pre-wrap' }}>
                 {props.message.detail}
               </pre>

--- a/plugins/kiali/src/components/MessageCenter/AlertDrawerMessage.tsx
+++ b/plugins/kiali/src/components/MessageCenter/AlertDrawerMessage.tsx
@@ -46,7 +46,7 @@ export const AlertDrawerMessage = (props: AlertDrawerMessageProps) => {
 
   return (
     <Card>
-      <CardContent>
+      <CardContent data-test={'drawer-message'}>
         {getIcon(props.message.type)}{' '}
         {props.message.seen ? (
           props.message.content
@@ -60,11 +60,17 @@ export const AlertDrawerMessage = (props: AlertDrawerMessageProps) => {
               onClick={() => toggleMessageDetail(props.message)}
               expandIcon={<ExpandMoreRounded />}
             >
-              <Typography>
+              <Typography
+                data-test={
+                  props.message.showDetail
+                    ? 'hide-message-detail'
+                    : 'show-message-detail'
+                }
+              >
                 {props.message.showDetail ? 'Hide Detail' : 'Show Detail'}
               </Typography>
             </AccordionSummary>
-            <AccordionDetails>
+            <AccordionDetails data-test={'message-detail'}>
               <pre style={{ whiteSpace: 'pre-wrap' }}>
                 {props.message.detail}
               </pre>

--- a/plugins/kiali/src/components/MessageCenter/MessageCenter.tsx
+++ b/plugins/kiali/src/components/MessageCenter/MessageCenter.tsx
@@ -92,7 +92,7 @@ export const MessageCenter = (props: { color?: string }) => {
       <Button
         onClick={() => toggleDrawer(true)}
         style={{ marginTop: '-15px' }}
-        data-test={'message-center'}
+        data-test="message-center"
       >
         <Badge
           overlap="circular"

--- a/plugins/kiali/src/components/MessageCenter/MessageCenter.tsx
+++ b/plugins/kiali/src/components/MessageCenter/MessageCenter.tsx
@@ -89,7 +89,11 @@ export const MessageCenter = (props: { color?: string }) => {
   */
   return (
     <>
-      <Button onClick={() => toggleDrawer(true)} style={{ marginTop: '-15px' }}>
+      <Button
+        onClick={() => toggleDrawer(true)}
+        style={{ marginTop: '-15px' }}
+        data-test={'message-center'}
+      >
         <Badge
           overlap="circular"
           badgeContent={

--- a/plugins/kiali/src/components/Validations/ValidationSummary.tsx
+++ b/plugins/kiali/src/components/Validations/ValidationSummary.tsx
@@ -128,6 +128,7 @@ export const ValidationSummary = (props: Props) => {
   return (
     <Tooltip
       aria-label="Validations list"
+      data-test={`validation-icon-${severity()}`}
       placement="right"
       title={tooltipContent()}
     >

--- a/plugins/kiali/src/pages/Kiali/Header/HelpKiali.tsx
+++ b/plugins/kiali/src/pages/Kiali/Header/HelpKiali.tsx
@@ -16,7 +16,7 @@ export const HelpKiali = (props: { color?: string }) => {
 
   return (
     <>
-      <Button onClick={openAbout} style={{ marginTop: '-5px' }}>
+      <Button onClick={openAbout} style={{ marginTop: '-5px' }} data-test={'help-button'} >
         <QuestionCircleIcon color={`${props.color}`} />
       </Button>
       <AboutUIModal

--- a/plugins/kiali/src/pages/Kiali/Header/HelpKiali.tsx
+++ b/plugins/kiali/src/pages/Kiali/Header/HelpKiali.tsx
@@ -19,7 +19,7 @@ export const HelpKiali = (props: { color?: string }) => {
       <Button
         onClick={openAbout}
         style={{ marginTop: '-5px' }}
-        data-test={'help-button'}
+        data-test="help-button"
       >
         <QuestionCircleIcon color={`${props.color}`} />
       </Button>

--- a/plugins/kiali/src/pages/Kiali/Header/HelpKiali.tsx
+++ b/plugins/kiali/src/pages/Kiali/Header/HelpKiali.tsx
@@ -16,7 +16,11 @@ export const HelpKiali = (props: { color?: string }) => {
 
   return (
     <>
-      <Button onClick={openAbout} style={{ marginTop: '-5px' }} data-test={'help-button'} >
+      <Button
+        onClick={openAbout}
+        style={{ marginTop: '-5px' }}
+        data-test={'help-button'}
+      >
         <QuestionCircleIcon color={`${props.color}`} />
       </Button>
       <AboutUIModal

--- a/plugins/kiali/src/pages/Kiali/Header/KialiHeader.tsx
+++ b/plugins/kiali/src/pages/Kiali/Header/KialiHeader.tsx
@@ -24,7 +24,7 @@ export const KialiHeader = () => {
           color="primary"
           icon={<ClusterIcon />}
           label={homeCluster?.name}
-          data-test={'home-cluster'}
+          data-test="home-cluster"
         />
       </Tooltip>
       <HelpKiali />
@@ -36,7 +36,7 @@ export const KialiHeader = () => {
             flexDirection: 'row',
             justifyContent: 'space-between',
           }}
-          data-test={'user'}
+          data-test="user"
         >
           <span style={{ margin: '10px' }}>
             <b>User : </b>

--- a/plugins/kiali/src/pages/Kiali/Header/KialiHeader.tsx
+++ b/plugins/kiali/src/pages/Kiali/Header/KialiHeader.tsx
@@ -24,6 +24,7 @@ export const KialiHeader = () => {
           color="primary"
           icon={<ClusterIcon />}
           label={homeCluster?.name}
+          data-test={'home-cluster'}
         />
       </Tooltip>
       <HelpKiali />
@@ -35,6 +36,7 @@ export const KialiHeader = () => {
             flexDirection: 'row',
             justifyContent: 'space-between',
           }}
+          data-test={'user'}
         >
           <span style={{ margin: '10px' }}>
             <b>User : </b>

--- a/plugins/kiali/src/pages/Kiali/Header/NamespaceSelector.tsx
+++ b/plugins/kiali/src/pages/Kiali/Header/NamespaceSelector.tsx
@@ -56,6 +56,7 @@ export const NamespaceSelector = (props: { page?: boolean }) => {
         onChange={handleChange}
         renderValue={selected => (selected as string[]).join(', ')}
         MenuProps={MenuProps}
+        data-test={'namespace-selector'}
       >
         {(kialiState.namespaces.items || []).map(ns => (
           <MenuItem key={ns.name} value={ns.name}>

--- a/plugins/kiali/src/pages/Kiali/Header/NamespaceSelector.tsx
+++ b/plugins/kiali/src/pages/Kiali/Header/NamespaceSelector.tsx
@@ -56,7 +56,7 @@ export const NamespaceSelector = (props: { page?: boolean }) => {
         onChange={handleChange}
         renderValue={selected => (selected as string[]).join(', ')}
         MenuProps={MenuProps}
-        data-test={'namespace-selector'}
+        data-test="namespace-selector"
       >
         {(kialiState.namespaces.items || []).map(ns => (
           <MenuItem key={ns.name} value={ns.name}>

--- a/plugins/kiali/src/pages/Overview/OverviewCard/NamespaceLabels.tsx
+++ b/plugins/kiali/src/pages/Overview/OverviewCard/NamespaceLabels.tsx
@@ -13,7 +13,7 @@ export const NamespaceLabels = (props: NamespaceLabelsprops) => {
     ? `${Object.entries(props.labels).length}`
     : 'No';
   const tooltipTitle = (
-    <ul>
+    <ul data-test={'namespace-labels'}>
       {Object.entries(props.labels || []).map(([key, value]) => (
         <li key={key}>
           {key}={value}
@@ -27,7 +27,7 @@ export const NamespaceLabels = (props: NamespaceLabelsprops) => {
         {labelsLength} label{labelsLength !== '1' ? 's' : ''}
       </div>
       <Tooltip title={tooltipTitle} placement="right">
-        <span>
+        <span data-test={'labels-info-icon'}>
           <KialiIcon.Info className={infoStyle} />
         </span>
       </Tooltip>

--- a/plugins/kiali/src/pages/Overview/OverviewCard/NamespaceLabels.tsx
+++ b/plugins/kiali/src/pages/Overview/OverviewCard/NamespaceLabels.tsx
@@ -13,7 +13,7 @@ export const NamespaceLabels = (props: NamespaceLabelsprops) => {
     ? `${Object.entries(props.labels).length}`
     : 'No';
   const tooltipTitle = (
-    <ul data-test={'namespace-labels'}>
+    <ul data-test="namespace-labels">
       {Object.entries(props.labels || []).map(([key, value]) => (
         <li key={key}>
           {key}={value}
@@ -27,7 +27,7 @@ export const NamespaceLabels = (props: NamespaceLabelsprops) => {
         {labelsLength} label{labelsLength !== '1' ? 's' : ''}
       </div>
       <Tooltip title={tooltipTitle} placement="right">
-        <span data-test={'labels-info-icon'}>
+        <span data-test="labels-info-icon">
           <KialiIcon.Info className={infoStyle} />
         </span>
       </Tooltip>

--- a/plugins/kiali/src/pages/Overview/OverviewCard/OverviewCard.tsx
+++ b/plugins/kiali/src/pages/Overview/OverviewCard/OverviewCard.tsx
@@ -111,7 +111,7 @@ export const OverviewCard = (props: OverviewCardProps) => {
   };
 
   return (
-    <Card>
+    <Card data-test={`overview-card-${props.namespace.name}`}>
       {!props.entity && <NamespaceHeader {...props} />}
       <CardContent>
         {!props.entity && isMultiCluster && props.namespace.cluster && (

--- a/plugins/kiali/src/pages/Overview/OverviewCard/OverviewCard.tsx
+++ b/plugins/kiali/src/pages/Overview/OverviewCard/OverviewCard.tsx
@@ -106,6 +106,7 @@ export const OverviewCard = (props: OverviewCardProps) => {
         errors={validations.errors}
         warnings={validations.warnings}
         objectCount={validations.objectCount}
+        data-test={'validation-summary'}
       />
     );
   };

--- a/plugins/kiali/src/pages/Overview/OverviewCard/OverviewCard.tsx
+++ b/plugins/kiali/src/pages/Overview/OverviewCard/OverviewCard.tsx
@@ -106,7 +106,7 @@ export const OverviewCard = (props: OverviewCardProps) => {
         errors={validations.errors}
         warnings={validations.warnings}
         objectCount={validations.objectCount}
-        data-test={'validation-summary'}
+        data-test="validation-summary"
       />
     );
   };

--- a/plugins/kiali/src/pages/Overview/OverviewStatus.tsx
+++ b/plugins/kiali/src/pages/Overview/OverviewStatus.tsx
@@ -43,8 +43,10 @@ export class OverviewStatus extends React.Component<Props, {}> {
       items.push(`and ${length - items.length} more...`);
     }
     const tooltipContent = (
-      <div>
-        <strong>{this.props.status.name}</strong>
+      <div data-test={'overview-status'}>
+        <strong data-test={`${this.props.status.name}-status`}>
+          {this.props.status.name}
+        </strong>
         {items.map((app, idx) => {
           return (
             <div

--- a/plugins/kiali/src/pages/Overview/OverviewStatus.tsx
+++ b/plugins/kiali/src/pages/Overview/OverviewStatus.tsx
@@ -43,7 +43,7 @@ export class OverviewStatus extends React.Component<Props, {}> {
       items.push(`and ${length - items.length} more...`);
     }
     const tooltipContent = (
-      <div data-test={'overview-status'}>
+      <div data-test="overview-status">
         <strong data-test={`${this.props.status.name}-status`}>
           {this.props.status.name}
         </strong>

--- a/plugins/kiali/tests/kialiHelper.ts
+++ b/plugins/kiali/tests/kialiHelper.ts
@@ -1,5 +1,7 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
+export { kialiData } from '../dev/__fixtures__';
+
 export class Common {
   page: Page;
 

--- a/plugins/kiali/tests/kialiPage.spec.ts
+++ b/plugins/kiali/tests/kialiPage.spec.ts
@@ -71,17 +71,8 @@ test.describe('Kiali page', () => {
       );
     });
 
-    test('Debug info can be opened', async () => {
-      await page.click('data-test=help-button');
-      await page.click('text=View Debug Info');
-      await expect(
-        page.locator('css=[aria-describedby="Debug information"]'),
-      ).toBeVisible();
-    });
-
     test('About page can be opened', async () => {
       await page.click('data-test=help-button');
-      await page.click('text=About');
       await expect(page.locator('data-test=Kiali')).toContainText(
         STATUS.status['Kiali version'],
       );

--- a/plugins/kiali/tests/kialiPage.spec.ts
+++ b/plugins/kiali/tests/kialiPage.spec.ts
@@ -168,5 +168,20 @@ test.describe('Kiali page', () => {
         ).toHaveCount(1);
       }
     });
+
+    test('Namespace card should have labels', async () => {
+      const ns = visibleNamespaces[0];
+      const ns_card = await page.locator(`data-test=overview-card-${ns.name}`);
+      const icon = await ns_card.locator('data-test=labels-info-icon');
+      icon.hover();
+      for (const [key, value] of Object.entries(ns.labels)) {
+        await expect(
+          page.locator('data-test=namespace-labels > li'),
+        ).toHaveText(`${key}=${value}`);
+      }
+      await expect(page.locator('#labels_info')).toContainText(
+        `${Object.entries(ns.labels).length} labels`,
+      );
+    });
   });
 });

--- a/plugins/kiali/tests/kialiPage.spec.ts
+++ b/plugins/kiali/tests/kialiPage.spec.ts
@@ -173,13 +173,18 @@ test.describe('Kiali page', () => {
       const ns = visibleNamespaces[0];
       const ns_card = await page.locator(`data-test=overview-card-${ns.name}`);
       const icon = await ns_card.locator('data-test=labels-info-icon');
-      icon.hover();
+      await icon.hover();
+      let list = await page.locator('data-test=namespace-labels');
+
+      // Wait for the list to appear
+      await page.waitForSelector('data-test=namespace-labels');
+
       for (const [key, value] of Object.entries(ns.labels)) {
-        await expect(
-          page.locator('data-test=namespace-labels > li'),
-        ).toHaveText(`${key}=${value}`);
+        await icon.hover({ force: true }).then(async () => {
+          await expect(list).toContainText(`${key}=${value}`);
+        });
       }
-      await expect(page.locator('#labels_info')).toContainText(
+      await expect(ns_card.locator('#labels_info')).toContainText(
         `${Object.entries(ns.labels).length} labels`,
       );
     });

--- a/plugins/kiali/tests/kialiPage.spec.ts
+++ b/plugins/kiali/tests/kialiPage.spec.ts
@@ -1,0 +1,80 @@
+import { expect, Page, test } from '@playwright/test';
+
+import CONFIG from '../dev/__fixtures__/general/config.json';
+import NAMESPACES from '../dev/__fixtures__/general/namespaces.json';
+import { Common } from './kialiHelper';
+
+function filterByIstioInjectionEnabled(jsonArray: any): any {
+  return jsonArray.filter(
+    json =>
+      (json.labels && json.labels['istio-injection'] === 'enabled') ||
+      (json.name && json.name === 'istio-system'),
+  );
+}
+const visibleNamespaces = filterByIstioInjectionEnabled(NAMESPACES);
+
+test.describe('Kiali page', () => {
+  let page: Page;
+  let common: Common;
+  test.describe('overview', () => {
+    test.beforeEach(async ({ browser }) => {
+      const context = await browser.newContext();
+      page = await context.newPage();
+      common = new Common(page);
+      await common.loginAsGuest();
+    });
+
+    test('Home cluster is visible', async () => {
+      await expect(page.locator('data-test=home-cluster')).toHaveText(
+        CONFIG.clusters.Kubernetes.name,
+      );
+    });
+
+    test('Debug info can be opened', async () => {
+      await page.click('data-test=help-button');
+      await page.click('text=View Debug Info');
+      await expect(
+        page.locator('css=[aria-describedby="Debug information"]'),
+      ).toBeVisible();
+    });
+
+    test('User is visible', async () => {
+      if (CONFIG.authStrategy === 'anonymous') {
+        await expect(page.locator('data-test=user')).toHaveText(
+          'User : anonymous',
+        );
+      }
+      // There could be an else branch with non-anonymous auth strategies, but there is not enough test data in the fixtures for this.
+    });
+
+    test('Check namespaces visible to Kiali', async () => {
+      await page.click('data-test=namespace-selector');
+      for (const ns of visibleNamespaces) {
+        await expect(page.locator(`ul[role="listbox"]`)).toContainText(ns.name);
+      }
+      await expect(page.locator('ul[role="listbox"] > li')).toHaveCount(
+        visibleNamespaces.length,
+      );
+    });
+
+    test('No namespaces are selected', async () => {
+      await page.click('data-test=namespace-selector');
+      for (const ns of visibleNamespaces) {
+        await page.click(`ul[role="listbox"] > li:has-text("${ns.name}")`);
+      }
+      for (const ns of visibleNamespaces) {
+        await expect(
+          page.locator(`data-test=overview-card-${ns.name}`),
+        ).toHaveCount(0);
+      }
+    });
+
+    test('All namespaces are selected', async () => {
+      for (const ns of visibleNamespaces) {
+        await expect(
+          page.locator(`data-test=overview-card-${ns.name}`),
+        ).toHaveCount(1);
+      }
+    });
+  });
+});

--- a/plugins/kiali/tests/kialiPage.spec.ts
+++ b/plugins/kiali/tests/kialiPage.spec.ts
@@ -21,14 +21,14 @@ async function checkReportedItems(
 
   const icon = await ns_card.locator('data-test=overview-app-health');
   await icon.hover();
-  let list = await page.locator('data-test=overview-status');
+  const list = await page.locator('data-test=overview-status');
 
   // Wait for the list to appear
   await page.waitForSelector('data-test=overview-status');
 
   let i = 0;
   for (const object of Object.entries(objects)) {
-    if (i == 5) {
+    if (i === 5) {
       break;
     }
     await icon.hover({ force: true }).then(async () => {
@@ -36,7 +36,7 @@ async function checkReportedItems(
     });
     i++;
   }
-  let expected = type == 'app' ? 'application' : type;
+  const expected = type === 'app' ? 'application' : type;
   await expect(
     ns_card.locator(`data-test=overview-type-${type}`),
   ).toContainText(`${Object.entries(objects).length} ${expected}s`);
@@ -201,7 +201,7 @@ test.describe('Kiali page', () => {
       const ns_card = await page.locator(`data-test=overview-card-${ns.name}`);
       const icon = await ns_card.locator('data-test=labels-info-icon');
       await icon.hover();
-      let list = await page.locator('data-test=namespace-labels');
+      const list = await page.locator('data-test=namespace-labels');
 
       // Wait for the list to appear
       await page.waitForSelector('data-test=namespace-labels');


### PR DESCRIPTION
I added some tests for the header and also for the Overview cards. Links to other pages and graphs cannot be tested yet, as they do not work properly.