### PR TITLE
feat(argocd): add permission support for argocd

### DIFF
--- a/plugins/argocd-common/.eslintrc.js
+++ b/plugins/argocd-common/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/argocd-common/README.md
+++ b/plugins/argocd-common/README.md
@@ -1,0 +1,11 @@
+# argocd-common
+
+Welcome to the argocd-common plugin!
+
+This plugin contains common utilities for the argocd plugin.
+
+# Argocd plugin for Backstage
+
+The Argocd plugin displays the information about your argocd applications in your Backstage application.
+
+For more information about Argocd plugin, see the [Argocd plugin documentation](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/argocd) on GitHub.

--- a/plugins/argocd-common/package.json
+++ b/plugins/argocd-common/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@janus-idp/backstage-plugin-argocd-common",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "module": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "common-library",
+    "supported-versions": "1.28.4",
+    "pluginId": "argocd",
+    "pluginPackages": [
+      "@janus-idp/backstage-plugin-argocd",
+      "@janus-idp/backstage-plugin-argocd-common"
+    ]
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
+    "lint": "backstage-cli package lint",
+    "postpack": "backstage-cli packag e postpack",
+    "prepack": "backstage-cli package prepack",
+    "test": "backstage-cli package test --passWithNoTests --coverage",
+    "tsc": "tsc"
+  },
+  "dependencies": {
+    "@backstage/plugin-permission-common": "^0.8.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.26.11"
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/janus-idp/backstage-plugins.git",
+    "directory": "plugins/argocd-common"
+  },
+  "keywords": [
+    "support:production",
+    "lifecycle:active",
+    "backstage",
+    "plugin"
+  ],
+  "homepage": "https://red.ht/rhdh",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues"
+}

--- a/plugins/argocd-common/src/index.ts
+++ b/plugins/argocd-common/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Common functionalities for the argocd plugin.
+ *
+ * @packageDocumentation
+ */
+
+export * from './permissions';

--- a/plugins/argocd-common/src/permissions.ts
+++ b/plugins/argocd-common/src/permissions.ts
@@ -1,0 +1,13 @@
+import { createPermission } from '@backstage/plugin-permission-common';
+
+export const argocdViewPermission = createPermission({
+  name: 'argocd.view.read',
+  attributes: {
+    action: 'read',
+  },
+});
+
+/**
+ * List of all permissions on permission polices.
+ */
+export const argocdPermissions = [argocdViewPermission];

--- a/plugins/argocd-common/tsconfig.json
+++ b/plugins/argocd-common/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "include": ["src", "dev"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "../../dist-types/plugins/argocd-common",
+    "rootDir": "."
+  }
+}

--- a/plugins/argocd-common/turbo.json
+++ b/plugins/argocd-common/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "tsc": {
+      "outputs": ["../../dist-types/plugins/argocd-common/**"],
+      "dependsOn": ["^tsc"]
+    }
+  }
+}

--- a/plugins/argocd/dev/index.tsx
+++ b/plugins/argocd/dev/index.tsx
@@ -5,7 +5,8 @@ import { ConfigReader } from '@backstage/config';
 import { configApiRef } from '@backstage/core-plugin-api';
 import { createDevApp } from '@backstage/dev-utils';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
-import { TestApiProvider } from '@backstage/test-utils';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
+import { MockPermissionApi, TestApiProvider } from '@backstage/test-utils';
 
 import { Box } from '@material-ui/core';
 import { createDevAppThemes } from '@redhat-developer/red-hat-developer-hub-theme';
@@ -47,7 +48,7 @@ const mockEntity: Entity = {
     owner: 'user:guest',
   },
 };
-
+const mockPermissionApi = new MockPermissionApi();
 export class MockArgoCDApiClient implements ArgoCDApi {
   async listApps(_options: listAppsOptions): Promise<any> {
     return { items: [mockApplication, preProdApplication, prodApplication] };
@@ -72,6 +73,7 @@ createDevApp()
         apis={[
           [configApiRef, new ConfigReader(mockArgocdConfig)],
           [argoCDApiRef, new MockArgoCDApiClient()],
+          [permissionApiRef, mockPermissionApi],
         ]}
       >
         <EntityProvider entity={mockEntity}>

--- a/plugins/argocd/package.json
+++ b/plugins/argocd/package.json
@@ -15,7 +15,8 @@
     "pluginId": "argocd",
     "pluginPackage": "@janus-idp/backstage-plugin-argocd",
     "pluginPackages": [
-      "@janus-idp/backstage-plugin-argocd"
+      "@janus-idp/backstage-plugin-argocd",
+      "@janus-idp/backstage-plugin-argocd-common"
     ]
   },
   "sideEffects": false,
@@ -37,6 +38,8 @@
     "@backstage/core-components": "^0.14.9",
     "@backstage/core-plugin-api": "^1.9.3",
     "@backstage/plugin-catalog-react": "^1.12.2",
+    "@backstage/plugin-permission-react": "^0.4.24",
+    "@janus-idp/backstage-plugin-argocd-common": "0.1.0",
     "@backstage/theme": "^0.5.6",
     "@kubernetes/client-node": "^0.20.0",
     "@material-ui/core": "^4.9.13",

--- a/plugins/argocd/src/components/Common/PermissionAlert.tsx
+++ b/plugins/argocd/src/components/Common/PermissionAlert.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Alert, AlertTitle } from '@material-ui/lab';
+
+const PermissionAlert = () => {
+  return (
+    <Alert severity="warning" data-testid="no-permission-alert">
+      <AlertTitle>Permission required</AlertTitle>
+      To view argocd plugin, contact your administrator to give you the
+      argocd.view.read permission.
+    </Alert>
+  );
+};
+export default PermissionAlert;

--- a/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
@@ -9,12 +9,14 @@ import { createStyles, makeStyles, Theme, Typography } from '@material-ui/core';
 import { argoCDApiRef } from '../../api';
 import { useApplications } from '../../hooks/useApplications';
 import { useArgocdConfig } from '../../hooks/useArgocdConfig';
+import { useArgocdViewPermission } from '../../hooks/useArgocdViewPermission';
 import { Application, Revision } from '../../types';
 import {
   getAppSelector,
   getInstanceName,
   getUniqueRevisions,
 } from '../../utils/utils';
+import PermissionAlert from '../Common/PermissionAlert';
 import DeploymentLifecycleCard from './DeploymentLifecycleCard';
 import DeploymentLifecycleDrawer from './DeploymentLifecycleDrawer';
 
@@ -49,6 +51,8 @@ const DeploymentLifecycle = () => {
     intervalMs,
     appSelector: encodeURIComponent(getAppSelector(entity)),
   });
+
+  const hasArgocdViewAccess = useArgocdViewPermission();
 
   const [open, setOpen] = React.useState(false);
   const [activeItem, setActiveItem] = React.useState<string>();
@@ -86,6 +90,10 @@ const DeploymentLifecycle = () => {
   const toggleDrawer = () => setOpen(e => !e);
 
   const activeApp = apps.find(a => a.metadata.name === activeItem);
+
+  if (!hasArgocdViewAccess) {
+    return <PermissionAlert />;
+  }
 
   if (error) {
     return <ResponseErrorPanel data-testid="error-panel" error={error} />;

--- a/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -9,6 +9,7 @@ import moment from 'moment';
 
 import { useApplications } from '../../hooks/useApplications';
 import { useArgocdConfig } from '../../hooks/useArgocdConfig';
+import { useArgocdViewPermission } from '../../hooks/useArgocdViewPermission';
 import { Application, HealthStatus, SyncStatuses } from '../../types';
 import {
   getAppSelector,
@@ -31,6 +32,8 @@ const DeploymentSummary = () => {
     appSelector: encodeURIComponent(getAppSelector(entity)),
     projectName: getProjectName(entity),
   });
+
+  const hasArgocdViewAccess = useArgocdViewPermission();
 
   const supportsMultipleArgoInstances = !!instances.length;
   const getBaseUrl = (row: any): string | undefined => {
@@ -162,7 +165,7 @@ const DeploymentSummary = () => {
     },
   ];
 
-  return !error ? (
+  return !error && hasArgocdViewAccess ? (
     <Table
       title="Deployment summary"
       options={{

--- a/plugins/argocd/src/hooks/useArgocdViewPermission.ts
+++ b/plugins/argocd/src/hooks/useArgocdViewPermission.ts
@@ -1,0 +1,11 @@
+import { usePermission } from '@backstage/plugin-permission-react';
+
+import { argocdViewPermission } from '@janus-idp/backstage-plugin-argocd-common';
+
+export const useArgocdViewPermission = () => {
+  const argocdViewPermissionResult = usePermission({
+    permission: argocdViewPermission,
+  });
+
+  return argocdViewPermissionResult.allowed;
+};

--- a/plugins/argocd/src/plugin.test.tsx
+++ b/plugins/argocd/src/plugin.test.tsx
@@ -3,8 +3,10 @@ import { Route, Routes } from 'react-router-dom';
 
 import { configApiRef } from '@backstage/core-plugin-api';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
 import {
   MockConfigApi,
+  MockPermissionApi,
   renderInTestApp,
   TestApiProvider,
 } from '@backstage/test-utils';
@@ -33,6 +35,8 @@ describe('argocd', () => {
     },
   };
 
+  const mockPermissionApi = new MockPermissionApi();
+
   const mockConfiguration = new MockConfigApi({
     backend: {
       baseUrl: 'http://localhost:7007',
@@ -50,6 +54,7 @@ describe('argocd', () => {
         apis={[
           [argoCDApiRef, mockedApi],
           [configApiRef, mockConfiguration],
+          [permissionApiRef, mockPermissionApi],
         ]}
       >
         <EntityProvider entity={mockEntity}>{children}</EntityProvider>

--- a/plugins/rbac-backend/docs/permissions.md
+++ b/plugins/rbac-backend/docs/permissions.md
@@ -126,3 +126,11 @@ Resource type permissions on the other hand are basic named permissions with a r
 | ------------------ | ------------- | ------ | ----------------------------------------------------------------------------------------------------------- | ------------------- |
 | topology.view.read |               | read   | Allows the user to view the topology plugin                                                                 | X                   |
 | kubernetes.proxy   |               |        | Allows the user to access the proxy endpoint (ability to read pod logs and events within Showcase and RHDH) | catalog.entity.read |
+
+## Argocd
+
+| Name | Resource Type | Policy | Description | Requirements |
+
+| -------------- | ------------- | ------ | --------------------------------------- | ------------------- |
+
+| argocd.view.read | | read | Allows the user to view the argocd plugin | catalog.entity.read |


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/RHIDP-1796

**Description:**

This PR adds support for RBAC permission in argocd plugin. `argocd.view.read` Permission allows the user view the argocd plugin components in overview and CD tabs.

**Screenshots:**
---
**Without `argocd.view.read`  Permission:**

![argocd_permission](https://github.com/janus-idp/backstage-plugins/assets/9964343/04c68285-9517-4846-bcb1-893d2e4d9ce5)

![overview_page](https://github.com/janus-idp/backstage-plugins/assets/9964343/17fe412b-0502-4d86-950d-53fae08bb224)


**With `argocd.view.read`  Permission**

![argocd_with_permission](https://github.com/janus-idp/backstage-plugins/assets/9964343/1480b6e2-8dc9-4ead-9063-5de61f57f3be)


![argocd_with_permission_overview](https://github.com/janus-idp/backstage-plugins/assets/9964343/5dc1c38c-b683-41d9-946b-7c727e5b9ff9)

---
**How to test:**



1. [Configure the Argocd plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/argocd#configuration) and add Github integration.
2. Create a policy file `rbac.csv` for the permission policies
```
    g, user:default/<YOUR_USERNAME>, role:default/argocd-viewer
    
    p, role:default/argocd-viewer, argocd.view.read, read, allow
  

    p, role:default/argocd-viewer, catalog-entity.read, read, allow
    p, role:default/argocd-viewer, catalog-entity.create, create, allow


```

3. Configure the RBAC Backend plugin to include the argocd permission.
  

  ```permission:
    enabled: true
    rbac:
      policies-csv-file: ../<PATH>/<TO>/<CSV>/rbac-policy.csv
      policyFileReload: true
```
4. Annotate the catalog component to include argocd application selector

```
    'argocd/app-selector': rht-gitops.com/janus-argocd=quarkus-app-bootstrap
```
5. Register the component and view the CD tab to see the argo applications working.
6. Now `deny` the `argocd.view.read` permission from the `rbac.csv` file and wait for the application to auto-reload. you should see the `Permission required` alert.
 

---
**Unit tests:**

```
 PASS  src/components/DeploymentSummary/__tests__/DeploymentSummary.test.tsx (6.254 s)
  DeploymentSummary
    ✓ should not render deployment summary table when the user does not have view permission (3 ms)
```

```
 PASS  src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycle.test.tsx
  DeploymentLifecycle
    ✓ should render Permission alert if the user does not have view permission (91 ms)

```   

cc: @kim-tsao @rohitkrai03 @nickboldt @invincibleJai 


