### PR TITLE
feat(tekton): add permissions support for tekton plugin

### DIFF
--- a/plugins/rbac-backend/docs/permissions.md
+++ b/plugins/rbac-backend/docs/permissions.md
@@ -113,6 +113,13 @@ Resource type permissions on the other hand are basic named permissions with a r
 | ocm.entity.read  |               | read   | Allows the user to read from the ocm plugin                       | X            |
 | ocm.cluster.read |               | read   | Allows the user to read the cluster information in the ocm plugin | X            |
 
+## Tekton
+
+| Name             | Resource Type | Policy | Description                                                                                                        | Requirements        |
+| ---------------- | ------------- | ------ | ------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| tekton.view.read |               | read   | Allows the user to view the tekton plugin                                                                          | catalog.entity.read |
+| kubernetes.proxy |               |        | Allows the user to access the proxy endpoint (ability to read tekton pod logs and events within Showcase and RHDH) | catalog.entity.read |
+
 ## Topology
 
 | Name               | Resource Type | Policy | Description                                                                                                 | Requirements        |

--- a/plugins/tekton-common/.eslintrc.js
+++ b/plugins/tekton-common/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/tekton-common/README.md
+++ b/plugins/tekton-common/README.md
@@ -1,0 +1,11 @@
+# Tekton Common plugin
+
+Welcome to the tekton-common plugin!
+
+This plugin contains common utilities for the tekton plugin.
+
+# Tekton plugin for Backstage
+
+The Tekton plugin enables you to visualize the `PipelineRun` resources available on the Kubernetes cluster.
+
+For more information about Tekton plugin, see the [Tekton plugin documentation](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/tekton) on GitHub.

--- a/plugins/tekton-common/package.json
+++ b/plugins/tekton-common/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@janus-idp/backstage-plugin-tekton-common",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "module": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "common-library",
+    "supported-versions": "1.28.4",
+    "pluginId": "tekton",
+    "pluginPackages": [
+      "@janus-idp/backstage-plugin-tekton",
+      "@janus-idp/backstage-plugin-tekton-common"
+    ]
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
+    "lint": "backstage-cli package lint",
+    "postpack": "backstage-cli package postpack",
+    "prepack": "backstage-cli package prepack",
+    "test": "backstage-cli package test --passWithNoTests --coverage",
+    "tsc": "tsc"
+  },
+  "dependencies": {
+    "@backstage/plugin-permission-common": "^0.8.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.26.11"
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/janus-idp/backstage-plugins",
+    "directory": "plugins/tekton-common"
+  },
+  "keywords": [
+    "support:production",
+    "lifecycle:active",
+    "backstage",
+    "plugin"
+  ],
+  "author": "Red Hat",
+  "homepage": "https://red.ht/rhdh",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
+  "maintainers": [
+    "janus-idp/rhtap"
+  ]
+}

--- a/plugins/tekton-common/src/index.ts
+++ b/plugins/tekton-common/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Common functionalities for the tekton plugin.
+ *
+ * @packageDocumentation
+ */
+
+export * from './permissions';

--- a/plugins/tekton-common/src/permissions.ts
+++ b/plugins/tekton-common/src/permissions.ts
@@ -1,0 +1,13 @@
+import { createPermission } from '@backstage/plugin-permission-common';
+
+export const tektonViewPermission = createPermission({
+  name: 'tekton.view.read',
+  attributes: {
+    action: 'read',
+  },
+});
+
+/**
+ * List of all permissions on permission polices.
+ */
+export const tektonPermissions = [tektonViewPermission];

--- a/plugins/tekton-common/tsconfig.json
+++ b/plugins/tekton-common/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "include": ["src", "dev"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "../../dist-types/plugins/tekton-common",
+    "rootDir": "."
+  }
+}

--- a/plugins/tekton-common/turbo.json
+++ b/plugins/tekton-common/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "tsc": {
+      "outputs": ["../../dist-types/plugins/tekton-common/**"],
+      "dependsOn": ["^tsc"]
+    }
+  }
+}

--- a/plugins/tekton/dev/index.tsx
+++ b/plugins/tekton/dev/index.tsx
@@ -10,7 +10,8 @@ import {
   KubernetesProxyApi,
   kubernetesProxyApiRef,
 } from '@backstage/plugin-kubernetes';
-import { TestApiProvider } from '@backstage/test-utils';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
+import { MockPermissionApi, TestApiProvider } from '@backstage/test-utils';
 
 import { createDevAppThemes } from '@redhat-developer/red-hat-developer-hub-theme';
 
@@ -41,6 +42,7 @@ const mockEntity: Entity = {
   },
 };
 
+const mockPermissionApi = new MockPermissionApi();
 class MockKubernetesProxyApi implements KubernetesProxyApi {
   async getPodLogs(_request: any): Promise<any> {
     const delayedResponse = (data: string, ms: number) =>
@@ -177,6 +179,7 @@ createDevApp()
             new MockKubernetesClient(mockKubernetesPlrResponse),
           ],
           [kubernetesProxyApiRef, new MockKubernetesProxyApi()],
+          [permissionApiRef, mockPermissionApi],
         ]}
       >
         <EntityProvider entity={mockEntity}>

--- a/plugins/tekton/package.json
+++ b/plugins/tekton/package.json
@@ -15,7 +15,8 @@
     "pluginId": "tekton",
     "pluginPackage": "@janus-idp/backstage-plugin-tekton",
     "pluginPackages": [
-      "@janus-idp/backstage-plugin-tekton"
+      "@janus-idp/backstage-plugin-tekton",
+      "@janus-idp/backstage-plugin-tekton-common"
     ]
   },
   "sideEffects": false,
@@ -42,6 +43,8 @@
     "@backstage/plugin-kubernetes-common": "^0.8.1",
     "@backstage/theme": "^0.5.6",
     "@janus-idp/shared-react": "2.9.0",
+    "@backstage/plugin-permission-react": "^0.4.24",
+    "@janus-idp/backstage-plugin-tekton-common": "0.1.0",
     "@kubernetes/client-node": "^0.20.0",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunList.test.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunList.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
+import { usePermission } from '@backstage/plugin-permission-react';
+
 import { render } from '@testing-library/react';
 
 import { ComputedStatus } from '@janus-idp/shared-react';
@@ -19,7 +21,19 @@ jest.mock('@backstage/plugin-catalog-react', () => ({
   }),
 }));
 
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: jest.fn(),
+}));
+
+const mockUsePermission = usePermission as jest.MockedFunction<
+  typeof usePermission
+>;
+
 describe('PipelineRunList', () => {
+  beforeEach(() => {
+    mockUsePermission.mockReturnValue({ loading: false, allowed: true });
+  });
+
   it('should render PipelineRunList if available', () => {
     const mockContextData = {
       watchResourcesData: {

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+import { kubernetesProxyPermission } from '@backstage/plugin-kubernetes-common';
+import { usePermission } from '@backstage/plugin-permission-react';
+
 import { IconButton } from '@material-ui/core';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
@@ -38,6 +41,10 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
     taskRuns,
   );
   const activeTaskName = sbomTaskRun?.metadata?.name;
+
+  const hasKubernetesProxyAccess = usePermission({
+    permission: kubernetesProxyPermission,
+  });
 
   const openDialog = (viewLogs?: boolean) => {
     if (viewLogs) setNoActiveTask(true);
@@ -100,9 +107,21 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
       />
       <Flex gap={{ default: 'gapXs' }}>
         <FlexItem>
-          <Tooltip content="View logs">
-            <IconButton size="small" onClick={() => openDialog(true)}>
-              <ViewLogsIcon />
+          <Tooltip
+            content={
+              hasKubernetesProxyAccess.allowed
+                ? 'View logs'
+                : 'Unauthorized to view logs'
+            }
+          >
+            <IconButton
+              size="small"
+              data-testid="view-logs-icon"
+              onClick={() => openDialog(true)}
+              disabled={!hasKubernetesProxyAccess.allowed}
+              style={{ pointerEvents: 'auto', padding: 0 }}
+            >
+              <ViewLogsIcon disabled={!hasKubernetesProxyAccess.allowed} />
             </IconButton>
           </Tooltip>
         </FlexItem>

--- a/plugins/tekton/src/components/Tekton/TektonCIComponent.test.tsx
+++ b/plugins/tekton/src/components/Tekton/TektonCIComponent.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { usePermission } from '@backstage/plugin-permission-react';
+
 import { render } from '@testing-library/react';
 
 import { TektonCIComponent } from './TektonCIComponent';
@@ -23,7 +25,25 @@ jest.mock('../../hooks/useTektonObjectsResponse', () => ({
   }),
 }));
 
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: jest.fn(),
+}));
+
+const mockUsePermission = usePermission as jest.MockedFunction<
+  typeof usePermission
+>;
+
 describe('TektonComponent', () => {
+  beforeEach(() => {
+    mockUsePermission.mockReturnValue({ loading: false, allowed: true });
+  });
+
+  it('should render Permission alert if the user does not have view permission', () => {
+    mockUsePermission.mockReturnValue({ loading: false, allowed: false });
+    const { getByTestId } = render(<TektonCIComponent />);
+    expect(getByTestId('no-permission-alert')).toBeInTheDocument();
+  });
+
   it('should render TektonComponent', () => {
     const { getByText } = render(<TektonCIComponent />);
     expect(getByText(/No Pipeline Runs found/i)).not.toBeNull();

--- a/plugins/tekton/src/components/Tekton/TektonCIComponent.tsx
+++ b/plugins/tekton/src/components/Tekton/TektonCIComponent.tsx
@@ -3,7 +3,9 @@ import React from 'react';
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
 import { useDarkTheme } from '../../hooks/useDarkTheme';
 import { useTektonObjectsResponse } from '../../hooks/useTektonObjectsResponse';
+import { useTektonViewPermission } from '../../hooks/useTektonViewPermission';
 import { ModelsPlural } from '../../models';
+import PermissionAlert from '../common/PermissionAlert';
 import PipelineRunList from '../PipelineRunList/PipelineRunList';
 
 export const TektonCIComponent = () => {
@@ -15,7 +17,11 @@ export const TektonCIComponent = () => {
     ModelsPlural.pods,
   ];
   const tektonResourcesContextData = useTektonObjectsResponse(watchedResources);
+  const hasViewPermission = useTektonViewPermission();
 
+  if (!hasViewPermission) {
+    return <PermissionAlert />;
+  }
   return (
     <TektonResourcesContext.Provider value={tektonResourcesContextData}>
       <PipelineRunList />

--- a/plugins/tekton/src/components/common/PermissionAlert.tsx
+++ b/plugins/tekton/src/components/common/PermissionAlert.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Alert, AlertTitle } from '@material-ui/lab';
+
+const PermissionAlert = () => {
+  return (
+    <Alert severity="warning" data-testid="no-permission-alert">
+      <AlertTitle>Permission required</AlertTitle>
+      To view Tekton Pipeline Runs, contact your administrator to give you the
+      tekton.view.read permission.
+    </Alert>
+  );
+};
+export default PermissionAlert;

--- a/plugins/tekton/src/hooks/useTektonViewPermission.ts
+++ b/plugins/tekton/src/hooks/useTektonViewPermission.ts
@@ -1,0 +1,11 @@
+import { usePermission } from '@backstage/plugin-permission-react';
+
+import { tektonViewPermission } from '@janus-idp/backstage-plugin-tekton-common';
+
+export const useTektonViewPermission = () => {
+  const tektonViewPermissionResult = usePermission({
+    permission: tektonViewPermission,
+  });
+
+  return tektonViewPermissionResult.allowed;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,23 +2559,6 @@
     knex "^3.0.0"
     luxon "^3.0.0"
 
-"@backstage/backend-plugin-api@^0.6.21":
-  version "0.6.21"
-  resolved "https://registry.npmjs.org/@backstage/backend-plugin-api/-/backend-plugin-api-0.6.21.tgz#0d1b9222a8e69cfd500a0789edaff7d14a77dffe"
-  integrity sha512-Cek3jgJmUY6oGDAYd7o/M6fezSnOIHzCBEsJHeE4vakdZ2vYOGVWPGIQmWSylEhK/oEL54JUslB5VjHo1onL9A==
-  dependencies:
-    "@backstage/cli-common" "^0.1.14"
-    "@backstage/config" "^1.2.0"
-    "@backstage/errors" "^1.2.4"
-    "@backstage/plugin-auth-node" "^0.4.16"
-    "@backstage/plugin-permission-common" "^0.7.14"
-    "@backstage/types" "^1.1.1"
-    "@types/express" "^4.17.6"
-    "@types/luxon" "^3.0.0"
-    express "^4.17.1"
-    knex "^3.0.0"
-    luxon "^3.0.0"
-
 "@backstage/backend-tasks@0.5.27", "@backstage/backend-tasks@^0.5.27":
   version "0.5.27"
   resolved "https://registry.yarnpkg.com/@backstage/backend-tasks/-/backend-tasks-0.5.27.tgz#e79517412135ddc2716152decf8e3fd6296c3a88"
@@ -2651,7 +2634,7 @@
   resolved "https://registry.yarnpkg.com/@backstage/cli-common/-/cli-common-0.1.14.tgz#2291520acfbac860a05dd48fc3b876d5cd789b76"
   integrity sha512-4kGWGrFuxoaCne2aHCOVW+vi8y2MLEMEj785SEApMG2J8jXJXUuIOzWw0MrN0pM1FqBXDb6aeQd+bmQMK/Ci+w==
 
-"@backstage/cli-node@^0.2.6", "@backstage/cli-node@^0.2.7":
+"@backstage/cli-node@^0.2.7":
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/@backstage/cli-node/-/cli-node-0.2.7.tgz#8f104698c9ae9bf2602572681b07e141aa7ce8f4"
   integrity sha512-fmGjmDFNMrc78qqOEnvpXmIErGq1hJ61A4yJU8iWzT/msEZNCt48Mza/D+nv53rfapsgJm1zYdhhqZRQpP5OkA==
@@ -3295,7 +3278,7 @@
     winston "^3.2.1"
     yn "^4.0.0"
 
-"@backstage/plugin-auth-node@0.4.17", "@backstage/plugin-auth-node@^0.4.16", "@backstage/plugin-auth-node@^0.4.17":
+"@backstage/plugin-auth-node@0.4.17", "@backstage/plugin-auth-node@^0.4.17":
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-node/-/plugin-auth-node-0.4.17.tgz#1e890a31ba0795b0c51720282fc72c31c5b7cc2a"
   integrity sha512-nNZPWPRMCfU0LoxV15bfClPUfZ8XbnKDC4VTMRGyXo37FdRI9uNvrSrZm++e0QKCR/xGfab377SByp/9jITKmQ==
@@ -3715,18 +3698,6 @@
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.8.0.tgz#13d29c146c50e9de1da47296c167ace9d1bc86f3"
   integrity sha512-4c8QfjDKiTJbQfiG3DibUqUsclsi53kRk8GR9CwHl1Is2Xm98AkqXGWyknHGPQOvw4vJR19nqnj7w0XfhLK2Jw==
-  dependencies:
-    "@backstage/config" "^1.2.0"
-    "@backstage/errors" "^1.2.4"
-    "@backstage/types" "^1.1.1"
-    cross-fetch "^4.0.0"
-    uuid "^9.0.0"
-    zod "^3.22.4"
-
-"@backstage/plugin-permission-common@^0.7.14":
-  version "0.7.14"
-  resolved "https://registry.npmjs.org/@backstage/plugin-permission-common/-/plugin-permission-common-0.7.14.tgz#ecb12877c412ff271124af54fca46ec06d9c812f"
-  integrity sha512-fHbxhX9ZoT8bTVuGycfTeU/6TE2yjZ6YNvm/2ko1bcxGnvYe1p5Ug5JW+iWjDZS+F6F152tWzhRcg05wQlPNKQ==
   dependencies:
     "@backstage/config" "^1.2.0"
     "@backstage/errors" "^1.2.4"
@@ -5791,83 +5762,6 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
-
-"@janus-idp/backstage-plugin-audit-log-node@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@janus-idp/backstage-plugin-audit-log-node/-/backstage-plugin-audit-log-node-1.3.0.tgz#f9cbed06fb3470e4f91fce494dfa1012ffcffe3e"
-  integrity sha512-s1IsCPl9lwuPxLzCLZ0/wEcIL5LIjr8pOXWuBKCTM8Lqk7cdRj6YsMDVtdRiHXmy+7nPdqgLfDJFUupZfAlxbA==
-  dependencies:
-    "@backstage/backend-plugin-api" "^0.6.21"
-    "@backstage/errors" "^1.2.4"
-    "@backstage/types" "^1.1.1"
-    express "^4.19.2"
-    lodash "^4.17.21"
-
-"@janus-idp/cli@1.12.0":
-  version "1.12.0"
-  resolved "https://registry.npmjs.org/@janus-idp/cli/-/cli-1.12.0.tgz#6bbb95a116c2db57fde370a5a20c378f6bb61c3e"
-  integrity sha512-HDMH3xBFH5ZtLnVX9S7aCknj0CX3cy9whAO9ovIojNUEytRKxtELtyqTsXzubuU0w7eaXqIXXxtKiRvilERnEw==
-  dependencies:
-    "@backstage/cli-common" "^0.1.14"
-    "@backstage/cli-node" "^0.2.6"
-    "@backstage/config" "^1.2.0"
-    "@backstage/config-loader" "^1.8.1"
-    "@backstage/errors" "^1.2.4"
-    "@backstage/eslint-plugin" "^0.1.8"
-    "@backstage/types" "^1.1.1"
-    "@manypkg/get-packages" "^1.1.3"
-    "@openshift/dynamic-plugin-sdk-webpack" "^3.0.0"
-    "@pmmmwh/react-refresh-webpack-plugin" "^0.5.7"
-    "@rollup/plugin-commonjs" "^25.0.4"
-    "@rollup/plugin-json" "^6.0.0"
-    "@rollup/plugin-node-resolve" "^15.2.1"
-    "@rollup/plugin-yaml" "^4.0.0"
-    "@svgr/rollup" "^8.1.0"
-    "@svgr/webpack" "^6.5.1"
-    "@yarnpkg/lockfile" "^1.1.0"
-    "@yarnpkg/parsers" "^3.0.0-rc.4"
-    bfj "^8.0.0"
-    chalk "^4.0.0"
-    chokidar "^3.3.1"
-    codeowners "^5.1.1"
-    commander "^9.1.0"
-    css-loader "^6.5.1"
-    esbuild "^0.21.0"
-    esbuild-loader "^2.18.0"
-    eslint "^8.49.0"
-    eslint-config-prettier "^8.10.0"
-    eslint-webpack-plugin "^3.2.0"
-    express "^4.18.2"
-    fork-ts-checker-webpack-plugin "^7.0.0-alpha.8"
-    fs-extra "^10.1.0"
-    gitconfiglocal "2.1.0"
-    handlebars "^4.7.7"
-    html-webpack-plugin "^5.3.1"
-    inquirer "^8.2.0"
-    is-native-module "^1.1.3"
-    lodash "^4.17.21"
-    mini-css-extract-plugin "^2.4.2"
-    node-libs-browser "^2.2.1"
-    npm-packlist "^5.0.0"
-    ora "^5.3.0"
-    postcss "^8.2.13"
-    process "^0.11.10"
-    react-dev-utils "^12.0.0-next.60"
-    react-refresh "^0.14.0"
-    recursive-readdir "^2.2.2"
-    rollup "^2.78.0"
-    rollup-plugin-dts "^4.0.1"
-    rollup-plugin-esbuild "^4.7.2"
-    rollup-plugin-postcss "^4.0.0"
-    rollup-pluginutils "^2.8.2"
-    semver "^7.5.4"
-    style-loader "^3.3.1"
-    swc-loader "^0.2.3"
-    typescript-json-schema "^0.63.0"
-    webpack "^5.89.0"
-    webpack-dev-server "^4.15.1"
-    yml-loader "^2.1.0"
-    yn "^4.0.0"
 
 "@jest/console@^29.7.0":
   version "29.7.0"


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/RHIDP-1793

**Description:**

This PR adds support for RBAC permission in tekton plugin. `tetkon.view.read` Permission allows the user view the tekton plugin component and `kubernetes.proxy` permission allow the user to view the logs. If the `kubernetes.proxy` permission is not available then the `view logs` action is disabled with `Unauthorized to view logs` tooltip.

**Screenshots:**
---
**Without `tekton.view.read`  Permission:**

![Tekton_no_permission](https://github.com/janus-idp/backstage-plugins/assets/9964343/7a98de0e-cb6c-4f35-8f2f-27467f36a06d)


**With `tekton.view.read`  Permission and without `kubernetes.proxy` permission logs action is disabled with tooltip:**


![logs_disabled](https://github.com/janus-idp/backstage-plugins/assets/9964343/c7249bee-55be-48db-aca9-412b0aa0dd6a)

---
**With  `tekton.view.read` and `kubernetes.proxy`  permission:**

![Tekton_with_permission](https://github.com/janus-idp/backstage-plugins/assets/9964343/54fc3d72-3ccc-4771-a216-523c1eda6ba3)
![tekton_logs_with_permission](https://github.com/janus-idp/backstage-plugins/assets/9964343/ce509a6a-6020-49cf-a22b-68373756829c)

---
**How to test:**



1. [Configure the Tekton plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/tekton#configuration) and add Github integration.
2. Create a policy file `rbac.csv` for the permission policies
```
    g, user:default/<YOUR_USERNAME>, role:default/tekton-viewer
    
    p, role:default/tekton-viewer, tekton.view.read, read, allow
    p, role:default/tekton-viewer, kubernetes.proxy, use, allow

    p, role:default/tekton-viewer, catalog-entity.read, read, allow
    p, role:default/tekton-viewer, catalog-entity.create, create, allow


```

3. Configure the RBAC Backend plugin to include the tekton permission.
  

  ```permission:
    enabled: true
    rbac:
      policies-csv-file: ../<PATH>/<TO>/<CSV>/rbac-policy.csv
      policyFileReload: true
```
4. Annotate the catalog component to include tekton pipelinerun

```
    'janus-idp.io/tekton': quarkus-app
```
5. Register the component and view the CI tab to see the pipelineruns working.
6. `deny` the `kubernetes.proxy` permission from the `rbac.csv` to see the view logs button getting disabled.
7. Now `deny` the `tekton.view.read` permission from the `rbac.csv` file and wait for the application to auto-reload. you should see the `Permission required` alert.
 

---
**Unit tests:**

```
 PASS  src/components/PipelineRunList/__tests__/PipelineRunRowActions.test.tsx (5.998 s)
  PipelineRunRowActions
    ✓ should disable the view logs action if the user does not have enough permission (20 ms)
```

```
 PASS  src/components/Tekton/TektonCIComponent.test.tsx (7.25 s)
  TektonComponent
    ✓ should render Permission alert if the user does not have view permission (49 ms)
    ✓ should render TektonComponent (163 ms)

```   

cc: @kim-tsao @rohitkrai03 @nickboldt @invincibleJai 


