### PR TITLE
feat(kiali): sticky headers for tables

### DIFF
--- a/plugins/kiali/src/components/IstioConfigCard/IstioConfigCard.tsx
+++ b/plugins/kiali/src/components/IstioConfigCard/IstioConfigCard.tsx
@@ -10,6 +10,7 @@ import {
   Typography,
 } from '@material-ui/core';
 
+import { cardsHeight } from '../../styles/StyleUtils';
 import { IstioConfigItem } from '../../types/IstioConfigList';
 import { PFBadge } from '../Pf/PfBadges';
 import { SimpleTable, tRow } from '../SimpleTable';
@@ -67,7 +68,7 @@ export const IstioConfigCard: React.FC<IstioConfigCardProps> = (
     });
 
   return (
-    <Card id="IstioConfigCard">
+    <Card id="IstioConfigCard" style={{ height: cardsHeight }}>
       {props.items.length > 0 && (
         <>
           <CardHeader

--- a/plugins/kiali/src/components/VirtualList/Renderers.tsx
+++ b/plugins/kiali/src/components/VirtualList/Renderers.tsx
@@ -82,7 +82,7 @@ const DrawerDiv = ({
   }) => {
     return (
       <div style={{ padding: '10px', minWidth: '400px' }} data-test="drawer">
-        <div style={{ paddingBottom: '10px' }}>
+        <div style={{ paddingBottom: '30px' }}>
           <IconButton
             key="dismiss"
             id="close_drawer"

--- a/plugins/kiali/src/components/VirtualList/VirtualList.tsx
+++ b/plugins/kiali/src/components/VirtualList/VirtualList.tsx
@@ -142,13 +142,16 @@ export const VirtualList = <R extends RenderResource>(
     setOrder(isAsc ? 'desc' : 'asc');
     setOrderBy(property.toLowerCase());
   };
-
+  const heightStyle =
+    listProps.view === ENTITY || listProps.view === DRAWER
+      ? { maxHeight: '300px' }
+      : {};
   return (
     <div>
       <Paper className="Paper">
         {listProps.tableToolbar}
-        <TableContainer>
-          <Table>
+        <TableContainer style={heightStyle}>
+          <Table stickyHeader>
             <TableHead style={{ border: 'collapse', background: 'white' }}>
               <TableRow>
                 {columns.map((column: ResourceType<any>, index: number) => (

--- a/plugins/kiali/src/dynamic/EntityKialiResourcesCard.tsx
+++ b/plugins/kiali/src/dynamic/EntityKialiResourcesCard.tsx
@@ -18,7 +18,6 @@ import { WorkloadListPage } from '../pages/WorkloadList/WorkloadListPage';
 import { DRAWER } from '../types/types';
 
 const tabStyle: React.CSSProperties = {
-  overflowY: 'scroll',
   maxHeight: '400px',
 };
 

--- a/plugins/kiali/src/pages/AppDetails/AppDescription.tsx
+++ b/plugins/kiali/src/pages/AppDetails/AppDescription.tsx
@@ -7,7 +7,7 @@ import { HealthIndicator } from '../../components/Health/HealthIndicator';
 import { Labels } from '../../components/Label/Labels';
 import { PFBadge, PFBadges } from '../../components/Pf/PfBadges';
 import { isMultiCluster, serverConfig } from '../../config';
-import { kialiStyle } from '../../styles/StyleUtils';
+import { cardsHeight, kialiStyle } from '../../styles/StyleUtils';
 import { App } from '../../types/App';
 import * as H from '../../types/Health';
 
@@ -36,11 +36,15 @@ export const AppDescription: React.FC<AppDescriptionProps> = (
   }
 
   return props.app ? (
-    <Card id="AppDescriptionCard" data-test="app-description-card">
+    <Card
+      id="AppDescriptionCard"
+      data-test="app-description-card"
+      style={{ height: cardsHeight }}
+    >
       <CardHeader
         title={
           <>
-            <Typography variant="h6" style={{ margin: '10px' }}>
+            <Typography variant="h6">
               <div key="service-icon" className={iconStyle}>
                 <PFBadge badge={PFBadges.App} />
               </div>

--- a/plugins/kiali/src/pages/AppList/AppListPage.tsx
+++ b/plugins/kiali/src/pages/AppList/AppListPage.tsx
@@ -16,7 +16,7 @@ import { getErrorString, kialiApiRef } from '../../services/Api';
 import { KialiAppState, KialiContext } from '../../store';
 import { baseStyle } from '../../styles/StyleUtils';
 import { AppListItem } from '../../types/AppList';
-import { ENTITY } from '../../types/types';
+import { DRAWER, ENTITY } from '../../types/types';
 import { NamespaceInfo } from '../Overview/NamespaceInfo';
 import { getNamespaces } from '../Overview/OverviewPage';
 import * as AppListClass from './AppListClass';
@@ -130,15 +130,16 @@ export const AppListPage = (props: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeNs, duration]);
 
-  return (
-    <div className={baseStyle}>
-      <Content>
+  const appContent = () => {
+    return (
+      <>
         {props.view !== ENTITY && (
           <DefaultSecondaryMasthead
             elements={grids()}
             onRefresh={() => getNS()}
           />
         )}
+
         <VirtualList
           activeNamespaces={namespaces}
           rows={allApps}
@@ -147,7 +148,20 @@ export const AppListPage = (props: {
           view={props.view}
           loading={loadingD}
         />
-      </Content>
+      </>
+    );
+  };
+
+  return (
+    <div className={baseStyle}>
+      {props.view !== ENTITY && props.view !== DRAWER && (
+        <Content>{appContent()}</Content>
+      )}
+      {(props.view === ENTITY || props.view === DRAWER) && (
+        <div style={{ paddingRight: '10px', paddingLeft: '10px' }}>
+          {appContent()}
+        </div>
+      )}
     </div>
   );
 };

--- a/plugins/kiali/src/pages/Overview/ListView/ListViewPage.tsx
+++ b/plugins/kiali/src/pages/Overview/ListView/ListViewPage.tsx
@@ -18,7 +18,7 @@ export const ListViewPage = () => {
     setSearchParams({ ['tabresources']: tabvalue });
   };
   const tabStyle: React.CSSProperties = {
-    height: '600px',
+    height: '350px',
     overflowY: 'scroll',
   };
 

--- a/plugins/kiali/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/plugins/kiali/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -17,7 +17,7 @@ import { TextOrLink } from '../../components/TextOrLink';
 import { LocalTime } from '../../components/Time/LocalTime';
 import { isMultiCluster, serverConfig } from '../../config';
 import { KialiIcon } from '../../config/KialiIcon';
-import { kialiStyle } from '../../styles/StyleUtils';
+import { cardsHeight, kialiStyle } from '../../styles/StyleUtils';
 import { AppWorkload } from '../../types/App';
 import { ServiceDetailsInfo, WorkloadOverview } from '../../types/ServiceInfo';
 
@@ -170,7 +170,7 @@ export const ServiceDescription: React.FC<ServiceInfoDescriptionProps> = (
   }
 
   return (
-    <Card id="ServiceDescriptionCard">
+    <Card id="ServiceDescriptionCard" style={{ height: cardsHeight }}>
       <CardHeader
         title={
           <>

--- a/plugins/kiali/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/plugins/kiali/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Grid } from '@material-ui/core';
 
 import { IstioConfigCard } from '../../components/IstioConfigCard/IstioConfigCard';
-import { cardsHeight } from '../../styles/StyleUtils';
 import { DurationInSeconds } from '../../types/Common';
 import {
   drToIstioItems,

--- a/plugins/kiali/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/plugins/kiali/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Grid } from '@material-ui/core';
 
 import { IstioConfigCard } from '../../components/IstioConfigCard/IstioConfigCard';
+import { cardsHeight } from '../../styles/StyleUtils';
 import { DurationInSeconds } from '../../types/Common';
 import {
   drToIstioItems,

--- a/plugins/kiali/src/pages/ServiceDetails/ServiceNetwork.tsx
+++ b/plugins/kiali/src/pages/ServiceDetails/ServiceNetwork.tsx
@@ -10,7 +10,7 @@ import {
 
 import { ValidationList } from '../../components/Validations/ValidationList';
 import { KialiIcon } from '../../config/KialiIcon';
-import { kialiStyle } from '../../styles/StyleUtils';
+import { cardsHeight, kialiStyle } from '../../styles/StyleUtils';
 import {
   Gateway,
   ObjectCheck,
@@ -106,7 +106,7 @@ export const ServiceNetwork: React.FC<ServiceNetworkProps> = (
   };
 
   return (
-    <Card id="ServiceNetworkCard">
+    <Card id="ServiceNetworkCard" style={{ height: cardsHeight }}>
       <CardHeader title={<Typography variant="h6">Network</Typography>} />
       <CardContent>
         <div key="network-list" className={resourceListStyle}>

--- a/plugins/kiali/src/pages/ServiceList/ServiceListPage.tsx
+++ b/plugins/kiali/src/pages/ServiceList/ServiceListPage.tsx
@@ -23,7 +23,7 @@ import { ServiceHealth } from '../../types/Health';
 import { validationKey } from '../../types/IstioConfigList';
 import { ObjectValidation, Validations } from '../../types/IstioObjects';
 import { ServiceList, ServiceListItem } from '../../types/ServiceList';
-import { ENTITY } from '../../types/types';
+import { DRAWER, ENTITY } from '../../types/types';
 import { sortIstioReferences } from '../AppList/FiltersAndSorts';
 import { NamespaceInfo } from '../Overview/NamespaceInfo';
 import { getNamespaces } from '../Overview/OverviewPage';
@@ -199,15 +199,16 @@ export const ServiceListPage = (props: {
     return <CircularProgress />;
   }
 
-  return (
-    <div className={baseStyle}>
-      <Content>
+  const serviceContent = () => {
+    return (
+      <>
         {props.view !== ENTITY && (
           <DefaultSecondaryMasthead
             elements={grids()}
             onRefresh={() => load()}
           />
         )}
+
         <VirtualList
           activeNamespaces={namespaces}
           rows={allServices}
@@ -216,7 +217,20 @@ export const ServiceListPage = (props: {
           view={props.view}
           loading={loadingD}
         />
-      </Content>
+      </>
+    );
+  };
+
+  return (
+    <div className={baseStyle}>
+      {props.view !== ENTITY && props.view !== DRAWER && (
+        <Content>{serviceContent()}</Content>
+      )}
+      {(props.view === ENTITY || props.view === DRAWER) && (
+        <div style={{ paddingRight: '10px', paddingLeft: '10px' }}>
+          {serviceContent()}
+        </div>
+      )}
     </div>
   );
 };

--- a/plugins/kiali/src/pages/WorkloadDetails/WorkloadPods.tsx
+++ b/plugins/kiali/src/pages/WorkloadDetails/WorkloadPods.tsx
@@ -15,7 +15,7 @@ import { PFBadge, PFBadges } from '../../components/Pf/PfBadges';
 import { SimpleTable, tRow } from '../../components/SimpleTable';
 import { LocalTime } from '../../components/Time/LocalTime';
 import { KialiIcon } from '../../config/KialiIcon';
-import { kialiStyle } from '../../styles/StyleUtils';
+import { cardsHeight, kialiStyle } from '../../styles/StyleUtils';
 import { ObjectValidation, Pod } from '../../types/IstioObjects';
 import { PodStatus } from './PodStatus';
 
@@ -151,7 +151,7 @@ export const WorkloadPods: React.FC<WorkloadPodsProps> = (
     });
 
   return (
-    <Card id="WorkloadPodsCard">
+    <Card id="WorkloadPodsCard" style={{ height: cardsHeight }}>
       <CardHeader
         title={
           <Typography variant="h6" style={{ margin: '10px' }}>

--- a/plugins/kiali/src/pages/WorkloadDetails/WorkloadsDescription.tsx
+++ b/plugins/kiali/src/pages/WorkloadDetails/WorkloadsDescription.tsx
@@ -22,7 +22,7 @@ import { LocalTime } from '../../components/Time/LocalTime';
 import { isMultiCluster, serverConfig } from '../../config';
 import { KialiIcon } from '../../config/KialiIcon';
 import { isGateway, isWaypoint } from '../../helpers/LabelFilterHelper';
-import { kialiStyle } from '../../styles/StyleUtils';
+import { cardsHeight, kialiStyle } from '../../styles/StyleUtils';
 import * as H from '../../types/Health';
 import { validationKey } from '../../types/IstioConfigList';
 import { Workload } from '../../types/Workload';
@@ -168,15 +168,11 @@ export const WorkloadDescription: React.FC<WorkloadDescriptionProps> = (
   ) : undefined;
 
   return (
-    <Card>
+    <Card style={{ height: cardsHeight }}>
       <CardHeader
         title={
           <>
-            <Typography
-              variant="h6"
-              style={{ margin: '10px' }}
-              data-test="workload-title"
-            >
+            <Typography variant="h6" data-test="workload-title">
               <div key="service-icon" className={iconStyle} data-test="w-badge">
                 <PFBadge badge={PFBadges.Workload} position="top" />
               </div>

--- a/plugins/kiali/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/plugins/kiali/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -18,7 +18,7 @@ import { getEntityNs, nsEqual } from '../../helpers/namespaces';
 import { getErrorString, kialiApiRef } from '../../services/Api';
 import { KialiAppState, KialiContext } from '../../store';
 import { baseStyle } from '../../styles/StyleUtils';
-import { ENTITY } from '../../types/types';
+import { DRAWER, ENTITY } from '../../types/types';
 import { WorkloadListItem } from '../../types/Workload';
 import { NamespaceInfo } from '../Overview/NamespaceInfo';
 import { getNamespaces } from '../Overview/OverviewPage';
@@ -136,15 +136,16 @@ export const WorkloadListPage = (props: { view?: string; entity?: Entity }) => {
     return elements;
   };
 
-  return (
-    <div className={baseStyle}>
-      <Content>
+  const mainContent = () => {
+    return (
+      <>
         {props.view !== ENTITY && (
           <DefaultSecondaryMasthead
             elements={grids()}
             onRefresh={() => load()}
           />
         )}
+
         <VirtualList
           activeNamespaces={namespaces}
           rows={allWorkloads}
@@ -154,7 +155,20 @@ export const WorkloadListPage = (props: { view?: string; entity?: Entity }) => {
           loading={loadingData}
           data-test="virtual-list"
         />
-      </Content>
+      </>
+    );
+  };
+
+  return (
+    <div className={baseStyle}>
+      {props.view !== ENTITY && props.view !== DRAWER && (
+        <Content>{mainContent()}</Content>
+      )}
+      {(props.view === ENTITY || props.view === DRAWER) && (
+        <div style={{ paddingRight: '10px', paddingLeft: '10px' }}>
+          {mainContent()}
+        </div>
+      )}
     </div>
   );
 };

--- a/plugins/kiali/src/styles/StyleUtils.ts
+++ b/plugins/kiali/src/styles/StyleUtils.ts
@@ -5,6 +5,7 @@ import { NestedCSSProperties } from 'typestyle/lib/types';
 
 const cssPrefix = process.env.CSS_PREFIX ?? 'kiali';
 
+export const cardsHeight = '300px';
 /**
  * Add prefix to CSS classname (mandatory in some plugins like OSSMC)
  * Default prefix value is kiali if the environment variable CSS_PREFIX is not defined


### PR DESCRIPTION
Improved styles for tables: 

![image](https://github.com/janus-idp/backstage-plugins/assets/49480155/04f3689f-26df-47ce-896c-2a36dfcc3da3)
![image](https://github.com/janus-idp/backstage-plugins/assets/49480155/2baf79c0-b37b-4cd9-9eee-2e96011a7b80)


Before: 
![image](https://github.com/janus-idp/backstage-plugins/assets/49480155/a67a88da-8f8d-48d0-a910-9cffb8c1ecc9)
![image](https://github.com/janus-idp/backstage-plugins/assets/49480155/9d373e0e-87b9-4242-806f-eebafa5beef3)
