### PR TITLE
fix(rbac): casbinDBAdapterFactory supporting postgres schema configuration

### DIFF
--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
@@ -61,6 +61,7 @@ describe('CasbinAdapterFactory', () => {
             connection: {
               host: 'localhost',
               port: '5432',
+              schema: 'public',
               user: 'postgresUser',
               password: process.env.TEST,
             },
@@ -74,6 +75,7 @@ describe('CasbinAdapterFactory', () => {
         type: 'postgres',
         host: 'localhost',
         port: 5432,
+        schema: 'public',
         username: 'postgresUser',
         password: process.env.TEST,
         database: 'test-database',
@@ -89,6 +91,7 @@ describe('CasbinAdapterFactory', () => {
             connection: {
               host: 'localhost',
               port: '5432',
+              schema: 'public',
               user: 'postgresUser',
               password: process.env.TEST,
               ssl: true,
@@ -103,6 +106,7 @@ describe('CasbinAdapterFactory', () => {
         type: 'postgres',
         host: 'localhost',
         port: 5432,
+        schema: 'public',
         username: 'postgresUser',
         password: process.env.TEST,
         database: 'test-database',
@@ -118,6 +122,7 @@ describe('CasbinAdapterFactory', () => {
             connection: {
               host: 'localhost',
               port: '5432',
+              schema: 'public',
               user: 'postgresUser',
               password: process.env.TEST,
               ssl: false,
@@ -132,6 +137,7 @@ describe('CasbinAdapterFactory', () => {
         type: 'postgres',
         host: 'localhost',
         port: 5432,
+        schema: 'public',
         username: 'postgresUser',
         password: process.env.TEST,
         database: 'test-database',
@@ -147,6 +153,7 @@ describe('CasbinAdapterFactory', () => {
             connection: {
               host: 'localhost',
               port: '5432',
+              schema: 'public',
               user: 'postgresUser',
               password: process.env.TEST,
               ssl: {
@@ -163,6 +170,7 @@ describe('CasbinAdapterFactory', () => {
         type: 'postgres',
         host: 'localhost',
         port: 5432,
+        schema: 'public',
         username: 'postgresUser',
         password: process.env.TEST,
         database: 'test-database',

--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
@@ -23,6 +23,7 @@ export class CasbinDBAdapterFactory {
     if (client === 'pg') {
       const dbName =
         await this.databaseClient.client.config.connection.database;
+      const schema = await this.databaseClient.client.searchPath?.[0] ?? 'public';
 
       const ssl = this.handleSSL(databaseConfig!);
 
@@ -34,6 +35,7 @@ export class CasbinDBAdapterFactory {
         password: databaseConfig?.getString('connection.password'),
         ssl,
         database: dbName,
+        schema: schema,
       });
     }
 

--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
@@ -23,7 +23,8 @@ export class CasbinDBAdapterFactory {
     if (client === 'pg') {
       const dbName =
         await this.databaseClient.client.config.connection.database;
-      const schema = await this.databaseClient.client.searchPath?.[0] ?? 'public';
+      const schema =
+        (await this.databaseClient.client.searchPath?.[0]) ?? 'public';
 
       const ssl = this.handleSSL(databaseConfig!);
 


### PR DESCRIPTION
When Backstage uses a single database, the **casbin_rule** table is created in the **public** schema instead of the **permission** schema.
https://backstage.io/docs/tutorials/switching-sqlite-postgres/#using-a-single-database

![image](https://github.com/janus-idp/backstage-plugins/assets/5660161/30c37516-cc91-4c1b-bb19-a2bf2b4f8edd)
