### PR TITLE
feat(keycloak): expose keycloak user/group transformer extension point

### DIFF
--- a/plugins/keycloak-backend/README.md
+++ b/plugins/keycloak-backend/README.md
@@ -243,11 +243,60 @@ yarn workspace backend add @janus-idp/backstage-plugin-keycloak-backend
    backend.start();
    ```
 
----
+1. Optional: provide a transformer function for user/group to mutate the entity before their ingestion into catalog. Create a new backend module with the `yarn new` command to use the `keycloakTransformerExtensionPoint`.
 
-**NOTE**
+   ```ts
+   /* highlight-add-start */
+   import {
+     GroupTransformer,
+     keycloakTransformerExtensionPoint,
+     UserTransformer,
+   } from '@janus-idp/backstage-plugin-keycloak-backend';
 
-Currently the new backend installation method does not support transformer functions for users and groups.
+   /* highlight-add-end */
+
+   /* highlight-add-start */
+   const groupTransformer: GroupTransformer = async (entity, realm, groups) => {
+     /* apply transformations */
+     return entity;
+   };
+   const userTransformer: UserTransformer = async (
+     entity,
+     user,
+     realm,
+     groups,
+   ) => {
+     /* apply transformations */
+     return entity;
+   };
+   /* highlight-add-end */
+
+   export const keycloakBackendModuleTransformer = createBackendModule({
+     pluginId: 'catalog',
+     moduleId: 'transformer',
+     register(reg) {
+       reg.registerInit({
+         deps: {
+           /* highlight-add-start */
+           keycloak: keycloakTransformerExtensionPoint,
+           /* highlight-add-end */
+         },
+         /* highlight-add-start */
+         async init({ keycloak }) {
+           keycloak.setUserTransformer(userTransformer);
+           keycloak.setGroupTransformer(groupTransformer);
+           /* highlight-add-end */
+         },
+       });
+     },
+   });
+   ```
+
+   ***
+
+   **NOTE**
+
+   The `pluginId` must be the ID of an existing plugin (e.g. `catalog`) due to a limitation with extending a module on top of another module. Otherwise the newly created backend module will not be initialized.
 
 ---
 

--- a/plugins/keycloak-backend/src/extensions.ts
+++ b/plugins/keycloak-backend/src/extensions.ts
@@ -1,0 +1,23 @@
+import { createExtensionPoint } from '@backstage/backend-plugin-api';
+
+import { GroupTransformer, UserTransformer } from './lib/types';
+
+/**
+ * An extension point that exposes the ability to implement user and group transformer functions for keycloak.
+ *
+ * @public
+ */
+export const keycloakTransformerExtensionPoint =
+  createExtensionPoint<KeycloakTransformerExtensionPoint>({
+    id: 'keycloak.transformer',
+  });
+
+/**
+ * The interface for {@link keycloakTransformerExtensionPoint}.
+ *
+ * @public
+ */
+export type KeycloakTransformerExtensionPoint = {
+  setUserTransformer(userTransformer: UserTransformer): void;
+  setGroupTransformer(groupTransformer: GroupTransformer): void;
+};

--- a/plugins/keycloak-backend/src/index.ts
+++ b/plugins/keycloak-backend/src/index.ts
@@ -18,3 +18,5 @@ export * from './providers';
 export type { UserTransformer, GroupTransformer } from './lib';
 export * from './lib/transformers';
 export * from './dynamic/index';
+export * from './extensions';
+export * from './lib/types';


### PR DESCRIPTION
Resolves [RHIDP-2644](https://issues.redhat.com/browse/RHIDP-2644): Expose extension points for the keycloak-backend plugin

To test this change locally, [this](https://github.com/JessicaJHee/backstage-showcase/tree/testing-keycloak-transformers) may be useful - it adds a new module that uses the extension point to append `_foo` and `_bar` to the group and user name respectively.