### PR TITLE
fix(orchestrator): change log level of cache messages to be debug

### DIFF
--- a/plugins/orchestrator-backend/src/OrchestratorPlugin.ts
+++ b/plugins/orchestrator-backend/src/OrchestratorPlugin.ts
@@ -19,6 +19,7 @@ export const orchestratorPlugin = createBackendPlugin({
         scheduler: coreServices.scheduler,
         permissions: coreServices.permissions,
         httpAuth: coreServices.httpAuth,
+        auth: coreServices.auth,
         catalogApi: catalogServiceRef,
       },
       async init({
@@ -31,17 +32,21 @@ export const orchestratorPlugin = createBackendPlugin({
         scheduler,
         permissions,
         httpAuth,
+        auth,
       }) {
-        const router = await createRouter({
-          config: config,
-          logger,
-          discovery: discovery,
-          catalogApi: catalogApi,
-          urlReader: urlReader,
-          scheduler: scheduler,
-          permissions: permissions,
-          httpAuth: httpAuth,
-        });
+        const router = await createRouter(
+          {
+            config: config,
+            logger,
+            discovery: discovery,
+            catalogApi: catalogApi,
+            urlReader: urlReader,
+            scheduler: scheduler,
+            permissions: permissions,
+            httpAuth: httpAuth,
+          },
+          auth,
+        );
         httpRouter.use(router);
         httpRouter.addAuthPolicy({
           path: '/static/generated/envelope',

--- a/plugins/orchestrator-backend/src/routerWrapper/index.ts
+++ b/plugins/orchestrator-backend/src/routerWrapper/index.ts
@@ -1,5 +1,6 @@
 import { createLegacyAuthAdapters, UrlReader } from '@backstage/backend-common';
 import {
+  AuthService,
   DiscoveryService,
   HttpAuthService,
   LoggerService,
@@ -25,7 +26,10 @@ export interface RouterArgs {
   httpAuth?: HttpAuthService;
 }
 
-export async function createRouter(args: RouterArgs): Promise<express.Router> {
+export async function createRouter(
+  args: RouterArgs,
+  auth: AuthService,
+): Promise<express.Router> {
   const autoStartDevMode =
     args.config.getOptionalBoolean(
       'orchestrator.sonataFlowService.autoStart',
@@ -45,14 +49,17 @@ export async function createRouter(args: RouterArgs): Promise<express.Router> {
     httpAuth: args.httpAuth,
     discovery: args.discovery,
   });
-  return await createBackendRouter({
-    config: args.config,
-    logger: args.logger,
-    discovery: args.discovery,
-    catalogApi: args.catalogApi,
-    urlReader: args.urlReader,
-    scheduler: args.scheduler,
-    permissions: args.permissions,
-    httpAuth: httpAuth,
-  });
+  return await createBackendRouter(
+    {
+      config: args.config,
+      logger: args.logger,
+      discovery: args.discovery,
+      catalogApi: args.catalogApi,
+      urlReader: args.urlReader,
+      scheduler: args.scheduler,
+      permissions: args.permissions,
+      httpAuth: httpAuth,
+    },
+    auth,
+  );
 }

--- a/plugins/orchestrator-backend/src/service/WorkflowCacheService.ts
+++ b/plugins/orchestrator-backend/src/service/WorkflowCacheService.ts
@@ -92,7 +92,7 @@ export class WorkflowCacheService {
         ? 'empty cache'
         : Array.from(this.definitionIdCache).join(', ');
 
-      this.logger.info(
+      this.logger.debug(
         `${this.TASK_ID} updated the workflow definition ID cache to: ${workflowDefinitionIds}`,
       );
     } catch (error) {

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -306,13 +306,13 @@ function setupInternalRoutes(
       level: 'debug',
       message: `Received request to '${endpoint}' endpoint`,
     });
-    const desicion = await authorize(
+    const decision = await authorize(
       req,
       orchestratorWorkflowInstancesReadPermission,
       permissions,
       httpAuth,
     );
-    if (desicion.result === AuthorizeResult.DENY) {
+    if (decision.result === AuthorizeResult.DENY) {
       manageDenyAuthorization(endpointName, endpoint);
     }
     await routerApi.v1
@@ -341,13 +341,13 @@ function setupInternalRoutes(
         level: 'debug',
         message: `Received request to '/workflows/overview' v2 endpoint`,
       });
-      const desicion = await authorize(
+      const decision = await authorize(
         req,
         orchestratorWorkflowInstancesReadPermission,
         permissions,
         httpAuth,
       );
-      if (desicion.result === AuthorizeResult.DENY) {
+      if (decision.result === AuthorizeResult.DENY) {
         manageDenyAuthorization(
           'getWorkflowsOverview',
           '/v2/workflows/overview',
@@ -381,13 +381,13 @@ function setupInternalRoutes(
       level: 'debug',
       message: `Received request to '/workflows/${workflowId}' v1 endpoint`,
     });
-    const desicion = await authorize(
+    const decision = await authorize(
       req,
       orchestratorWorkflowReadPermission,
       permissions,
       httpAuth,
     );
-    if (desicion.result === AuthorizeResult.DENY) {
+    if (decision.result === AuthorizeResult.DENY) {
       manageDenyAuthorization(
         'WorkflowsWorkflowId',
         `/v1/workflows/${workflowId}`,
@@ -420,13 +420,13 @@ function setupInternalRoutes(
         message: `Received request to '${endpoint}' endpoint`,
       });
 
-      const desicion = await authorize(
+      const decision = await authorize(
         _req,
         orchestratorWorkflowReadPermission,
         permissions,
         httpAuth,
       );
-      if (desicion.result === AuthorizeResult.DENY) {
+      if (decision.result === AuthorizeResult.DENY) {
         manageDenyAuthorization(endpointName, endpoint);
       }
       await routerApi.v2
@@ -457,13 +457,13 @@ function setupInternalRoutes(
       message: `Received request to '${endpoint}' endpoint`,
     });
 
-    const desicion = await authorize(
+    const decision = await authorize(
       req,
       orchestratorWorkflowReadPermission,
       permissions,
       httpAuth,
     );
-    if (desicion.result === AuthorizeResult.DENY) {
+    if (decision.result === AuthorizeResult.DENY) {
       manageDenyAuthorization(endpointName, endpoint);
     }
 
@@ -494,13 +494,13 @@ function setupInternalRoutes(
         message: `Received request to '${endpoint}' endpoint`,
       });
 
-      const desicion = await authorize(
+      const decision = await authorize(
         _req,
         orchestratorWorkflowReadPermission,
         permissions,
         httpAuth,
       );
-      if (desicion.result === AuthorizeResult.DENY) {
+      if (decision.result === AuthorizeResult.DENY) {
         manageDenyAuthorization(endpointName, endpoint);
       }
 
@@ -534,13 +534,13 @@ function setupInternalRoutes(
       message: `Received request to '${endpoint}' endpoint`,
     });
 
-    const desicion = await authorize(
+    const decision = await authorize(
       req,
       orchestratorWorkflowExecutePermission,
       permissions,
       httpAuth,
     );
-    if (desicion.result === AuthorizeResult.DENY) {
+    if (decision.result === AuthorizeResult.DENY) {
       manageDenyAuthorization(endpointName, endpoint);
     }
 
@@ -576,13 +576,13 @@ function setupInternalRoutes(
         message: `Received request to '${endpoint}' endpoint`,
       });
 
-      const desicion = await authorize(
+      const decision = await authorize(
         req,
         orchestratorWorkflowExecutePermission,
         permissions,
         httpAuth,
       );
-      if (desicion.result === AuthorizeResult.DENY) {
+      if (decision.result === AuthorizeResult.DENY) {
         manageDenyAuthorization(endpointName, endpoint);
       }
 
@@ -621,13 +621,13 @@ function setupInternalRoutes(
       message: `Received request to '${endpoint}' endpoint`,
     });
 
-    const desicion = await authorize(
+    const decision = await authorize(
       req,
       orchestratorWorkflowReadPermission,
       permissions,
       httpAuth,
     );
-    if (desicion.result === AuthorizeResult.DENY) {
+    if (decision.result === AuthorizeResult.DENY) {
       manageDenyAuthorization(endpointName, endpoint);
     }
 
@@ -652,13 +652,13 @@ function setupInternalRoutes(
         message: `Received request to '${endpoint}' endpoint`,
       });
 
-      const desicion = await authorize(
+      const decision = await authorize(
         _req,
         orchestratorWorkflowReadPermission,
         permissions,
         httpAuth,
       );
-      if (desicion.result === AuthorizeResult.DENY) {
+      if (decision.result === AuthorizeResult.DENY) {
         manageDenyAuthorization(endpointName, endpoint);
       }
 
@@ -685,13 +685,13 @@ function setupInternalRoutes(
       message: `Received request to '${endpoint}' endpoint`,
     });
 
-    const desicion = await authorize(
+    const decision = await authorize(
       req,
       orchestratorWorkflowReadPermission,
       permissions,
       httpAuth,
     );
-    if (desicion.result === AuthorizeResult.DENY) {
+    if (decision.result === AuthorizeResult.DENY) {
       manageDenyAuthorization(endpointName, endpoint);
     }
 
@@ -846,13 +846,13 @@ function setupInternalRoutes(
         message: `Received request to '${endpoint}' endpoint`,
       });
 
-      const desicion = await authorize(
+      const decision = await authorize(
         _req,
         orchestratorWorkflowInstanceReadPermission,
         permissions,
         httpAuth,
       );
-      if (desicion.result === AuthorizeResult.DENY) {
+      if (decision.result === AuthorizeResult.DENY) {
         manageDenyAuthorization(endpointName, endpoint);
       }
 
@@ -882,13 +882,13 @@ function setupInternalRoutes(
         level: 'debug',
         message: `Received request to '${endpoint}' endpoint`,
       });
-      const desicion = await authorize(
+      const decision = await authorize(
         _req,
         orchestratorWorkflowInstanceReadPermission,
         permissions,
         httpAuth,
       );
-      if (desicion.result === AuthorizeResult.DENY) {
+      if (decision.result === AuthorizeResult.DENY) {
         manageDenyAuthorization(endpointName, endpoint);
       }
       await routerApi.v2
@@ -916,13 +916,13 @@ function setupInternalRoutes(
       message: `Received request to '${endpoint}' endpoint`,
     });
 
-    const desicion = await authorize(
+    const decision = await authorize(
       req,
       orchestratorWorkflowInstancesReadPermission,
       permissions,
       httpAuth,
     );
-    if (desicion.result === AuthorizeResult.DENY) {
+    if (decision.result === AuthorizeResult.DENY) {
       manageDenyAuthorization(endpointName, endpoint);
     }
     await routerApi.v1
@@ -951,13 +951,13 @@ function setupInternalRoutes(
         message: `Received request to '${endpoint}' endpoint`,
       });
 
-      const desicion = await authorize(
+      const decision = await authorize(
         req,
         orchestratorWorkflowInstancesReadPermission,
         permissions,
         httpAuth,
       );
-      if (desicion.result === AuthorizeResult.DENY) {
+      if (decision.result === AuthorizeResult.DENY) {
         manageDenyAuthorization(endpointName, endpoint);
       }
       await routerApi.v2
@@ -983,13 +983,13 @@ function setupInternalRoutes(
       message: `Received request to '${endpoint}' endpoint`,
     });
 
-    const desicion = await authorize(
+    const decision = await authorize(
       req,
       orchestratorWorkflowInstanceReadPermission,
       permissions,
       httpAuth,
     );
-    if (desicion.result === AuthorizeResult.DENY) {
+    if (decision.result === AuthorizeResult.DENY) {
       manageDenyAuthorization(endpointName, endpoint);
     }
 
@@ -1025,13 +1025,13 @@ function setupInternalRoutes(
         message: `Received request to '${endpoint}' endpoint`,
       });
 
-      const desicion = await authorize(
+      const decision = await authorize(
         _req,
         orchestratorWorkflowInstanceReadPermission,
         permissions,
         httpAuth,
       );
-      if (desicion.result === AuthorizeResult.DENY) {
+      if (decision.result === AuthorizeResult.DENY) {
         manageDenyAuthorization(endpointName, endpoint);
       }
       const includeAssessment = routerApi.v2.extractQueryParam(
@@ -1067,13 +1067,13 @@ function setupInternalRoutes(
       message: `Received request to '${endpoint}' endpoint`,
     });
 
-    const desicion = await authorize(
+    const decision = await authorize(
       req,
       orchestratorWorkflowInstanceAbortPermission,
       permissions,
       httpAuth,
     );
-    if (desicion.result === AuthorizeResult.DENY) {
+    if (decision.result === AuthorizeResult.DENY) {
       manageDenyAuthorization(endpointName, endpoint);
     }
 
@@ -1105,13 +1105,13 @@ function setupInternalRoutes(
         message: `Received request to '${endpoint}' endpoint`,
       });
 
-      const desicion = await authorize(
+      const decision = await authorize(
         _req,
         orchestratorWorkflowInstanceAbortPermission,
         permissions,
         httpAuth,
       );
-      if (desicion.result === AuthorizeResult.DENY) {
+      if (decision.result === AuthorizeResult.DENY) {
         manageDenyAuthorization(endpointName, endpoint);
       }
       await routerApi.v2
@@ -1143,13 +1143,13 @@ function setupInternalRoutes(
       message: `Received request to '${endpoint}' endpoint`,
     });
 
-    const desicion = await authorize(
+    const decision = await authorize(
       req,
       orchestratorWorkflowExecutePermission,
       permissions,
       httpAuth,
     );
-    if (desicion.result === AuthorizeResult.DENY) {
+    if (decision.result === AuthorizeResult.DENY) {
       manageDenyAuthorization(endpointName, endpoint);
     }
 

--- a/plugins/orchestrator/src/components/WorkflowEditor/WorkflowEditor.tsx
+++ b/plugins/orchestrator/src/components/WorkflowEditor/WorkflowEditor.tsx
@@ -197,18 +197,14 @@ const RefForwardingWorkflowEditor: ForwardRefRenderFunction<
     });
   }, [editorMode, embeddedFile, languageService, stateControl]);
 
-  useImperativeHandle(
-    forwardedRef,
-    () => {
-      return {
-        validate,
-        getContent,
-        workflowDefinition: workflowDefinitionPromise.data,
-        isReady: ready,
-      };
-    },
-    [validate, getContent, workflowDefinitionPromise.data, ready],
-  );
+  useImperativeHandle(forwardedRef, () => {
+    return {
+      validate,
+      getContent,
+      workflowDefinition: workflowDefinitionPromise.data,
+      isReady: ready,
+    };
+  }, [validate, getContent, workflowDefinitionPromise.data, ready]);
 
   useCancelableEffect(
     useCallback(


### PR DESCRIPTION
The cache messages were generating a large volume of logs, which was overwhelming and obscuring other important log messages. This made it difficult to debug issues effectively. By changing the log level to debug, we can reduce noise in the logs and make it easier to identify and address other issues.