### PR TITLE
fix(kiali): assets missing in dist

### DIFF
--- a/plugins/bulk-import-backend/package.json
+++ b/plugins/bulk-import-backend/package.json
@@ -58,7 +58,7 @@
     "@backstage/plugin-permission-common": "^0.8.0",
     "@backstage/plugin-permission-node": "^0.8.0",
     "@janus-idp/backstage-plugin-audit-log-node": "1.4.0",
-    "@janus-idp/backstage-plugin-bulk-import-common": "1.0.1",
+    "@janus-idp/backstage-plugin-bulk-import-common": "1.0.0",
     "@octokit/auth-app": "^6.0.3",
     "@octokit/core": "^5.1.0",
     "@octokit/rest": "^20.0.2",

--- a/plugins/kiali/dev/index.tsx
+++ b/plugins/kiali/dev/index.tsx
@@ -1,3 +1,5 @@
+/// <reference types="@backstage/cli/asset-types" />
+
 import React from 'react';
 
 import { Content, InfoCard, Page } from '@backstage/core-components';

--- a/plugins/kiali/src/components/Logos/Logos.tsx
+++ b/plugins/kiali/src/components/Logos/Logos.tsx
@@ -1,26 +1,22 @@
 import React from 'react';
 
+import GraphqlIcon from '../../assets/img/api/graphql.svg';
+import GrpcIcon from '../../assets/img/api/grpc.svg';
+import RestIcon from '../../assets/img/api/rest.svg';
+import GoLogo from '../../assets/img/runtime/go.svg';
+import JVMLogo from '../../assets/img/runtime/java.svg';
+import MicroProfileLogo from '../../assets/img/runtime/microprofile.svg';
+import NodejsLogo from '../../assets/img/runtime/nodejs.svg';
+import QuarkusLogo from '../../assets/img/runtime/quarkus.svg';
+import SpringBootLogo from '../../assets/img/runtime/spring-boot.svg';
+import ThorntailLogo from '../../assets/img/runtime/thorntail.svg';
+import TomcatLogo from '../../assets/img/runtime/tomcat.svg';
+import VertxLogo from '../../assets/img/runtime/vertx.svg';
 import { kialiStyle } from '../../styles/StyleUtils';
 
 const iconStyle = kialiStyle({
   height: '1.5rem',
 });
-
-const GraphqlIcon = require('../../assets/img/api/graphql.svg') as string;
-const GrpcIcon = require('../../assets/img/api/grpc.svg') as string;
-const RestIcon = require('../../assets/img/api/rest.svg') as string;
-const GoLogo = require('../../assets/img/runtime/go.svg') as string;
-const JVMLogo = require('../../assets/img/runtime/java.svg') as string;
-const MicroProfileLogo =
-  require('../../assets/img/runtime/microprofile.svg') as string;
-const NodejsLogo = require('../../assets/img/runtime/nodejs.svg') as string;
-const QuarkusLogo = require('../../assets/img/runtime/quarkus.svg') as string;
-const SpringBootLogo =
-  require('../../assets/img/runtime/spring-boot.svg') as string;
-const ThorntailLogo =
-  require('../../assets/img/runtime/thorntail.svg') as string;
-const TomcatLogo = require('../../assets/img/runtime/tomcat.svg') as string;
-const VertxLogo = require('../../assets/img/runtime/vertx.svg') as string;
 
 const renderLogo = (
   name: string,

--- a/plugins/kiali/src/components/MTls/MTLSIcon.tsx
+++ b/plugins/kiali/src/components/MTls/MTLSIcon.tsx
@@ -2,13 +2,10 @@ import * as React from 'react';
 
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 
-const fullIcon = require('../../assets/img/mtls-status-full.svg') as string;
-const hollowIcon =
-  require('../../assets/img/mtls-status-partial.svg') as string;
-const fullIconDark =
-  require('../../assets/img/mtls-status-full-dark.svg') as string;
-const hollowIconDark =
-  require('../../assets/img/mtls-status-partial-dark.svg') as string;
+import fullIconDark from '../../assets/img/mtls-status-full-dark.svg';
+import fullIcon from '../../assets/img/mtls-status-full.svg';
+import hollowIconDark from '../../assets/img/mtls-status-partial-dark.svg';
+import hollowIcon from '../../assets/img/mtls-status-partial.svg';
 
 export { fullIcon, hollowIcon, fullIconDark, hollowIconDark };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5816,13 +5816,6 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@janus-idp/backstage-plugin-bulk-import-common@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@janus-idp/backstage-plugin-bulk-import-common/-/backstage-plugin-bulk-import-common-0.2.0.tgz#b1a3c12ef4e7e21c34feaab2d0808d0b39ce14be"
-  integrity sha512-Y1m0Ev/U9SLIBma3Ypx5JW0C+kc3R6tB8bE4uPqjsrJCq9tdbvXwsifY3nB8p+A+Y9ZSOK/kJLzqJBRUdG3WHA==
-  dependencies:
-    "@backstage/plugin-permission-common" "^0.8.0"
-
 "@janus-idp/cli@1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@janus-idp/cli/-/cli-1.13.0.tgz#acdd10ad3239f3c8951caebd3d4611b6982036f6"
@@ -31618,16 +31611,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -31722,7 +31706,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -31735,13 +31719,6 @@ strip-ansi@5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -34535,7 +34512,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -34548,15 +34525,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
close #1527

---

I don't know why `require` assets are not transformed by backstage's build config, and `kiali` is not included in `app`, so `/// <reference types="@backstage/cli/asset-types" />` must be add somewhere in the plugin itself, so I add it in `plugins/kiali/dev/index.tsx`, after this change all assets are included in `dist/assets` correctly now.

<img width="430" alt="image" src="https://github.com/janus-idp/backstage-plugins/assets/8336744/85ce83b0-bc08-45f3-b611-19dea7cc29e7">
