### PR TITLE
fix(topology): remove check for catalog entity permission

### DIFF
--- a/plugins/topology/package.json
+++ b/plugins/topology/package.json
@@ -29,7 +29,6 @@
     "@backstage/catalog-model": "^1.4.5",
     "@backstage/core-components": "^0.14.6",
     "@backstage/core-plugin-api": "^1.9.2",
-    "@backstage/plugin-catalog-common": "^1.0.23",
     "@backstage/plugin-catalog-react": "^1.11.3",
     "@backstage/plugin-kubernetes": "^0.11.9",
     "@backstage/plugin-kubernetes-common": "^0.7.5",

--- a/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
+++ b/plugins/topology/src/components/Topology/TopologyViewWorkloadComponent.tsx
@@ -25,7 +25,6 @@ import TopologyToolbar from './TopologyToolbar';
 
 import './TopologyToolbar.css';
 
-import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
 import { usePermission } from '@backstage/plugin-permission-react';
 
 import { topologyViewPermission } from '@janus-idp/backstage-plugin-topology-common';
@@ -56,11 +55,6 @@ const TopologyViewWorkloadComponent = ({
 
   const topologyViewPermissionResult = usePermission({
     permission: topologyViewPermission,
-  });
-
-  const catalogEntityPermissionResult = usePermission({
-    permission: catalogEntityReadPermission,
-    resourceRef: catalogEntityReadPermission.resourceType,
   });
 
   const allErrors: ClusterErrors = [
@@ -117,6 +111,21 @@ const TopologyViewWorkloadComponent = ({
 
   const isDataModelEmpty = loaded && dataModel?.nodes?.length === 0;
 
+  const getTopologyState = () => {
+    if (isDataModelEmpty) {
+      return <TopologyEmptyState />;
+    }
+    if (!topologyViewPermissionResult.allowed) {
+      return (
+        <TopologyEmptyState
+          title="Permission required"
+          description="To view Topology, contact your administrator to give you the topology.view.read permission"
+        />
+      );
+    }
+    return <VisualizationSurface state={{ selectedIds: [selectedId] }} />;
+  };
+
   return (
     <>
       {allErrors && allErrors.length > 0 && (
@@ -140,18 +149,7 @@ const TopologyViewWorkloadComponent = ({
             sideBarOpen={sideBarOpen}
             minSideBarSize="400px"
           >
-            {isDataModelEmpty ||
-            !(
-              topologyViewPermissionResult.allowed &&
-              catalogEntityPermissionResult.allowed
-            ) ? (
-              <TopologyEmptyState
-                title="Permission required"
-                description="To view Topology, contact your administrator to give you the topology.view.read and catalog.entity.read permissions"
-              />
-            ) : (
-              <VisualizationSurface state={{ selectedIds: [selectedId] }} />
-            )}
+            {getTopologyState()}
           </TopologyView>
         )}
       </InfoCard>


### PR DESCRIPTION
## Description

There is an issue where using a conditional policy that involves the catalog entity read permission will cause an error to be thrown when attempting to access the Topology page. This PR aims to remove the catalog entity read permission check from the Topology page which in turn will fix the error. 

# Fixes

- Fixes: [RHIDP-2594](https://issues.redhat.com/browse/RHIDP-2594)