### PR TITLE
feat(kiali): include Kiali external URL as a parameter

### DIFF
--- a/plugins/kiali-backend/app-config.janus-idp.yaml
+++ b/plugins/kiali-backend/app-config.janus-idp.yaml
@@ -4,6 +4,8 @@ catalog:
     kiali:
       # Required. Kiali endpoint
       url: ${KIALI_BASE_URL}
+      # Optional. Kiali public URL to redirect to standalone Kiali. When not specified, url will be used.
+      urlExternal: ''
       # Optional. Required by token authentication
       serviceAccountToken: ${KIALI_SERVICE_ACCOUNT_TOKEN}
       # Optional. defaults false

--- a/plugins/kiali-backend/config.d.ts
+++ b/plugins/kiali-backend/config.d.ts
@@ -7,6 +7,10 @@ export interface Config {
          */
         url: string;
         /**
+         * Url of the Kiali standalone for external access
+         */
+        urlExternal?: string;
+        /**
          * Service Account Token which is used for querying data from Kiali
          * @visibility secret
          */

--- a/plugins/kiali-backend/src/clients/KialiAPIConnector.test.ts
+++ b/plugins/kiali-backend/src/clients/KialiAPIConnector.test.ts
@@ -7,7 +7,10 @@ const logger = getVoidLogger();
 
 const kialiApi = new KialiApiImpl({
   logger,
-  kiali: { url: 'https://localhost:4000' },
+  kiali: {
+    url: 'https://localhost:4000',
+    urlExternal: 'https://localhost:4000',
+  },
 });
 
 describe('kiali Api Connector', () => {

--- a/plugins/kiali-backend/src/clients/fetch.test.ts
+++ b/plugins/kiali-backend/src/clients/fetch.test.ts
@@ -12,7 +12,10 @@ describe('kiali Fetch', () => {
     describe(`${AuthStrategy.anonymous} strategy`, () => {
       it('should get a true', async () => {
         const kialiFetch = new KialiFetcher(
-          { url: 'https://localhost:4000' },
+          {
+            url: 'https://localhost:4000',
+            urlExternal: 'https://localhost:4000',
+          },
           logger,
         );
         const result = (kialiFetch as any).validateConfiguration({
@@ -30,7 +33,10 @@ describe('kiali Fetch', () => {
     describe(`${AuthStrategy.token} strategy`, () => {
       it('should get a false when `serviceAccountToken` is missed', async () => {
         const kialiFetch = new KialiFetcher(
-          { url: 'https://localhost:4000' },
+          {
+            url: 'https://localhost:4000',
+            urlExternal: 'https://localhost:4000',
+          },
           logger,
         );
         const result = (kialiFetch as any).validateConfiguration({
@@ -52,7 +58,11 @@ describe('kiali Fetch', () => {
 
       it('should get a true when `serviceAccountToken` is set', async () => {
         const kialiFetch = new KialiFetcher(
-          { url: 'https://localhost:4000', serviceAccountToken: '<token>' },
+          {
+            url: 'https://localhost:4000',
+            serviceAccountToken: '<token>',
+            urlExternal: 'https://localhost:4000',
+          },
           logger,
         );
         const result = (kialiFetch as any).validateConfiguration({
@@ -71,7 +81,10 @@ describe('kiali Fetch', () => {
     describe(`Not ${AuthStrategy.openid} strategy supported`, () => {
       it('should get a true', async () => {
         const kialiFetch = new KialiFetcher(
-          { url: 'https://localhost:4000' },
+          {
+            url: 'https://localhost:4000',
+            urlExternal: 'https://localhost:4000',
+          },
           logger,
         );
         const result = (kialiFetch as any).validateConfiguration({
@@ -93,7 +106,10 @@ describe('kiali Fetch', () => {
     describe('bufferFromFileOrString', () => {
       it('No file or data passed', () => {
         const kialiFetch = new KialiFetcher(
-          { url: 'https://localhost:4000' },
+          {
+            url: 'https://localhost:4000',
+            urlExternal: 'https://localhost:4000',
+          },
           logger,
         );
         const result = (kialiFetch as any).bufferFromFileOrString();
@@ -103,7 +119,10 @@ describe('kiali Fetch', () => {
 
       it('Read from file', () => {
         const kialiFetch = new KialiFetcher(
-          { url: 'https://localhost:4000' },
+          {
+            url: 'https://localhost:4000',
+            urlExternal: 'https://localhost:4000',
+          },
           logger,
         );
         const result = (kialiFetch as any).bufferFromFileOrString(
@@ -116,7 +135,10 @@ describe('kiali Fetch', () => {
 
       it('Read from data', () => {
         const kialiFetch = new KialiFetcher(
-          { url: 'https://localhost:4000' },
+          {
+            url: 'https://localhost:4000',
+            urlExternal: 'https://localhost:4000',
+          },
           logger,
         );
         const result = (kialiFetch as any).bufferFromFileOrString(
@@ -133,7 +155,10 @@ describe('kiali Fetch', () => {
   describe('Return networking error in checkSession', () => {
     it('Respond with verify category to network', async () => {
       const kialiFetch = new KialiFetcher(
-        { url: 'https://localhost:4000' },
+        {
+          url: 'https://localhost:4000',
+          urlExternal: 'https://localhost:4000',
+        },
         logger,
       );
 
@@ -150,7 +175,10 @@ describe('kiali Fetch', () => {
   describe('Handle Unsuccessful Response', () => {
     it('Respond with a readable message with endpoint', () => {
       const kialiFetch = new KialiFetcher(
-        { url: 'https://localhost:4000' },
+        {
+          url: 'https://localhost:4000',
+          urlExternal: 'https://localhost:4000',
+        },
         logger,
       );
       const message = 'Error server message';
@@ -169,7 +197,10 @@ describe('kiali Fetch', () => {
 
     it('Respond with a readable message without endpoint', () => {
       const kialiFetch = new KialiFetcher(
-        { url: 'https://localhost:4000' },
+        {
+          url: 'https://localhost:4000',
+          urlExternal: 'https://localhost:4000',
+        },
         logger,
       );
       const message = 'Error server message';

--- a/plugins/kiali-backend/src/service/config.test.ts
+++ b/plugins/kiali-backend/src/service/config.test.ts
@@ -16,6 +16,7 @@ describe('Configuration', () => {
     const result = readKialiConfigs(configuration);
     expect(result).toStrictEqual({
       url: 'https://localhost:4000/',
+      urlExternal: 'https://localhost:4000/',
       serviceAccountToken: undefined,
       skipTLSVerify: false,
       sessionTime: undefined,

--- a/plugins/kiali-backend/src/service/config.ts
+++ b/plugins/kiali-backend/src/service/config.ts
@@ -4,6 +4,7 @@ const KIALI_PREFIX = 'catalog.providers.kiali';
 
 export type KialiDetails = {
   url: string;
+  urlExternal: string;
   skipTLSVerify?: boolean;
   sessionTime?: number;
   serviceAccountToken?: string;
@@ -45,8 +46,14 @@ export const getHubClusterFromConfig = (config: Config): KialiDetails => {
     new URL(url).href => guarantees that the url will end in '/' 
     - If the user does not indicate the last character as /, URL class will put it
   */
+  const kialiExternal = hub.getOptionalString('urlExternal');
+  if (kialiExternal && kialiExternal !== '' && !isValidUrl(kialiExternal)) {
+    throw new Error(`"${kialiExternal}" is not a valid url`);
+  }
+  const externalUrl = kialiExternal ? kialiExternal : url;
   return {
     url: new URL(url).href,
+    urlExternal: new URL(externalUrl).href,
     serviceAccountToken: hub.getOptionalString('serviceAccountToken'),
     skipTLSVerify: hub.getOptionalBoolean('skipTLSVerify') || false,
     caData: hub.getOptionalString('caData'),

--- a/plugins/kiali-backend/src/service/router.ts
+++ b/plugins/kiali-backend/src/service/router.ts
@@ -5,7 +5,7 @@ import { Config } from '@backstage/config';
 import express from 'express';
 
 import { KialiApiImpl } from '../clients/KialiAPIConnector';
-import { readKialiConfigs } from './config';
+import { KialiDetails, readKialiConfigs } from './config';
 
 export interface RouterOptions {
   logger: LoggerService;
@@ -15,6 +15,7 @@ export interface RouterOptions {
 export const makeRouter = (
   logger: LoggerService,
   kialiAPI: KialiApiImpl,
+  kiali: KialiDetails,
 ): express.Router => {
   const router = express.Router();
   router.use(express.json());
@@ -23,7 +24,14 @@ export const makeRouter = (
   router.post('/proxy', async (req, res) => {
     const endpoint = req.body.endpoint;
     logger.info(`Call to Kiali ${endpoint}`);
-    res.json(await kialiAPI.proxy(endpoint));
+
+    kialiAPI.proxy(endpoint).then((response: any) => {
+      if (endpoint.includes('api/status')) {
+        // Include kiali external url to status
+        response.status.kialiExternalUrl = kiali.urlExternal;
+      }
+      res.json(response);
+    });
   });
 
   router.post('/status', async (_, res) => {
@@ -48,5 +56,5 @@ export async function createRouter(
 
   const kialiAPI = new KialiApiImpl({ logger, kiali });
 
-  return makeRouter(logger, kialiAPI);
+  return makeRouter(logger, kialiAPI, kiali);
 }

--- a/plugins/kiali/src/components/About/AboutUIModal.tsx
+++ b/plugins/kiali/src/components/About/AboutUIModal.tsx
@@ -132,6 +132,7 @@ export const AboutUIModal = (props: AboutUIModalProps) => {
         props.status[StatusKey.MESH_VERSION] || ''
       }`
     : 'Unknown';
+  const kialiExternalUrl = props.status[StatusKey.KIALI_EXTERNAL_URL];
 
   return (
     <Dialog
@@ -171,6 +172,12 @@ export const AboutUIModal = (props: AboutUIModalProps) => {
             </Grid>
             <Grid item xs={8}>
               {meshVersion || 'Unknown'}
+            </Grid>
+            <Grid item xs={4}>
+              Kiali External URL
+            </Grid>
+            <Grid item xs={8}>
+              {kialiExternalUrl}
             </Grid>
           </Grid>
         </Typography>

--- a/plugins/kiali/src/components/DetailDescription/DetailDescription.tsx
+++ b/plugins/kiali/src/components/DetailDescription/DetailDescription.tsx
@@ -106,7 +106,11 @@ export const DetailDescription: React.FC<Props> = (props: Props) => {
     }
 
     return (
-      <li key={`App_${namespace}_${appName}`} className={itemStyle}>
+      <li
+        key={`App_${namespace}_${appName}`}
+        data-test={`App_${namespace}_${appName}`}
+        className={itemStyle}
+      >
         <div className={iconStyle}>
           <PFBadge badge={PFBadges.App} position="top" />
         </div>
@@ -148,7 +152,11 @@ export const DetailDescription: React.FC<Props> = (props: Props) => {
     }
 
     return (
-      <li key={`Service_${serviceName}`} className={itemStyle}>
+      <li
+        key={`Service_${serviceName}`}
+        data-test={`Service_${serviceName}`}
+        className={itemStyle}
+      >
         <div className={iconStyle}>
           <PFBadge badge={PFBadges.Service} position="top" />
         </div>

--- a/plugins/kiali/src/components/Label/Labels.tsx
+++ b/plugins/kiali/src/components/Label/Labels.tsx
@@ -80,7 +80,7 @@ export const Labels: React.FC<LabelsProps> = (props: LabelsProps) => {
       placement="right"
       title={<div style={{ textAlign: 'left' }}>{props.tooltipMessage}</div>}
     >
-      <div>
+      <div data-test="help-icon">
         <KialiIcon.Info className={infoStyle} />
       </div>
     </Tooltip>

--- a/plugins/kiali/src/pages/WorkloadDetails/WorkloadsDescription.tsx
+++ b/plugins/kiali/src/pages/WorkloadDetails/WorkloadsDescription.tsx
@@ -172,8 +172,12 @@ export const WorkloadDescription: React.FC<WorkloadDescriptionProps> = (
       <CardHeader
         title={
           <>
-            <Typography variant="h6" style={{ margin: '10px' }}>
-              <div key="service-icon" className={iconStyle}>
+            <Typography
+              variant="h6"
+              style={{ margin: '10px' }}
+              data-test="workload-title"
+            >
+              <div key="service-icon" className={iconStyle} data-test="w-badge">
                 <PFBadge badge={PFBadges.Workload} position="top" />
               </div>
 

--- a/plugins/kiali/src/types/StatusState.ts
+++ b/plugins/kiali/src/types/StatusState.ts
@@ -6,6 +6,7 @@ export enum StatusKey {
   KIALI_STATE = 'Kiali state',
   MESH_NAME = 'Mesh name',
   MESH_VERSION = 'Mesh version',
+  KIALI_EXTERNAL_URL = 'kialiExternalUrl',
 }
 
 export type Status = { [K in StatusKey]?: string };

--- a/plugins/kiali/tests/entityResources.spec.ts
+++ b/plugins/kiali/tests/entityResources.spec.ts
@@ -86,6 +86,39 @@ test.describe('Entity resources', () => {
       expect(page.locator('[data-test="drawer"]')).toBeDefined();
     });
 
+    // Verify drawer date
+    test('Workload Drawer Data', async () => {
+      const wbadge = page.locator('[data-test="w-badge"]');
+      expect(wbadge).toBeDefined();
+      await expect(wbadge).toContainText('W');
+
+      const title = page.locator('[data-test="workload-title"]');
+      expect(title).toBeDefined();
+      await expect(title).toContainText('details-v1');
+
+      const health = title.locator('[data-test="health"]');
+      expect(health).toBeDefined();
+      await health.hover();
+      const tooltip = page.getByRole('tooltip');
+      await expect(tooltip).toContainText('Pod Status');
+
+      const labels = page.locator('[data-test="app-label-container"]');
+      await expect(labels).toContainText('app=details');
+      const versionLabels = page.locator(
+        '[data-test="version-label-container"]',
+      );
+      await expect(versionLabels).toContainText('version=v1');
+      expect(page.locator('[data-test="help-icon"]')).toBeDefined();
+
+      const appLinks = page.locator('[data-test="App_bookinfo_details"]');
+      await expect(appLinks).toContainText('A');
+      await expect(appLinks).toContainText('details');
+
+      const serviceLinks = page.locator('[data-test="Service_details"]');
+      await expect(serviceLinks).toContainText('S');
+      await expect(serviceLinks).toContainText('details');
+    });
+
     // The drawer is closed
     test('Close drawer', async () => {
       await page.locator('#close_drawer').click();


### PR DESCRIPTION
```
    kiali:
      # Required. Kiali endpoint
      url: ${KIALI_BASE_URL}
      # Optional. Kiali public URL to redirect to standalone Kiali. When not specified, url will be used.
      urlExternal: ''
```

This URL is also displayed in the about window, it can be used to verify: 

![image](https://github.com/janus-idp/backstage-plugins/assets/49480155/5b835f6f-a4c6-49e4-817f-43ea46d42b9c)

- Added some test coverage for resources card.