### PR TITLE
fix(argocd): hide commit section for helm based applications

### DIFF
--- a/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
@@ -87,14 +87,18 @@ const DeploymentLifecycle = () => {
 
   const activeApp = apps.find(a => a.metadata.name === activeItem);
 
+  if (error) {
+    return <ResponseErrorPanel data-testid="error-panel" error={error} />;
+  }
+
   if (loading) {
     return (
       <div data-testid="argocd-loader">
         <Progress />
       </div>
     );
-  } else if (error) {
-    return <ResponseErrorPanel data-testid="error-panel" error={error} />;
+  } else if (apps?.length === 0) {
+    return null;
   }
 
   return (

--- a/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
@@ -117,47 +117,49 @@ const DeploymentLifecycleCard: React.FC<DeploymentLifecycleCardProps> = ({
 
             <AppNamespace app={app} />
           </Grid>
-          <Grid item xs={12}>
-            <Typography color="textPrimary">Commit</Typography>
-            {revisionsMap && latestRevision ? (
-              <>
-                <Chip
-                  data-testid={`${latestRevision?.revision?.slice(
-                    0,
-                    5,
-                  )}-commit-link`}
-                  size="small"
-                  variant="outlined"
-                  onClick={e => {
-                    e.stopPropagation();
-                    const repoUrl = app?.spec?.source?.repoURL ?? '';
-                    if (repoUrl.length) {
-                      window.open(
-                        getCommitUrl(
-                          repoUrl,
-                          latestRevision?.revision,
-                          entity?.metadata?.annotations ?? {},
-                        ),
-                        '_blank',
-                      );
-                    }
-                  }}
-                  icon={<GitLabIcon />}
-                  color="primary"
-                  label={latestRevision?.revision.slice(0, 7)}
-                />
-                <Typography variant="body2" color="textSecondary">
-                  {revisionsMap?.[latestRevision?.revision] ? (
-                    <>{revisionsMap?.[latestRevision?.revision]?.message}</>
-                  ) : (
-                    <Skeleton />
-                  )}
-                </Typography>
-              </>
-            ) : (
-              <>-</>
-            )}
-          </Grid>
+          {!app?.spec?.source?.chart && (
+            <Grid item xs={12}>
+              <Typography color="textPrimary">Commit</Typography>
+              {revisionsMap && latestRevision ? (
+                <>
+                  <Chip
+                    data-testid={`${latestRevision?.revision?.slice(
+                      0,
+                      5,
+                    )}-commit-link`}
+                    size="small"
+                    variant="outlined"
+                    onClick={e => {
+                      e.stopPropagation();
+                      const repoUrl = app?.spec?.source?.repoURL ?? '';
+                      if (repoUrl.length) {
+                        window.open(
+                          getCommitUrl(
+                            repoUrl,
+                            latestRevision?.revision,
+                            entity?.metadata?.annotations ?? {},
+                          ),
+                          '_blank',
+                        );
+                      }
+                    }}
+                    icon={<GitLabIcon />}
+                    color="primary"
+                    label={latestRevision?.revision.slice(0, 7)}
+                  />
+                  <Typography variant="body2" color="textSecondary">
+                    {revisionsMap?.[latestRevision?.revision] ? (
+                      <>{revisionsMap?.[latestRevision?.revision]?.message}</>
+                    ) : (
+                      <Skeleton />
+                    )}
+                  </Typography>
+                </>
+              ) : (
+                <>-</>
+              )}
+            </Grid>
+          )}
 
           <Grid item xs={12}>
             <Typography variant="body1" color="textPrimary">

--- a/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleDrawer.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleDrawer.tsx
@@ -136,51 +136,53 @@ const DeploymentLifecycleDrawer: React.FC<DeploymentLifecycleDrawerProps> = ({
 
             <AppNamespace app={app} />
           </Grid>
-          <Grid item xs={12}>
-            <Typography color="textPrimary">Commit</Typography>
-            {latestRevision ? (
-              <>
-                <Chip
-                  data-testid={`${latestRevision?.revision?.slice(
-                    0,
-                    5,
-                  )}-commit-link`}
-                  size="small"
-                  variant="outlined"
-                  icon={<GitLabIcon />}
-                  color="primary"
-                  onClick={e => {
-                    e.stopPropagation();
+          {!app?.spec?.source?.chart && (
+            <Grid item xs={12}>
+              <Typography color="textPrimary">Commit</Typography>
+              {latestRevision ? (
+                <>
+                  <Chip
+                    data-testid={`${latestRevision?.revision?.slice(
+                      0,
+                      5,
+                    )}-commit-link`}
+                    size="small"
+                    variant="outlined"
+                    icon={<GitLabIcon />}
+                    color="primary"
+                    onClick={e => {
+                      e.stopPropagation();
 
-                    const repoUrl = app?.spec?.source?.repoURL ?? '';
-                    if (repoUrl) {
-                      window.open(
-                        getCommitUrl(
-                          repoUrl,
-                          latestRevision?.revision,
-                          entity?.metadata?.annotations ?? {},
-                        ),
-                        '_blank',
-                      );
-                    }
-                  }}
-                  label={latestRevision?.revision.slice(0, 7)}
-                />
-                <Typography color="textSecondary">
-                  {revisionsMap?.[latestRevision?.revision] ? (
-                    <>
-                      {revisionsMap?.[latestRevision?.revision]?.message} by{' '}
-                      {revisionsMap?.[latestRevision?.revision]?.author}
-                    </>
-                  ) : (
-                    <Skeleton />
-                  )}
-                </Typography>
-              </>
-            ) : (
-              <>-</>
-            )}
-          </Grid>
+                      const repoUrl = app?.spec?.source?.repoURL ?? '';
+                      if (repoUrl) {
+                        window.open(
+                          getCommitUrl(
+                            repoUrl,
+                            latestRevision?.revision,
+                            entity?.metadata?.annotations ?? {},
+                          ),
+                          '_blank',
+                        );
+                      }
+                    }}
+                    label={latestRevision?.revision.slice(0, 7)}
+                  />
+                  <Typography color="textSecondary">
+                    {revisionsMap?.[latestRevision?.revision] ? (
+                      <>
+                        {revisionsMap?.[latestRevision?.revision]?.message} by{' '}
+                        {revisionsMap?.[latestRevision?.revision]?.author}
+                      </>
+                    ) : (
+                      <Skeleton />
+                    )}
+                  </Typography>
+                </>
+              ) : (
+                <>-</>
+              )}
+            </Grid>
+          )}
           {appHistory.length >= 1 && (
             <Grid item xs={12}>
               <Typography color="textPrimary">Latest deployment</Typography>

--- a/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycle.test.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycle.test.tsx
@@ -140,6 +140,25 @@ describe('DeploymentLifecycle', () => {
     });
   });
 
+  test('should not render the component if there are no applications matching the selector', async () => {
+    (useApi as any).mockReturnValue({
+      listApps: async () => {
+        return Promise.resolve({ items: [] });
+      },
+      getRevisionDetailsList: async () => {
+        return Promise.resolve({});
+      },
+    });
+    render(<DeploymentLifecycle />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('argocd-loader')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Deployment lifecycle'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   test('should open and close the sidebar', async () => {
     render(<DeploymentLifecycle />);
 

--- a/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleCard.test.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleCard.test.tsx
@@ -148,3 +148,25 @@ describe('DeploymentLifecylceCard', () => {
     screen.getByText('commit message');
   });
 });
+
+test('application card should not contain commit section for helm based applications', () => {
+  (useArgocdConfig as any).mockReturnValue({
+    baseUrl: 'https://baseUrl.com',
+    instances: [{ name: 'main', url: 'https://main-instance-url.com' }],
+    intervalMs: 10000,
+    instanceName: 'main',
+  });
+
+  const helmApplication = {
+    ...mockApplication,
+    spec: {
+      ...mockApplication.spec,
+      source: { ...mockApplication.spec.source, chart: 'redhat-charts' },
+    },
+  };
+
+  render(<DeploymentLifecycleCard app={helmApplication} revisionsMap={{}} />);
+
+  const commitLink = screen.queryByText('Commit');
+  expect(commitLink).not.toBeInTheDocument();
+});

--- a/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleDrawer.test.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleDrawer.test.tsx
@@ -80,6 +80,28 @@ describe('DeploymentLifecycleDrawer', () => {
     expect(screen.getByTestId('quarkus-app-dev-drawer')).toBeInTheDocument();
   });
 
+  test('should not render the commit section for helm based applications in drawer component', () => {
+    const helmApplication = {
+      ...mockApplication,
+      spec: {
+        ...mockApplication.spec,
+        source: { ...mockApplication.spec.source, chart: 'redhat-charts' },
+      },
+    };
+    render(
+      <DeploymentLifecycleDrawer
+        app={helmApplication}
+        isOpen
+        onClose={() => jest.fn()}
+        revisionsMap={{}}
+      />,
+      { wrapper },
+    );
+
+    const commitLink = screen.queryByText('Commit');
+    expect(commitLink).not.toBeInTheDocument();
+  });
+
   test('should render the commit link in drawer component', () => {
     global.open = jest.fn();
 

--- a/plugins/argocd/src/types.ts
+++ b/plugins/argocd/src/types.ts
@@ -26,6 +26,7 @@ export interface Destination {
 }
 
 export interface Source {
+  chart?: string;
   repoURL: string;
   path: string;
   helm?: {


### PR DESCRIPTION
**Description:**

Do not show Commit section for non-gitops application (helm based).

**How to test**

1. Create a namespace called `test`
2. Create a application using helm charts
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: quarkus-app
  labels:
     rht-gitops.com/janus-argocd: quarkus-app
spec:
  destination:
    namespace: test
    server: https://kubernetes.default.svc
  project: default
  source:
    helm:
      parameters:
        - name: build.enabled
          value: "false"
        - name: deploy.route.enabled
          value: "false"
        - name: image.name
          value: quay.io/redhatworkshops/gitops-helm-quarkus
    chart: quarkus
    repoURL: https://redhat-developer.github.io/redhat-helm-charts
    targetRevision: 0.0.3
  syncPolicy:
    retry:
      backoff:
        duration: 5s
        factor: 2
        maxDuration: 3m0s
      limit: 5
    automated:
      prune: true
      selfHeal: true
    syncOptions:
    - CreateNamespace=true
```

3. Add this argocd selector in catalog.info.yaml.

```
    'argocd/app-selector': rht-gitops.com/janus-argocd=quarkus-app-bootstrap

```


<img width="1789" alt="Screenshot 2024-06-21 at 12 27 00 PM" src="https://github.com/janus-idp/backstage-plugins/assets/9964343/9e3147dc-8df2-4fc1-aefd-467cea0186c5">



cc: @rohitkrai03 @invincibleJai 