### PR TITLE
feat(kiali): add banner to warn for tech preview windows

### DIFF
--- a/plugins/kiali/src/components/Banners/TechPreviewWarning.tsx
+++ b/plugins/kiali/src/components/Banners/TechPreviewWarning.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { DismissableBanner, WarningIcon } from '@backstage/core-components';
+
+type DismissableBannerProps = {
+  message: React.ReactElement;
+  variant: 'info' | 'warning' | 'error';
+  fixed: boolean;
+};
+
+const defaultProps: DismissableBannerProps = {
+  message: (
+    <>
+      <WarningIcon /> This is a tech preview feature
+    </>
+  ),
+  variant: 'warning',
+  fixed: false,
+};
+
+export const TechPreviewWarning = () => {
+  return (
+    <div>
+      <DismissableBanner {...defaultProps} id="default_dismissable" />
+    </div>
+  );
+};

--- a/plugins/kiali/src/components/Router.tsx
+++ b/plugins/kiali/src/components/Router.tsx
@@ -33,6 +33,7 @@ import {
   workloadsRouteRef,
 } from '../routes';
 import { KialiProvider } from '../store/KialiProvider';
+import { TechPreviewWarning } from './Banners/TechPreviewWarning';
 
 export const KUBERNETES_ANNOTATION = 'backstage.io/kubernetes-id';
 export const KUBERNETES_NAMESPACE = 'backstage.io/kubernetes-namespace';
@@ -86,6 +87,7 @@ export const EmbeddedRouter = () => {
     <KialiNoAnnotation />
   ) : (
     <KialiProvider entity={entity}>
+      <TechPreviewWarning />
       <KialiHeaderEntity />
       {getEntityRoutes()}
     </KialiProvider>
@@ -159,6 +161,7 @@ export const getRoutes = (dev?: boolean) => {
 export const Router = () => {
   return (
     <KialiProvider>
+      <TechPreviewWarning />
       <Page themeId="tool">
         <KialiHeader />
         <KialiTabs />


### PR DESCRIPTION
Included in Kiali tab: 

![image](https://github.com/janus-idp/backstage-plugins/assets/49480155/3ef15849-9a0c-4cae-8214-f403dddb8bd0)

And Kiali standalone: 

![image](https://github.com/janus-idp/backstage-plugins/assets/49480155/701df37e-1a86-4916-9976-c0600e4e9298)
