### PR TITLE
chore: deprecate and private the scaffolder relation processor module

### DIFF
--- a/plugins/catalog-backend-module-scaffolder-relation-processor/README.md
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/README.md
@@ -1,3 +1,9 @@
+# ❗DEPRECATED❗
+
+This package has been deprecated.
+
+Please use the **[@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor](https://github.com/backstage/community-plugins/tree/main/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor)** package instead.
+
 # Catalog Backend Module for Scaffolder Relation Catalog Processor
 
 This is an extension module to the catalog-backend plugin, providing an additional catalog entity processor that adds a new relation that depends on the `spec.scaffoldedFrom` field to link scaffolder templates and the catalog entities they generated.

--- a/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
+  "private": "true",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",


### PR DESCRIPTION
### Description
Deprecates the scaffolder relation processor module

### What issue(s) does this fix?
Fixes: [RHIDP-3162](https://issues.redhat.com/browse/RHIDP-3162)