### PR TITLE
fix: missing postversion script is several plugins and missing turbo dependency

### DIFF
--- a/plugins/feedback-backend/dist-dynamic/package.json
+++ b/plugins/feedback-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-feedback-backend-dynamic",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/plugins/feedback-backend/package.json
+++ b/plugins/feedback-backend/package.json
@@ -36,6 +36,7 @@
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
+    "postversion": "yarn run export-dynamic",
     "tsc": "tsc",
     "export-dynamic": "janus-cli package export-dynamic-plugin --no-embed-as-dependencies"
   },

--- a/plugins/kiali-backend/dist-dynamic/package.json
+++ b/plugins/kiali-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-kiali-backend-dynamic",
-  "version": "1.10.21",
+  "version": "1.10.22",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/plugins/kiali-backend/package.json
+++ b/plugins/kiali-backend/package.json
@@ -37,6 +37,7 @@
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
+    "postversion": "yarn run export-dynamic",
     "export-dynamic": "janus-cli package export-dynamic-plugin --no-embed-as-dependencies"
   },
   "configSchema": "config.d.ts",

--- a/plugins/kubernetes-actions/dist-dynamic/package.json
+++ b/plugins/kubernetes-actions/dist-dynamic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-scaffolder-backend-module-kubernetes-dynamic",
   "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/plugins/kubernetes-actions/package.json
+++ b/plugins/kubernetes-actions/package.json
@@ -38,6 +38,7 @@
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
+    "postversion": "yarn run export-dynamic",
     "export-dynamic": "janus-cli package export-dynamic-plugin --no-embed-as-dependencies"
   },
   "dependencies": {

--- a/plugins/nexus-repository-manager/turbo.json
+++ b/plugins/nexus-repository-manager/turbo.json
@@ -13,9 +13,6 @@
     },
     "test": {
       "dependsOn": ["generate"]
-    },
-    "export-dynamic": {
-      "dependsOn": ["generate"]
     }
   }
 }

--- a/plugins/scaffolder-annotator-action/dist-dynamic/package.json
+++ b/plugins/scaffolder-annotator-action/dist-dynamic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-scaffolder-backend-module-annotator-dynamic",
   "description": "The annotator module for @backstage/plugin-scaffolder-backend",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-annotator-action/package.json
+++ b/plugins/scaffolder-annotator-action/package.json
@@ -37,6 +37,7 @@
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
+    "postversion": "yarn run export-dynamic",
     "export-dynamic": "janus-cli package export-dynamic-plugin --no-embed-as-dependencies",
     "lodash": "^4.17.21",
     "tsc": "tsc"

--- a/plugins/servicenow-actions/turbo.json
+++ b/plugins/servicenow-actions/turbo.json
@@ -13,9 +13,6 @@
     },
     "test": {
       "dependsOn": ["generate"]
-    },
-    "export-dynamic": {
-      "dependsOn": ["generate"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,8 @@
       "outputs": ["coverage/**"]
     },
     "export-dynamic": {
-      "cache": false
+      "cache": false,
+      "dependsOn": ["tsc"]
     },
     "lint": {},
     "lint:fix": {},


### PR DESCRIPTION
Fix missing postversion script is several plugins, as well as a missing dependency in the turbo file between the `export-dynamic` task and the `tsc` task.