### PR TITLE
fix(argocd): fix argocd commit message visibility

### DIFF
--- a/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
@@ -33,6 +33,11 @@ const useCardStyles = makeStyles<Theme>(theme =>
       marginRight: theme.spacing(2.5),
       maxWidth: '300px',
     },
+    commitMessage: {
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+    },
   }),
 );
 
@@ -147,9 +152,25 @@ const DeploymentLifecycleCard: React.FC<DeploymentLifecycleCardProps> = ({
                     color="primary"
                     label={latestRevision?.revision.slice(0, 7)}
                   />
-                  <Typography variant="body2" color="textSecondary">
+                  <Typography
+                    variant="body2"
+                    color="textSecondary"
+                    className={classes.commitMessage}
+                  >
                     {revisionsMap?.[latestRevision?.revision] ? (
-                      <>{revisionsMap?.[latestRevision?.revision]?.message}</>
+                      <Tooltip
+                        data-testid={`${latestRevision?.revision?.slice(
+                          0,
+                          5,
+                        )}-commit-message`}
+                        title={
+                          revisionsMap?.[latestRevision?.revision]?.message
+                        }
+                      >
+                        <span>
+                          {revisionsMap?.[latestRevision?.revision]?.message}
+                        </span>
+                      </Tooltip>
                     ) : (
                       <Skeleton />
                     )}

--- a/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleDrawer.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleDrawer.tsx
@@ -51,6 +51,9 @@ const useDrawerStyles = makeStyles<Theme>(theme =>
       justifyContent: 'space-between',
       alignItems: 'baseline',
     },
+    commitMessage: {
+      wordBreak: 'break-word',
+    },
   }),
 );
 const DeploymentLifecycleDrawer: React.FC<DeploymentLifecycleDrawerProps> = ({
@@ -167,7 +170,10 @@ const DeploymentLifecycleDrawer: React.FC<DeploymentLifecycleDrawerProps> = ({
                     }}
                     label={latestRevision?.revision.slice(0, 7)}
                   />
-                  <Typography color="textSecondary">
+                  <Typography
+                    color="textSecondary"
+                    className={classes.commitMessage}
+                  >
                     {revisionsMap?.[latestRevision?.revision] ? (
                       <>
                         {revisionsMap?.[latestRevision?.revision]?.message} by{' '}
@@ -193,7 +199,11 @@ const DeploymentLifecycleDrawer: React.FC<DeploymentLifecycleDrawerProps> = ({
                     Deployment
                   </Typography>
 
-                  <Typography variant="body2" color="textSecondary">
+                  <Typography
+                    variant="body2"
+                    color="textSecondary"
+                    className={classes.commitMessage}
+                  >
                     Image{' '}
                     <Link
                       href={`https://${app?.status?.summary?.images?.[0]}`}
@@ -257,7 +267,11 @@ const DeploymentLifecycleDrawer: React.FC<DeploymentLifecycleDrawerProps> = ({
                             Deployment
                           </Typography>
 
-                          <Typography variant="body2" color="textSecondary">
+                          <Typography
+                            variant="body2"
+                            color="textSecondary"
+                            className={classes.commitMessage}
+                          >
                             {revisionsMap[dep.revision]?.message}{' '}
                             <Link
                               aria-disabled={!!commitUrl}


### PR DESCRIPTION
Fixes:

https://issues.redhat.com/browse/RHTAPBUGS-1251

Description:

Ensuring that long commit messages do not spill over within the application. For the Card view, messages are truncated with an added tooltip. For the Drawer (Side panel) view, messages are split onto new lines.

Screenshots:

1. Card View
<img width="1469" alt="Screenshot 2024-07-09 at 3 46 29 PM" src="https://github.com/janus-idp/backstage-plugins/assets/173716252/99a912ac-b8ba-448d-b2f8-2b6a5b4ccf19">

2. Side Panel View
<img width="1482" alt="Screenshot 2024-07-09 at 3 47 06 PM" src="https://github.com/janus-idp/backstage-plugins/assets/173716252/b3571a8e-8044-416b-8ebf-09b01a2f5c6a">

CC: @karthikjeeyar 

