### PR TITLE
fix(cli): fix the removal of type definitions by `export-dynamic`.

### DIFF
--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-code.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-code.ts
@@ -346,6 +346,9 @@ export async function backend(
   // Remove the `dist` folder of the original plugin root folder and rebuild it,
   // since it has been compiled with dynamic-specific settings.
   await fs.remove(paths.resolveTarget('dist'));
+  if (roleInfo.output.includes('types')) {
+    outputs.add(Output.types);
+  }
   await buildPackage({
     outputs,
     minify: Boolean(opts.minify),


### PR DESCRIPTION
This PR fixes the erroneous removal of `dist/*.d.ts` files by the `export-dynamic` command, when used on backend plugins with the `no-embed-as-dependencies` option.
