### PR TITLE
[WIP]feat(orchestrator): Orchestrator frontend permission support

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -79,4 +79,36 @@ catalog:
       target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates.yaml
 
 dynamicPlugins:
-  frontend: {}
+  frontend:
+    janus.dynamic-frontend-plugin:
+      dynamicRoutes:
+        - path: '/settings'
+          importName: 'UserSettingsPage'
+          module: 'UserSettings'
+        - path: '/tech-radar'
+          width: 1500
+          height: 800
+          importName: 'TechRadarPage'
+          module: 'TechRadar'
+        - path: '/create'
+          importName: 'ScaffolderPage'
+          module: 'Scaffolder'
+      routeBindings:
+        - bindTarget: 'catalogPlugin.externalRoutes'
+          bindMap:
+            createComponent: 'remotePlugins.Scaffolder.scaffolderPlugin.routes.root'
+            viewTechDoc: 'techdocsPlugin.routes.docRoot'
+        - bindTarget: 'remotePlugins.Scaffolder.scaffolderPlugin.externalRoutes'
+          bindMap:
+            registerComponent: 'catalogImportPlugin.routes.importPage'
+
+orchestrator:
+  sonataFlowService:
+    baseUrl: http://localhost
+    port: 8099
+    autoStart: true
+    workflowsSource:
+      gitRepositoryUrl: https://github.com/parodos-dev/backstage-orchestrator-workflows
+      localPath: /tmp/orchestrator/repository
+  dataIndexService:
+    url: http://localhost:8099

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -36,7 +36,6 @@ import { TechRadarPage } from '@backstage-community/plugin-tech-radar';
 import { getThemes } from '@redhat-developer/red-hat-developer-hub-theme';
 
 import { OrchestratorPage } from '@janus-idp/backstage-plugin-orchestrator';
-import { OrchestratorPlugin } from '@janus-idp/backstage-plugin-orchestrator';
 
 import { apis } from './apis';
 import { entityPage } from './components/catalog/EntityPage';

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -35,6 +35,9 @@ import { UserSettingsPage } from '@backstage/plugin-user-settings';
 import { TechRadarPage } from '@backstage-community/plugin-tech-radar';
 import { getThemes } from '@redhat-developer/red-hat-developer-hub-theme';
 
+import { OrchestratorPage } from '@janus-idp/backstage-plugin-orchestrator';
+import { OrchestratorPlugin } from '@janus-idp/backstage-plugin-orchestrator';
+
 import { apis } from './apis';
 import { entityPage } from './components/catalog/EntityPage';
 import { Root } from './components/Root';
@@ -64,7 +67,6 @@ const app = createApp({
   },
   themes: getThemes(),
 });
-
 const routes = (
   <FlatRoutes>
     <Route path="/" element={<Navigate to="catalog" />} />
@@ -103,6 +105,7 @@ const routes = (
     </Route>
     <Route path="/settings" element={<UserSettingsPage />} />
     <Route path="/catalog-graph" element={<CatalogGraphPage />} />
+    <Route path="/orchestrator" element={<OrchestratorPage/>} />
   </FlatRoutes>
 );
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -104,7 +104,7 @@ const routes = (
     </Route>
     <Route path="/settings" element={<UserSettingsPage />} />
     <Route path="/catalog-graph" element={<CatalogGraphPage />} />
-    <Route path="/orchestrator" element={<OrchestratorPage/>} />
+    <Route path="/orchestrator" element={<OrchestratorPage />} />
   </FlatRoutes>
 );
 

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -105,6 +105,7 @@ export const Root = ({
           to="orchestrator"
           text="Orchestrator"
         />
+
       </SidebarGroup>
       <SidebarSpace />
       <SidebarDivider />
@@ -115,6 +116,7 @@ export const Root = ({
       >
         <SidebarSettings />
       </SidebarGroup>
+     
     </Sidebar>
     {children}
   </SidebarPage>

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -26,6 +26,8 @@ import MapIcon from '@mui/icons-material/MyLocation';
 import SearchIcon from '@mui/icons-material/Search';
 import { makeStyles } from 'tss-react/mui';
 
+import { OrchestratorIcon } from '@janus-idp/backstage-plugin-orchestrator';
+
 import LogoFull from './LogoFull';
 import LogoIcon from './LogoIcon';
 
@@ -98,6 +100,11 @@ export const Root = ({
             text="Tech Radar"
           />
         </SidebarScrollWrapper>
+        <SidebarItem
+          icon={OrchestratorIcon}
+          to="orchestrator"
+          text="Orchestrator"
+        />
       </SidebarGroup>
       <SidebarSpace />
       <SidebarDivider />

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -105,7 +105,6 @@ export const Root = ({
           to="orchestrator"
           text="Orchestrator"
         />
-
       </SidebarGroup>
       <SidebarSpace />
       <SidebarDivider />
@@ -116,7 +115,6 @@ export const Root = ({
       >
         <SidebarSettings />
       </SidebarGroup>
-     
     </Sidebar>
     {children}
   </SidebarPage>

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -48,4 +48,6 @@ backend.add(import('@backstage/plugin-search-backend/alpha'));
 backend.add(import('@backstage/plugin-search-backend-module-catalog/alpha'));
 backend.add(import('@backstage/plugin-search-backend-module-techdocs/alpha'));
 
+backend.add(import('@janus-idp/backstage-plugin-orchestrator-backend/alpha'));
+
 backend.start();

--- a/packages/backend/src/plugins/orchestrator.ts
+++ b/packages/backend/src/plugins/orchestrator.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+
+import { createRouter } from '@janus-idp/backstage-plugin-orchestrator-backend';
+
+import { PluginEnvironment } from '../types';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  return await createRouter({
+    config: env.config,
+    logger: env.logger,
+    discovery: env.discovery,
+    catalogApi: env.catalogApi,
+    urlReader: env.reader,
+    scheduler: env.scheduler,
+    permissions: env.permissions,
+    identity: env.identity,
+  });
+}

--- a/packages/backend/src/plugins/orchestrator.ts
+++ b/packages/backend/src/plugins/orchestrator.ts
@@ -15,6 +15,5 @@ export default async function createPlugin(
     urlReader: env.reader,
     scheduler: env.scheduler,
     permissions: env.permissions,
-    identity: env.identity,
   });
 }

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -82,8 +82,10 @@ const authorize = async (
   return decision;
 };
 
-declare class UnauthorizedError extends NotAllowedError {
-  message: 'Unauthorized';
+export class UnauthorizedError extends NotAllowedError {
+  constructor() {
+    super('Unauthorized');
+  }
 }
 
 export async function createBackendRouter(

--- a/plugins/orchestrator/docs/Permissions.md
+++ b/plugins/orchestrator/docs/Permissions.md
@@ -31,3 +31,17 @@ g, user:default/guest, role:default/workflowViewer
 g, user:default/myOrgUser, role:default/workflowAdmin
 g, group:default/platformAdmins, role:default/worflowAdmin
 ```
+
+See https://casbin.org/docs/rbac for more information about casbin rules
+
+## Enable permissions
+
+To enable permissions, you need to add the following in the [app-config file](../../../app-config.yaml):
+
+```
+permission:
+  enabled: true
+  rbac:
+    policies-csv-file: <absolute path to the policy file>
+    policyFileReload: true
+```

--- a/plugins/orchestrator/src/components/WorkflowDefinitionViewerPage/WorkflowDefinitionViewerPage.tsx
+++ b/plugins/orchestrator/src/components/WorkflowDefinitionViewerPage/WorkflowDefinitionViewerPage.tsx
@@ -8,10 +8,13 @@ import {
   useRouteRef,
   useRouteRefParams,
 } from '@backstage/core-plugin-api';
+import { usePermission } from '@backstage/plugin-permission-react';
 
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 import Skeleton from '@mui/material/Skeleton';
+
+import { orchestratorWorkflowExecutePermission } from '@janus-idp/backstage-plugin-orchestrator-common';
 
 import { orchestratorApiRef } from '../../api';
 import {
@@ -25,6 +28,9 @@ import WorkflowDefinitionDetailsCard from './WorkflowDefinitionDetailsCard';
 export const WorkflowDefinitionViewerPage = () => {
   const { workflowId, format } = useRouteRefParams(workflowDefinitionsRouteRef);
   const orchestratorApi = useApi(orchestratorApiRef);
+  const { loading: loadingPermission, allowed: canRun } = usePermission({
+    permission: orchestratorWorkflowExecutePermission,
+  });
   const {
     value: workflowOverview,
     loading,
@@ -61,13 +67,16 @@ export const WorkflowDefinitionViewerPage = () => {
             {loading ? (
               <Skeleton variant="text" width="5rem" />
             ) : (
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleExecute}
-              >
-                Run
-              </Button>
+              !loadingPermission && (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleExecute}
+                  disabled={!canRun}
+                >
+                  Run
+                </Button>
+              )
             )}
           </Grid>
         </Grid>

--- a/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
@@ -11,16 +11,17 @@ import {
   useRouteRef,
   useRouteRefParams,
 } from '@backstage/core-plugin-api';
+import { usePermission } from '@backstage/plugin-permission-react';
 
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 
 import {
   AssessedProcessInstance,
+  orchestratorWorkflowExecutePermission,
   QUERY_PARAM_ASSESSMENT_INSTANCE_ID,
   QUERY_PARAM_INSTANCE_ID,
   QUERY_PARAM_INSTANCE_STATE,
-  orchestratorWorkflowExecutePermission,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
 
 import { orchestratorApiRef } from '../api';
@@ -32,7 +33,6 @@ import { buildUrl } from '../utils/UrlUtils';
 import { BaseOrchestratorPage } from './BaseOrchestratorPage';
 import { InfoDialog } from './InfoDialog';
 import { WorkflowInstancePageContent } from './WorkflowInstancePageContent';
-import { usePermission } from '@backstage/plugin-permission-react';
 
 export type AbortConfirmationDialogActionsProps = {
   handleSubmit: () => void;
@@ -90,10 +90,9 @@ export const WorkflowInstancePage = ({
   const [isAbortAlertDialogOpen, setIsAbortAlertDialogOpen] = useState(false);
   const [abortWorkflowInstanceErrorMsg, setAbortWorkflowInstanceErrorMsg] =
     useState('');
-    const permittedToExecute = usePermission({
+  const permittedToExecute = usePermission({
     permission: orchestratorWorkflowExecutePermission,
   });
-
 
   const fetchInstance = React.useCallback(async () => {
     if (!instanceId && !queryInstanceId) {
@@ -210,7 +209,7 @@ export const WorkflowInstancePage = ({
                     <Button
                       variant="contained"
                       color="primary"
-                      disabled={!permittedToExecute.allowed|| !canAbort}
+                      disabled={!permittedToExecute.allowed || !canAbort}
                       onClick={canAbort ? handleRerun : undefined}
                     >
                       Retrigger

--- a/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
@@ -20,6 +20,7 @@ import {
   QUERY_PARAM_ASSESSMENT_INSTANCE_ID,
   QUERY_PARAM_INSTANCE_ID,
   QUERY_PARAM_INSTANCE_STATE,
+  orchestratorWorkflowExecutePermission,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
 
 import { orchestratorApiRef } from '../api';
@@ -31,6 +32,7 @@ import { buildUrl } from '../utils/UrlUtils';
 import { BaseOrchestratorPage } from './BaseOrchestratorPage';
 import { InfoDialog } from './InfoDialog';
 import { WorkflowInstancePageContent } from './WorkflowInstancePageContent';
+import { usePermission } from '@backstage/plugin-permission-react';
 
 export type AbortConfirmationDialogActionsProps = {
   handleSubmit: () => void;
@@ -88,6 +90,10 @@ export const WorkflowInstancePage = ({
   const [isAbortAlertDialogOpen, setIsAbortAlertDialogOpen] = useState(false);
   const [abortWorkflowInstanceErrorMsg, setAbortWorkflowInstanceErrorMsg] =
     useState('');
+    const permittedToExecute = usePermission({
+    permission: orchestratorWorkflowExecutePermission,
+  });
+
 
   const fetchInstance = React.useCallback(async () => {
     if (!instanceId && !queryInstanceId) {
@@ -204,7 +210,7 @@ export const WorkflowInstancePage = ({
                     <Button
                       variant="contained"
                       color="primary"
-                      disabled={!canAbort}
+                      disabled={!permittedToExecute.allowed|| !canAbort}
                       onClick={canAbort ? handleRerun : undefined}
                     >
                       Retrigger
@@ -214,7 +220,7 @@ export const WorkflowInstancePage = ({
                     <Button
                       variant="contained"
                       color="secondary"
-                      disabled={!canAbort}
+                      disabled={!permittedToExecute.allowed || !canAbort}
                       onClick={
                         canAbort ? toggleAbortConfirmationDialog : undefined
                       }
@@ -229,7 +235,7 @@ export const WorkflowInstancePage = ({
                   <Button
                     variant="contained"
                     color="primary"
-                    disabled={!canRerun}
+                    disabled={!permittedToExecute.allowed || !canRerun}
                     onClick={canRerun ? handleRerun : undefined}
                   >
                     Rerun

--- a/plugins/orchestrator/src/components/WorkflowsTable.tsx
+++ b/plugins/orchestrator/src/components/WorkflowsTable.tsx
@@ -9,6 +9,8 @@ import PlayArrow from '@mui/icons-material/PlayArrow';
 
 import {
   capitalize,
+  orchestratorWorkflowExecutePermission,
+  orchestratorWorkflowInstancesReadPermission,
   ProcessInstanceStateValues,
   WorkflowOverview,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
@@ -23,6 +25,7 @@ import {
 } from '../routes';
 import OverrideBackstageTable from './ui/OverrideBackstageTable';
 import { WorkflowInstanceStatusIndicator } from './WorkflowInstanceStatusIndicator';
+import { usePermission } from '@backstage/plugin-permission-react';
 
 export interface WorkflowsTableProps {
   items: WorkflowOverview[];
@@ -33,7 +36,12 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
   const definitionLink = useRouteRef(workflowDefinitionsRouteRef);
   const executeWorkflowLink = useRouteRef(executeWorkflowRouteRef);
   const [data, setData] = useState<FormattedWorkflowOverview[]>([]);
-
+  const permittedToExecute = usePermission({
+    permission: orchestratorWorkflowExecutePermission,
+  });
+  const permittedToReadWorkflows = usePermission({
+    permission: orchestratorWorkflowInstancesReadPermission,
+  });
   const initialState = useMemo(
     () => items.map(WorkflowOverviewFormatter.format),
     [items],
@@ -64,6 +72,7 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
       {
         icon: () => <PlayArrow />,
         tooltip: 'Execute',
+        disabled: !permittedToExecute.allowed,
         onClick: (_, rowData) =>
           handleExecute(rowData as FormattedWorkflowOverview),
       },
@@ -130,12 +139,14 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
   );
 
   return (
-    <OverrideBackstageTable<FormattedWorkflowOverview>
-      title="Workflows"
-      options={options}
-      columns={columns}
-      data={data}
-      actions={actions}
-    />
+        !permittedToReadWorkflows && ( 
+        <OverrideBackstageTable<FormattedWorkflowOverview>
+          title="Workflows"
+          options={options}
+          columns={columns}
+          data={data}
+          actions={actions}
+        />
+        )
   );
 };

--- a/plugins/orchestrator/src/components/WorkflowsTable.tsx
+++ b/plugins/orchestrator/src/components/WorkflowsTable.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { Link, TableColumn, TableProps } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
+import { usePermission } from '@backstage/plugin-permission-react';
 
 import Pageview from '@mui/icons-material/Pageview';
 import PlayArrow from '@mui/icons-material/PlayArrow';
@@ -25,7 +26,6 @@ import {
 } from '../routes';
 import OverrideBackstageTable from './ui/OverrideBackstageTable';
 import { WorkflowInstanceStatusIndicator } from './WorkflowInstanceStatusIndicator';
-import { usePermission } from '@backstage/plugin-permission-react';
 
 export interface WorkflowsTableProps {
   items: WorkflowOverview[];
@@ -139,14 +139,14 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
   );
 
   return (
-        !permittedToReadWorkflows && ( 
-        <OverrideBackstageTable<FormattedWorkflowOverview>
-          title="Workflows"
-          options={options}
-          columns={columns}
-          data={data}
-          actions={actions}
-        />
-        )
+    permittedToReadWorkflows && (
+      <OverrideBackstageTable<FormattedWorkflowOverview>
+        title="Workflows"
+        options={options}
+        columns={columns}
+        data={data}
+        actions={actions}
+      />
+    )
   );
 };

--- a/plugins/rbac/src/components/ConditionalAccess/ConditionsFormRowFields.tsx
+++ b/plugins/rbac/src/components/ConditionalAccess/ConditionsFormRowFields.tsx
@@ -4,7 +4,7 @@ import { PermissionCondition } from '@backstage/plugin-permission-common';
 
 import { Box, makeStyles, TextField } from '@material-ui/core';
 import { Autocomplete } from '@material-ui/lab';
-import Form from '@rjsf/mui';
+import Form from '@rjsf/material-ui';
 import { RegistryFieldsType, RJSFSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 


### PR DESCRIPTION
In the Orchestrator plugin UI,  a given user shall only see the workflows it is allowed to see/execute

The runs of the workflow shall also be hidden to the not allowed users