### PR TITLE
fix(orchestrator): fix error handling in case data index failed to start

### DIFF
--- a/plugins/orchestrator-backend/src/service/OrchestratorService.test.ts
+++ b/plugins/orchestrator-backend/src/service/OrchestratorService.test.ts
@@ -141,17 +141,13 @@ describe('OrchestratorService', () => {
     });
 
     it('should throw error when data index returns error', async () => {
-      let err: Error | null = null;
       const errMsg = 'Failed to load instances';
       dataIndexServiceMock.fetchInstances = jest.fn().mockImplementation(() => {
         throw new Error(errMsg);
       });
-      try {
-        await orchestratorService.fetchInstances({});
-      } catch (err_) {
-        err = err_ as Error;
-      }
-      expect(err?.message).toEqual(errMsg);
+
+      const promise = orchestratorService.fetchInstances({});
+      await expect(promise).rejects.toThrow(errMsg);
     });
 
     it('should execute the operation', async () => {
@@ -172,19 +168,14 @@ describe('OrchestratorService', () => {
     });
 
     it('should throw error when data index returns error', async () => {
-      let err: Error | null = null;
       const errMsg = 'Failed to get instances total count';
       dataIndexServiceMock.fetchInstancesTotalCount = jest
         .fn()
         .mockImplementation(() => {
           throw new Error(errMsg);
         });
-      try {
-        await orchestratorService.fetchInstancesTotalCount();
-      } catch (err_) {
-        err = err_ as Error;
-      }
-      expect(err?.message).toEqual(errMsg);
+      const promise = orchestratorService.fetchInstancesTotalCount();
+      await expect(promise).rejects.toThrow(errMsg);
     });
 
     it('should execute the operation', async () => {
@@ -205,19 +196,15 @@ describe('OrchestratorService', () => {
     });
 
     it('should throw error when data index returns error', async () => {
-      let err: Error | null = null;
       const errMsg = 'Failed to get workflows overview';
       sonataFlowServiceMock.fetchWorkflowOverviews = jest
         .fn()
         .mockImplementation(() => {
           throw new Error(errMsg);
         });
-      try {
-        await orchestratorService.fetchWorkflowOverviews({});
-      } catch (err_) {
-        err = err_ as Error;
-      }
-      expect(err?.message).toEqual(errMsg);
+
+      const promise = orchestratorService.fetchWorkflowOverviews({});
+      await expect(promise).rejects.toThrow();
     });
 
     it('should execute the operation', async () => {

--- a/plugins/orchestrator-backend/src/service/OrchestratorService.test.ts
+++ b/plugins/orchestrator-backend/src/service/OrchestratorService.test.ts
@@ -140,8 +140,21 @@ describe('OrchestratorService', () => {
       jest.clearAllMocks();
     });
 
-    it('should execute the operation when the cache is not empty', async () => {
-      workflowCacheServiceMock.isEmpty = jest.fn().mockReturnValue(false);
+    it('should throw error when data index returns error', async () => {
+      let err: Error | null = null;
+      const errMsg = 'Failed to load instances';
+      dataIndexServiceMock.fetchInstances = jest.fn().mockImplementation(() => {
+        throw new Error(errMsg);
+      });
+      try {
+        await orchestratorService.fetchInstances({});
+      } catch (err_) {
+        err = err_ as Error;
+      }
+      expect(err?.message).toEqual(errMsg);
+    });
+
+    it('should execute the operation', async () => {
       dataIndexServiceMock.fetchInstances = jest
         .fn()
         .mockResolvedValue(instances);
@@ -151,15 +164,6 @@ describe('OrchestratorService', () => {
       expect(result).toHaveLength(instances.length);
       expect(dataIndexServiceMock.fetchInstances).toHaveBeenCalled();
     });
-
-    it('should not execute the operation when the cache is empty', async () => {
-      workflowCacheServiceMock.isEmpty = jest.fn().mockReturnValue(true);
-
-      const result = await orchestratorService.fetchInstances({});
-
-      expect(result).toHaveLength(0);
-      expect(dataIndexServiceMock.fetchInstances).not.toHaveBeenCalled();
-    });
   });
 
   describe('fetchInstancesTotalCount', () => {
@@ -167,8 +171,23 @@ describe('OrchestratorService', () => {
       jest.clearAllMocks();
     });
 
-    it('should execute the operation when the cache is not empty', async () => {
-      workflowCacheServiceMock.isEmpty = jest.fn().mockReturnValue(false);
+    it('should throw error when data index returns error', async () => {
+      let err: Error | null = null;
+      const errMsg = 'Failed to get instances total count';
+      dataIndexServiceMock.fetchInstancesTotalCount = jest
+        .fn()
+        .mockImplementation(() => {
+          throw new Error(errMsg);
+        });
+      try {
+        await orchestratorService.fetchInstancesTotalCount();
+      } catch (err_) {
+        err = err_ as Error;
+      }
+      expect(err?.message).toEqual(errMsg);
+    });
+
+    it('should execute the operation', async () => {
       dataIndexServiceMock.fetchInstancesTotalCount = jest
         .fn()
         .mockResolvedValue(instances.length);
@@ -178,17 +197,6 @@ describe('OrchestratorService', () => {
       expect(result).toBe(instances.length);
       expect(dataIndexServiceMock.fetchInstancesTotalCount).toHaveBeenCalled();
     });
-
-    it('should not execute the operation when the cache is empty', async () => {
-      workflowCacheServiceMock.isEmpty = jest.fn().mockReturnValue(true);
-
-      const result = await orchestratorService.fetchInstancesTotalCount();
-
-      expect(result).toBe(0);
-      expect(
-        dataIndexServiceMock.fetchInstancesTotalCount,
-      ).not.toHaveBeenCalled();
-    });
   });
 
   describe('fetchWorkflowOverviews', () => {
@@ -196,8 +204,23 @@ describe('OrchestratorService', () => {
       jest.clearAllMocks();
     });
 
-    it('should execute the operation when the cache is not empty', async () => {
-      workflowCacheServiceMock.isEmpty = jest.fn().mockReturnValue(false);
+    it('should throw error when data index returns error', async () => {
+      let err: Error | null = null;
+      const errMsg = 'Failed to get workflows overview';
+      sonataFlowServiceMock.fetchWorkflowOverviews = jest
+        .fn()
+        .mockImplementation(() => {
+          throw new Error(errMsg);
+        });
+      try {
+        await orchestratorService.fetchWorkflowOverviews({});
+      } catch (err_) {
+        err = err_ as Error;
+      }
+      expect(err?.message).toEqual(errMsg);
+    });
+
+    it('should execute the operation', async () => {
       sonataFlowServiceMock.fetchWorkflowOverviews = jest
         .fn()
         .mockResolvedValue(workflowOverviews);
@@ -206,17 +229,6 @@ describe('OrchestratorService', () => {
 
       expect(result).toHaveLength(workflowOverviews.length);
       expect(sonataFlowServiceMock.fetchWorkflowOverviews).toHaveBeenCalled();
-    });
-
-    it('should not execute the operation when the cache is empty', async () => {
-      workflowCacheServiceMock.isEmpty = jest.fn().mockReturnValue(true);
-
-      const result = await orchestratorService.fetchWorkflowOverviews({});
-
-      expect(result).toHaveLength(0);
-      expect(
-        sonataFlowServiceMock.fetchWorkflowOverviews,
-      ).not.toHaveBeenCalled();
     });
   });
 

--- a/plugins/orchestrator-backend/src/service/OrchestratorService.ts
+++ b/plugins/orchestrator-backend/src/service/OrchestratorService.ts
@@ -54,9 +54,6 @@ export class OrchestratorService {
   public async fetchInstances(args: {
     pagination?: Pagination;
   }): Promise<ProcessInstance[]> {
-    if (this.workflowCacheService.isEmpty()) {
-      return [];
-    }
     return await this.dataIndexService.fetchInstances({
       definitionIds: this.workflowCacheService.definitionIds,
       pagination: args.pagination,
@@ -64,9 +61,6 @@ export class OrchestratorService {
   }
 
   public async fetchInstancesTotalCount(): Promise<number> {
-    if (this.workflowCacheService.isEmpty()) {
-      return 0;
-    }
     return await this.dataIndexService.fetchInstancesTotalCount(
       this.workflowCacheService.definitionIds,
     );
@@ -149,9 +143,6 @@ export class OrchestratorService {
   public async fetchWorkflowOverviews(args: {
     pagination?: Pagination;
   }): Promise<WorkflowOverview[] | undefined> {
-    if (this.workflowCacheService.isEmpty()) {
-      return [];
-    }
     return await this.sonataFlowService.fetchWorkflowOverviews({
       definitionIds: this.workflowCacheService.definitionIds,
       pagination: args.pagination,


### PR DESCRIPTION
https://issues.redhat.com/browse/FLPATH-1381
resolved the issue by calling the data index also when the cache is empty, so it'll fail in case data index isn't available