### PR TITLE
feat(orchestrator): fix build failure from #1833

### DIFF
--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -1173,12 +1173,6 @@ function setupInternalRoutes(
           .json({ message: error.message || INTERNAL_SERVER_ERROR_MESSAGE });
       });
   });
-
-  router.post('/webhook/jira', async (req, res) => {
-    const event = req.body as JiraEvent;
-    await services.jiraService.handleEvent(event);
-    res.status(200).send();
-  });
 }
 
 // ======================================================


### PR DESCRIPTION
This pr fixes the [build](https://github.com/janus-idp/backstage-plugins/actions/runs/9698241417/job/26765971595) failure on main branch from [#1833](https://github.com/janus-idp/backstage-plugins/pull/1833). It only removes the obsolete route and dependencies.