### PR TITLE
chore: add catalog-info yamls

### DIFF
--- a/catalog-info-teams.yaml
+++ b/catalog-info-teams.yaml
@@ -1,0 +1,62 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: owner-unknown
+spec:
+  type: team
+  children: []
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: rhdh-team
+spec:
+  type: team
+  children: [rhdh-core-team, rhdh-dynamic-plugin-team, rhdh-ui-team]
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: rhdh-core-team
+spec:
+  type: team
+  children: []
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: rhdh-dynamic-plugin-team
+spec:
+  type: team
+  children: []
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: rhdh-ui-team
+spec:
+  type: team
+  children: []
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: ansible-team
+spec:
+  type: team
+  children: []
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: rhtap-team
+spec:
+  type: team
+  children: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,18 +1,88 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-system
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: rhdh
+spec:
+  owner: rhdh-team
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: janus-idp-backstage-plugins
-  description: An example of a Backstage application.
+  title: RHDH plugins
+  description: Backstage Plugins by Red Hat
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main
+      title: GitHub Source
+      icon: source
+      type: source
 spec:
   type: website
-  owner: group:janus-idp
   lifecycle: production
+  owner: rhdh-team
+  system: rhdh
 ---
+# https://backstage.io/docs/features/software-catalog/descriptor-format/#kind-location
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
   name: janus-idp-backstage-plugins
 spec:
   targets:
-    - ./plugins/**/catalog-info.yaml
-    - ./utils/**/catalog-info.yaml
+    - ./plugins/3scale-backend/catalog-info.yaml
+    - ./plugins/aap-backend/catalog-info.yaml
+    - ./plugins/acr/catalog-info.yaml
+    - ./plugins/analytics-module-matomo/catalog-info.yaml
+    - ./plugins/analytics-provider-segment/catalog-info.yaml
+    - ./plugins/argocd/catalog-info.yaml
+    - ./plugins/argocd-common/catalog-info.yaml
+    - ./plugins/audit-log-node/catalog-info.yaml
+    - ./plugins/bulk-import/catalog-info.yaml
+    - ./plugins/bulk-import-backend/catalog-info.yaml
+    - ./plugins/bulk-import-common/catalog-info.yaml
+    - ./plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
+    - ./plugins/dynamic-plugins-info/catalog-info.yaml
+    - ./plugins/feedback/catalog-info.yaml
+    - ./plugins/feedback-backend/catalog-info.yaml
+    - ./plugins/jfrog-artifactory/catalog-info.yaml
+    - ./plugins/keycloak-backend/catalog-info.yaml
+    - ./plugins/kiali/catalog-info.yaml
+    - ./plugins/kiali-backend/catalog-info.yaml
+    - ./plugins/kubernetes-actions/catalog-info.yaml
+    - ./plugins/matomo/catalog-info.yaml
+    - ./plugins/matomo-backend/catalog-info.yaml
+    - ./plugins/nexus-repository-manager/catalog-info.yaml
+    - ./plugins/ocm/catalog-info.yaml
+    - ./plugins/ocm-backend/catalog-info.yaml
+    - ./plugins/ocm-common/catalog-info.yaml
+    - ./plugins/openshift-image-registry/catalog-info.yaml
+    - ./plugins/orchestrator/catalog-info.yaml
+    - ./plugins/orchestrator-backend/catalog-info.yaml
+    - ./plugins/orchestrator-common/catalog-info.yaml
+    - ./plugins/quay/catalog-info.yaml
+    - ./plugins/quay-common/catalog-info.yaml
+    - ./plugins/quay-actions/catalog-info.yaml
+    - ./plugins/rbac/catalog-info.yaml
+    - ./plugins/rbac-backend/catalog-info.yaml
+    - ./plugins/rbac-common/catalog-info.yaml
+    - ./plugins/rbac-node/catalog-info.yaml
+    - ./plugins/regex-actions/catalog-info.yaml
+    - ./plugins/scaffolder-annotator-action/catalog-info.yaml
+    - ./plugins/servicenow-actions/catalog-info.yaml
+    - ./plugins/shared-react/catalog-info.yaml
+    - ./plugins/sonarqube-actions/catalog-info.yaml
+    - ./plugins/tekton/catalog-info.yaml
+    - ./plugins/tekton-common/catalog-info.yaml
+    - ./plugins/topology/catalog-info.yaml
+    - ./plugins/topology-common/catalog-info.yaml
+    - ./plugins/web-terminal/catalog-info.yaml
+    - ./packages/cli/catalog-info.yaml

--- a/packages/cli/catalog-info.yaml
+++ b/packages/cli/catalog-info.yaml
@@ -1,10 +1,27 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-cli
-  title: '@backstage/cli'
-  description: CLI for developing Backstage plugins and apps
+  name: janus-idp-cli
+  title: '@janus-idp/cli'
+  description: This package provides a CLI for developing Backstage plugins and apps.
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/packages/cli
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/packages/cli/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/packages/cli/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/packages/cli
+      title: GitHub Source
+      icon: source
+      type: source
 spec:
-  lifecycle: experimental
   type: backstage-cli
-  owner: maintainers
+  lifecycle: experimental
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins

--- a/plugins/3scale-backend/catalog-info.yaml
+++ b/plugins/3scale-backend/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-3scale
+  title: 3scale plugin
+  description: 3scale integration
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/3scale-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/3scale-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/3scale-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/3scale-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: owner-unknown
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-3scale-backend
+  title: '@janus-idp/backstage-plugin-3scale-backend'
+  description: 3scale Backstage provider
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/3scale-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/3scale-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/3scale-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/3scale-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: owner-unknown
+  system: rhdh
+  subcomponentOf: janus-idp-3scale

--- a/plugins/aap-backend/catalog-info.yaml
+++ b/plugins/aap-backend/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-aap
+  title: Ansible Automation Platform plugin
+  description: Ansible Automation Platform Backstage provider plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/aap-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/aap-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/aap-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/aap-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: ansible-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-aap-backend
+  title: '@janus-idp/backstage-plugin-aap-backend'
+  description: Ansible Automation Platform Backstage provider plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/aap-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/aap-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/aap-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/aap-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: ansible-team
+  system: rhdh
+  subcomponentOf: janus-idp-aap

--- a/plugins/acr/catalog-info.yaml
+++ b/plugins/acr/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-acr
+  title: Azure Container Registry plugin
+  description: Azure Container Registry plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/acr
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/acr/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/acr/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/acr
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: owner-unknown
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-acr-frontend
+  title: '@janus-idp/backstage-plugin-acr'
+  description: Azure Container Registry plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/acr
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/acr/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/acr/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/acr
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: owner-unknown
+  system: rhdh
+  subcomponentOf: janus-idp-acr

--- a/plugins/analytics-module-matomo/catalog-info.yaml
+++ b/plugins/analytics-module-matomo/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-analytics-matomo
+  title: 'Analytics Module: Matomo'
+  description: 'Analytics Module: Matomo Analytics'
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-module-matomo
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/analytics-module-matomo/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/analytics-module-matomo/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-module-matomo
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-analytics-module-matomo
+  title: '@janus-idp/backstage-plugin-analytics-module-matomo'
+  description: 'Analytics Module: Matomo Analytics'
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-module-matomo
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/analytics-module-matomo/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/analytics-module-matomo/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-module-matomo
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin-module
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-analytics-matomo

--- a/plugins/analytics-provider-segment/catalog-info.yaml
+++ b/plugins/analytics-provider-segment/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-analytics-segment
+  title: 'Analytics Module: Segment'
+  description: 'Analytics Module: Segment'
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-provider-segment
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/analytics-provider-segment/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/analytics-provider-segment/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-provider-segment
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-analytics-provider-segment
+  title: '@janus-idp/backstage-plugin-analytics-provider-segment'
+  description: 'Analytics Module: Segment'
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-provider-segment
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/analytics-provider-segment/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/analytics-provider-segment/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-provider-segment
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin-module
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-analytics-segment

--- a/plugins/argocd-common/catalog-info.yaml
+++ b/plugins/argocd-common/catalog-info.yaml
@@ -1,0 +1,28 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-argocd-common
+  title: '@janus-idp/backstage-plugin-argocd-common'
+  description: Argo CD common for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/argocd-common
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/argocd-common/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/argocd-common/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/argocd-common
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-common-library
+  lifecycle: production
+  owner: rhtap-team
+  system: rhdh
+  subcomponentOf: janus-idp-argocd

--- a/plugins/argocd/catalog-info.yaml
+++ b/plugins/argocd/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-argocd
+  title: Argo CD plugin
+  description: Argo CD plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/argocd
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/argocd/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/argocd/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/argocd
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhtap-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-argocd-frontend
+  title: '@janus-idp/backstage-plugin-argocd'
+  description: Argo CD plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/argocd
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/argocd/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/argocd/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/argocd
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhtap-team
+  system: rhdh
+  subcomponentOf: janus-idp-argocd

--- a/plugins/audit-log-node/catalog-info.yaml
+++ b/plugins/audit-log-node/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-audit-log
+  title: Audit Log plugin
+  description: Backend for the audit-log
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/audit-log-node
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/audit-log-node/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/audit-log-node/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/audit-log-node
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-audit-log-node
+  title: '@janus-idp/backstage-plugin-audit-log-node'
+  description: Node.js library for the audit-log plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/audit-log-node
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/audit-log-node/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/audit-log-node/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/audit-log-node
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-node-library
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-audit-log

--- a/plugins/bulk-import-backend/catalog-info.yaml
+++ b/plugins/bulk-import-backend/catalog-info.yaml
@@ -1,0 +1,25 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-bulk-import-backend
+  title: '@janus-idp/backstage-plugin-bulk-import-backend'
+  description: Bulk Import Backend Plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/bulk-import-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-bulk-import

--- a/plugins/bulk-import-common/catalog-info.yaml
+++ b/plugins/bulk-import-common/catalog-info.yaml
@@ -1,0 +1,25 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-bulk-import-common
+  title: '@janus-idp/backstage-plugin-bulk-import-common'
+  description: Bulk import for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import-common
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import-common/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/bulk-import-common/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import-common
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-common-library
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-bulk-import

--- a/plugins/bulk-import/catalog-info.yaml
+++ b/plugins/bulk-import/catalog-info.yaml
@@ -1,0 +1,50 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-bulk-import
+  title: Bulk import plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/bulk-import/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-bulk-import-frontend
+  title: '@janus-idp/backstage-plugin-bulk-import'
+  description: Bulk import frontend plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/bulk-import/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-bulk-import

--- a/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
@@ -1,0 +1,55 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-catalog-scaffolder-relation-processor
+  title: Catalog relation scaffolder processor
+  description: Catalog Backend Module for Scaffolder Relation Catalog Processor
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/catalog-backend-module-scaffolder-relation-processor
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - scaffolder
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/catalog-backend-module-scaffolder-relation-processor
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-catalog-backend-module-scaffolder-relation-processor
+  title: '@janus-idp/backstage-plugin-catalog-backend-module-scaffolder-relation-processor'
+  description: Catalog Backend Module for Scaffolder Relation Catalog Processor
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/catalog-backend-module-scaffolder-relation-processor
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - scaffolder
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/catalog-backend-module-scaffolder-relation-processor
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin-module
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-catalog-scaffolder-relation-processor

--- a/plugins/dynamic-plugins-info/catalog-info.yaml
+++ b/plugins/dynamic-plugins-info/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-dynamic-plugins-info
+  title: Dynamic Plugins Info plugin
+  description: Dynamic Plugins Info plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/dynamic-plugins-info
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/dynamic-plugins-info/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/dynamic-plugins-info/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/dynamic-plugins-info
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-dynamic-plugin-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-dynamic-plugins-info-frontend
+  title: '@janus-idp/backstage-plugin-dynamic-plugins-info'
+  description: Dynamic Plugins Info plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/dynamic-plugins-info
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/dynamic-plugins-info/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/dynamic-plugins-info/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/dynamic-plugins-info
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-dynamic-plugin-team
+  system: rhdh
+  subcomponentOf: janus-idp-dynamic-plugins-info

--- a/plugins/feedback-backend/catalog-info.yaml
+++ b/plugins/feedback-backend/catalog-info.yaml
@@ -1,0 +1,25 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-feedback-backend
+  title: '@janus-idp/backstage-plugin-feedback-backend'
+  description: Feedback Backend
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/feedback-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/feedback-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/feedback-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/feedback-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-feedback

--- a/plugins/feedback/catalog-info.yaml
+++ b/plugins/feedback/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-feedback
+  title: Feedback plugin
+  description: ''
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/feedback
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/feedback/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/feedback/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/feedback
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-feedback-frontend
+  title: '@janus-idp/backstage-plugin-feedback'
+  description: Feedback Plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/feedback
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/feedback/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/feedback/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/feedback
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-feedback

--- a/plugins/jfrog-artifactory/catalog-info.yaml
+++ b/plugins/jfrog-artifactory/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-jfrog-artifactory
+  title: Jfrog Artifactory plugin
+  description: Jfrog Artifactory plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/jfrog-artifactory
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/jfrog-artifactory/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/jfrog-artifactory/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/jfrog-artifactory
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: owner-unknown
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-jfrog-artifactory-frontend
+  title: '@janus-idp/backstage-plugin-jfrog-artifactory'
+  description: Jfrog Artifactory plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/jfrog-artifactory
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/jfrog-artifactory/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/jfrog-artifactory/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/jfrog-artifactory
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: owner-unknown
+  system: rhdh
+  subcomponentOf: janus-idp-jfrog-artifactory

--- a/plugins/keycloak-backend/catalog-info.yaml
+++ b/plugins/keycloak-backend/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-keycloak
+  title: Keycloak plugin
+  description: Keycloak backend plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/keycloak-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/keycloak-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/keycloak-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/keycloak-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-core-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-keycloak-backend
+  title: '@janus-idp/backstage-plugin-keycloak-backend'
+  description: Keycloak backend plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/keycloak-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/keycloak-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/keycloak-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/keycloak-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: rhdh-core-team
+  system: rhdh
+  subcomponentOf: janus-idp-keycloak

--- a/plugins/kiali-backend/catalog-info.yaml
+++ b/plugins/kiali-backend/catalog-info.yaml
@@ -1,0 +1,25 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-kiali-backend
+  title: '@janus-idp/backstage-plugin-kiali-backend'
+  description: Kiali Backend plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kiali-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kiali-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/kiali-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kiali-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-kiali

--- a/plugins/kiali/catalog-info.yaml
+++ b/plugins/kiali/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-kiali
+  title: Kiali plugin
+  description: Kiali plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kiali
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kiali/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/kiali/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kiali
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-kiali-frontend
+  title: '@janus-idp/backstage-plugin-kiali'
+  description: Kiali plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kiali
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kiali/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/kiali/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kiali
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-kiali

--- a/plugins/kubernetes-actions/catalog-info.yaml
+++ b/plugins/kubernetes-actions/catalog-info.yaml
@@ -1,0 +1,61 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-kubernetes-actions-scaffolder
+  title: Kubernetes scaffolder actions
+  description: Kubernetes scaffolder actions for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kubernetes-actions
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kubernetes-actions/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/kubernetes-actions/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kubernetes-actions
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-kubernetes-actions-scaffolder-module
+  title: '@janus-idp/backstage-scaffolder-backend-module-kubernetes'
+  description: Kubernetes scaffolder actions for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kubernetes-actions
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kubernetes-actions/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/kubernetes-actions/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kubernetes-actions
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin-module
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-kubernetes-actions-scaffolder

--- a/plugins/matomo-backend/catalog-info.yaml
+++ b/plugins/matomo-backend/catalog-info.yaml
@@ -1,0 +1,25 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-matomo-backend
+  title: '@janus-idp/backstage-plugin-matomo-backend'
+  description: Matomo backend plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/matomo-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/matomo-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/matomo-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/matomo-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-matomo

--- a/plugins/matomo/catalog-info.yaml
+++ b/plugins/matomo/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-matomo
+  title: Matomo plugin
+  description: ''
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/matomo
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/matomo/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/matomo/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/matomo
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-matomo-frontend
+  title: '@janus-idp/backstage-plugin-matomo'
+  description: Matomo frontend plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/matomo
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/matomo/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/matomo/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/matomo
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-matomo

--- a/plugins/nexus-repository-manager/catalog-info.yaml
+++ b/plugins/nexus-repository-manager/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-nexus-repository-manager
+  title: Nexus Repository Manager
+  description: Nexus Repository Manager plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/nexus-repository-manager
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/nexus-repository-manager/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/nexus-repository-manager/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/nexus-repository-manager
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: owner-unknown
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-nexus-repository-manager
+  title: '@janus-idp/backstage-plugin-nexus-repository-manager'
+  description: Nexus Repository Manager plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/nexus-repository-manager
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/nexus-repository-manager/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/nexus-repository-manager/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/nexus-repository-manager
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-nexus-repository-manager

--- a/plugins/ocm-backend/catalog-info.yaml
+++ b/plugins/ocm-backend/catalog-info.yaml
@@ -1,0 +1,28 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-ocm-backend
+  title: '@janus-idp/backstage-plugin-ocm-backend'
+  description: Open Cluster Management backend plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/ocm-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/ocm-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-ocm

--- a/plugins/ocm-common/catalog-info.yaml
+++ b/plugins/ocm-common/catalog-info.yaml
@@ -1,0 +1,28 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-ocm-backend
+  title: '@janus-idp/backstage-plugin-ocm-backend'
+  description: Open Cluster Management backend plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/ocm-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/ocm-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-common-library
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-ocm

--- a/plugins/ocm/catalog-info.yaml
+++ b/plugins/ocm/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-ocm
+  title: OCM plugin
+  description: Open Cluster Management plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/ocm/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/ocm/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-ocm-frontend
+  title: '@janus-idp/backstage-plugin-ocm'
+  description: Open Cluster Management plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/ocm/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/ocm/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-ocm

--- a/plugins/openshift-image-registry/catalog-info.yaml
+++ b/plugins/openshift-image-registry/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-openshift-image-registry
+  title: OpenShift Image Registry plugin
+  description: OpenShift Image Registry plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/openshift-image-registry
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/openshift-image-registry/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/openshift-image-registry/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/openshift-image-registry
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-openshift-image-registry-frontend
+  title: '@janus-idp/backstage-plugin-openshift-image-registry'
+  description: OpenShift Image Registry plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/openshift-image-registry
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/openshift-image-registry/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/openshift-image-registry/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/openshift-image-registry
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-openshift-image-registry

--- a/plugins/orchestrator-backend/catalog-info.yaml
+++ b/plugins/orchestrator-backend/catalog-info.yaml
@@ -1,0 +1,25 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-orchestrator-backend
+  title: '@janus-idp/backstage-plugin-orchestrator-backend'
+  description: Orchestrator Backend Plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/orchestrator-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-orchestrator

--- a/plugins/orchestrator-common/catalog-info.yaml
+++ b/plugins/orchestrator-common/catalog-info.yaml
@@ -1,0 +1,25 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-orchestrator-common
+  title: '@janus-idp/backstage-plugin-orchestrator-common'
+  description: Orchestrator Common Plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator-common
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator-common/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/orchestrator-common/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator-common
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-common-library
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-orchestrator

--- a/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
+++ b/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
@@ -1,0 +1,25 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-orchestrator-swf-editor-envelope
+  title: '@janus-idp/backstage-plugin-orchestrator-swf-editor-envelope'
+  description: Serverless workflow editor envelope for the Orchestrator plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator-swf-editor-envelope
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator-swf-editor-envelope
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins

--- a/plugins/orchestrator/catalog-info.yaml
+++ b/plugins/orchestrator/catalog-info.yaml
@@ -1,0 +1,51 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-orchestrator
+  title: Orchestrator plugin
+  description: Orchestrator Plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/orchestrator/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-orchestrator-frontend
+  title: '@janus-idp/backstage-plugin-orchestrator'
+  description: Orchestrator Plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/orchestrator/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-orchestrator

--- a/plugins/quay-actions/catalog-info.yaml
+++ b/plugins/quay-actions/catalog-info.yaml
@@ -1,0 +1,59 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-quay-actions
+  title: Quay scaffolder actions
+  description: Quay actions for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/quay-actions
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/quay-actions/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/quay-actions/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - quay
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/quay-actions
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-quay-actions-module
+  title: '@janus-idp/backstage-scaffolder-backend-module-quay'
+  description: Quay actions for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/quay-actions
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/quay-actions/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/quay-actions/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - quay
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/quay-actions
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin-module
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-quay-actions

--- a/plugins/quay-common/catalog-info.yaml
+++ b/plugins/quay-common/catalog-info.yaml
@@ -1,0 +1,27 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-quay-common
+  title: '@janus-idp/backstage-plugin-quay-common'
+  description: Quay Common plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/quay-common
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/quay-common/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/quay-common/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - quay
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/quay-common
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-common-library
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-quay

--- a/plugins/quay/catalog-info.yaml
+++ b/plugins/quay/catalog-info.yaml
@@ -1,0 +1,55 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-quay
+  title: Quay plugin
+  description: Quay plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/quay
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/quay/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/quay/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - quay
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/quay
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-quay-frontend
+  title: '@janus-idp/backstage-plugin-quay'
+  description: Quay plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/quay
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/quay/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/quay/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - quay
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/quay
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-quay

--- a/plugins/rbac-backend/catalog-info.yaml
+++ b/plugins/rbac-backend/catalog-info.yaml
@@ -1,0 +1,28 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-rbac-backend
+  title: '@janus-idp/backstage-plugin-rbac-backend'
+  description: RBAC backend plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac-backend
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/rbac-backend/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - security
+    - rbac
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac-backend
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-rbac

--- a/plugins/rbac-common/catalog-info.yaml
+++ b/plugins/rbac-common/catalog-info.yaml
@@ -1,0 +1,28 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-rbac-common
+  title: '@janus-idp/backstage-plugin-rbac-common'
+  description: RBAC plugin shared code
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac-common
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac-common/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/rbac-common/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - security
+    - rbac
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac-common
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-common-library
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-rbac

--- a/plugins/rbac-node/catalog-info.yaml
+++ b/plugins/rbac-node/catalog-info.yaml
@@ -1,0 +1,28 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-rbac-node
+  title: '@janus-idp/backstage-plugin-rbac-node'
+  description: Node.js library for the rbac plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac-node
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac-node/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/rbac-node/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - security
+    - rbac
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac-node
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-node-library
+  lifecycle: production
+  owner: rhdh-core-team
+  system: rhdh
+  subcomponentOf: janus-idp-rbac

--- a/plugins/rbac/catalog-info.yaml
+++ b/plugins/rbac/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-rbac
+  title: RBAC plugin
+  description: RBAC for Backstage and RHDH
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/rbac/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - security
+    - rbac
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-rbac-frontend
+  title: '@janus-idp/backstage-plugin-rbac'
+  description: RBAC frontend plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/rbac/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - security
+    - rbac
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-rbac

--- a/plugins/regex-actions/catalog-info.yaml
+++ b/plugins/regex-actions/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-regex-actions
+  title: Regex scaffolder actions
+  description: The regex custom actions
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/regex-actions
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/regex-actions/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/regex-actions/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/regex-actions
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-core-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-regex-actions-module
+  title: '@janus-idp/backstage-scaffolder-backend-module-regex'
+  description: The regex custom actions
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/regex-actions
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/regex-actions/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/regex-actions/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/regex-actions
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin-module
+  lifecycle: production
+  owner: rhdh-core-team
+  system: rhdh
+  subcomponentOf: janus-idp-regex-actions

--- a/plugins/scaffolder-annotator-action/catalog-info.yaml
+++ b/plugins/scaffolder-annotator-action/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-scaffolder-annotator-action
+  title: Annotator scaffolder actions
+  description: The annotator module for @backstage/plugin-scaffolder-backend
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/scaffolder-annotator-action
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/scaffolder-annotator-action/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/scaffolder-annotator-action/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/scaffolder-annotator-action
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-scaffolder-annotator-action-module
+  title: '@janus-idp/backstage-scaffolder-backend-module-annotator'
+  description: The annotator module for @backstage/plugin-scaffolder-backend
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/scaffolder-annotator-action
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/scaffolder-annotator-action/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/scaffolder-annotator-action/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/scaffolder-annotator-action
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin-module
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-scaffolder-annotator-action

--- a/plugins/servicenow-actions/catalog-info.yaml
+++ b/plugins/servicenow-actions/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-servicenow-actions
+  title: ServiceNow scaffolder actions
+  description: ServiceNow actions for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/servicenow-actions
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/servicenow-actions/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/servicenow-actions/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/servicenow-actions
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-servicenow-actions-module
+  title: '@janus-idp/backstage-scaffolder-backend-module-servicenow'
+  description: ServiceNow actions for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/servicenow-actions
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/servicenow-actions/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/servicenow-actions/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/servicenow-actions
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin-module
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-servicenow-actions

--- a/plugins/shared-react/catalog-info.yaml
+++ b/plugins/shared-react/catalog-info.yaml
@@ -1,0 +1,25 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-shared-react
+  title: '@janus-idp/shared-react'
+  description: Janus React Common
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/shared-react
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/shared-react/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/shared-react/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/shared-react
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-web-library
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins

--- a/plugins/sonarqube-actions/catalog-info.yaml
+++ b/plugins/sonarqube-actions/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-sonarqube-actions
+  title: SonarQube scaffolder actions
+  description: SonarQube actions for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/sonarqube-actions
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/sonarqube-actions/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/sonarqube-actions/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/sonarqube-actions
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-sonarqube-actions-module
+  title: '@janus-idp/backstage-scaffolder-backend-module-sonarqube'
+  description: SonarQube actions for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/sonarqube-actions
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/sonarqube-actions/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/sonarqube-actions/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/sonarqube-actions
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin-module
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-sonarqube-actions-module

--- a/plugins/tekton-common/catalog-info.yaml
+++ b/plugins/tekton-common/catalog-info.yaml
@@ -1,0 +1,28 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-tekton-common
+  title: '@janus-idp/backstage-plugin-tekton-common'
+  description: Tekton Common plugin
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/tekton-common
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/tekton-common/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/tekton-common/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/tekton-common
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-common-library
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-tekton

--- a/plugins/tekton/catalog-info.yaml
+++ b/plugins/tekton/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-tekton
+  title: Tekton plugin
+  description: Tekton plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/tekton
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/tekton/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/tekton/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/tekton
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-tekton-frontend
+  title: '@janus-idp/backstage-plugin-tekton'
+  description: Tekton plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/tekton
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/tekton/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/tekton/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/tekton
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-tekton

--- a/plugins/topology-common/catalog-info.yaml
+++ b/plugins/topology-common/catalog-info.yaml
@@ -1,0 +1,28 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-topology-frontend-common
+  title: '@janus-idp/backstage-plugin-topology-common'
+  description: Topology plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/topology-common
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/topology-common/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/topology-common/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/topology-common
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-topology

--- a/plugins/topology/catalog-info.yaml
+++ b/plugins/topology/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-topology
+  title: Topology plugin
+  description: Topology plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/topology
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/topology/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/topology/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/topology
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-topology-frontend
+  title: '@janus-idp/backstage-plugin-topology'
+  description: Topology plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/topology
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/topology/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/topology/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/topology
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-ui-team
+  system: rhdh
+  subcomponentOf: janus-idp-topology

--- a/plugins/web-terminal/catalog-info.yaml
+++ b/plugins/web-terminal/catalog-info.yaml
@@ -1,0 +1,57 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-web-terminal
+  title: Web Terminal plugin
+  description: Web Terminal plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/web-terminal
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/web-terminal/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/web-terminal/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/web-terminal
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-backstage-plugins
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: janus-idp-web-terminal-frontend
+  title: '@janus-idp/backstage-plugin-web-terminal'
+  description: Web Terminal plugin for Backstage
+  annotations:
+    backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/web-terminal
+    backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/web-terminal/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/web-terminal/catalog-info.yaml
+    github.com/project-slug: janus-idp/backstage-plugins
+    #github.com/team-slug: janus-idp/maintainers
+    sonarqube.org/project-key: janus-idp_backstage-plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/web-terminal
+      title: GitHub Source
+      icon: source
+      type: source
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  system: rhdh
+  subcomponentOf: janus-idp-web-terminal


### PR DESCRIPTION
A set of `catalog-info.yaml` files that adds overall 77 components for all plugins, frontend-plugins, backend-plugins, and shared libraries.

## Component types

One catalog-info yaml for each plugin and one additional plugin for each "meta plugin", "plugin pack" or "plugin group"..

The types of the components are aligned with the upstream types:

1. `type: backstage-backend` components are "meta plugin" that doesn't contain code
   * their catalog component name has no suffix, for example `janus-idp-rbac`
2. Additional types are available for all kinds of plugins, modules, or libraries. See below.
   * frontend plugins use the component name suffix -frontend, like `janus-idp-rbac-frontend`

```
backstage (master)  find plugins packages -name catalog-info.yaml | xargs grep 'type: ' | sed 's/.*type: //g' | sort | uniq -c
      2 backstage-backend
     15 backstage-backend-plugin
     64 backstage-backend-plugin-module
      6 backstage-cli
     18 backstage-common-library
      3 backstage-frontend
     20 backstage-frontend-plugin
      2 backstage-frontend-plugin-module
     28 backstage-node-library
     24 backstage-web-library
      4 service
      1 website
```

```
community-plugins (main)  find -name catalog-info.yaml | xargs grep 'type: ' | sed 's/.*type: //g' | sort | uniq -c
     22 backstage-backend-plugin
      2 backstage-backend-plugin-module
     11 backstage-common-library
     59 backstage-frontend-plugin
      4 backstage-frontend-plugin-module
      2 backstage-node-library
      2 backstage-web-library
      1 service
     61 website
```

```
backstage-plugins (update-catalog-infos)  find plugins packages -name catalog-info.yaml | xargs grep '^  type: ' | sed 's/.*type: //g' | sort | uniq -c
     10 backstage-backend-plugin
      1 backstage-backend-plugin-module
      1 backstage-cli
      7 backstage-common-library
     19 backstage-frontend-plugin
      8 backstage-frontend-plugin-module
      2 backstage-node-library
     30 backstage-plugin
      1 backstage-web-library
```

## Testing this PR

Checkout this branch and link the root catalog-info.yaml and catalog-info-teams.yaml:

```yaml
catalog:
  locations:
    - type: file
      target: /home/christoph/git/janus-idp/backstage-plugins/catalog-info-teams.yaml
      rules:
        - allow: [Group]
    - type: file
      target: /home/christoph/git/janus-idp/backstage-plugins/catalog-info.yaml
```

Or link the branch on GitHub:

```yaml
catalog:
  locations:
    - type: url
      target: /https://github.com/jerolimov/janus-backstage-plugins/blob/update-catalog-infos/catalog-info-teams.yaml
      rules:
        - allow: [Group]
    - type: url
      target: https://github.com/jerolimov/janus-backstage-plugins/blob/update-catalog-infos/catalog-info.yaml
```

## Screenshots

Catalog types:

![image](https://github.com/user-attachments/assets/df465019-6d7f-44c9-b0f5-6c807b05c367)

Backstage plugins:

![image](https://github.com/user-attachments/assets/41d4cc32-ee72-4790-b2bc-9310ecb23e05)

Frontend plugins:

![image](https://github.com/user-attachments/assets/1c5c835f-f90f-4557-85f7-47b05fae1ec3)

etc.

RBAC as example:

![image](https://github.com/user-attachments/assets/0d081935-50cb-4e22-9b43-d4a3569f1d58)
