### PR TITLE
fix(rbac): catch errors whenever a plugin token is not generated

### DIFF
--- a/plugins/rbac-backend/src/service/plugin-endpoints.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoints.ts
@@ -96,19 +96,26 @@ export class PluginPermissionMetadataCollector {
     let pluginResponses: PluginMetadataResponse[] = [];
 
     for (const pluginId of this.pluginIds) {
-      const { token } = await auth.getPluginRequestToken({
-        onBehalfOf: await auth.getOwnServiceCredentials(),
-        targetPluginId: pluginId,
-      });
-      const permMetaData = await this.getMetadataByPluginId(pluginId, token);
-      if (permMetaData) {
-        pluginResponses = [
-          ...pluginResponses,
-          {
-            metaDataResponse: permMetaData,
-            pluginId,
-          },
-        ];
+      try {
+        const { token } = await auth.getPluginRequestToken({
+          onBehalfOf: await auth.getOwnServiceCredentials(),
+          targetPluginId: pluginId,
+        });
+
+        const permMetaData = await this.getMetadataByPluginId(pluginId, token);
+        if (permMetaData) {
+          pluginResponses = [
+            ...pluginResponses,
+            {
+              metaDataResponse: permMetaData,
+              pluginId,
+            },
+          ];
+        }
+      } catch (error) {
+        this.logger.error(
+          `Failed to retrieve permission metadata for ${pluginId}. ${error}`,
+        );
       }
     }
 


### PR DESCRIPTION
## Description

With the recent changes to service to service auth for plugin communication, if a plugin does not exist or there are errors generating a token for the plugin, it breaks our permission metadata retrieval for all plugins. This PR wraps the token generation with a try catch block and logs the error in the event that we are unable to generate a token. This fix now allows for us to still retrieve the rest of the permission metadata for the valid plugins.

## Fixes
- Fixes: [RHIDP-2858](https://issues.redhat.com/browse/RHIDP-2858)