### PR TITLE
feat(bulk-import): add permissions support to the backend endpoints [RHIDP-1208]

### DIFF
--- a/plugins/bulk-import-backend/CONTRIBUTING.md
+++ b/plugins/bulk-import-backend/CONTRIBUTING.md
@@ -14,7 +14,7 @@ permission:
 ```
 
 When you run the previous command, a standalone server for the bulk-import backend is setup utilizing the root app configurations.
-The server is available at `http://localhost:7007/api/bulk-import-backend`.
+The server is available at `http://localhost:7007/api/bulk-import`.
 
 Please refer to the [API documentation](./api-docs/README.md) for the API endpoints and their corresponding request and response formats.
 

--- a/plugins/bulk-import-backend/README.md
+++ b/plugins/bulk-import-backend/README.md
@@ -148,7 +148,7 @@ backend.add(import('@backstage/plugin-permission-backend/alpha'));
 
 ### Usage
 
-The bulk import backend plugin provides a REST API to bulk import catalog entities into the catalog. The API is available at the `/api/bulk-import-backend` endpoint.
+The bulk import backend plugin provides a REST API to bulk import catalog entities into the catalog. The API is available at the `/api/bulk-import` endpoint.
 
 As a prerequisite, you need to add at least one GitHub Integration (using either a GitHub token or a GitHub App or both) in your app-config YAML file (or a local `app-config.local.yaml` file).
 See https://backstage.io/docs/integrations/github/locations/#configuration and https://backstage.io/docs/integrations/github/github-apps/#including-in-integrations-config for more details.

--- a/plugins/bulk-import-backend/README.md
+++ b/plugins/bulk-import-backend/README.md
@@ -81,59 +81,68 @@ export default async function createPlugin(
    backend.start();
    ```
 
-[//]: # '#### Permission Framework Support'
-[//]: #
-[//]: # "TODO: Update this section of the documentation as it doesn't work. Not sure how to setup the permission framework on vanilla backstage, but confirmed to work with the RBAC plugin."
-[//]: #
-[//]: # 'The bulk import backend plugin has support for the permission framework. A basic example permission policy is shown below to disallow access to the bulk import API for all users except those in the `backstage-admins` group. Please note that the This policy should be added to the `packages/backend/src/plugins/permissions.ts` file:'
-[//]: #
-[//]: # '```ts title="packages/backend/src/plugins/permissions.ts"'
-[//]: # "import { createBackendModule } from '@backstage/backend-plugin-api';"
-[//]: # "import { BackstageIdentityResponse } from '@backstage/plugin-auth-node';"
-[//]: # 'import {'
-[//]: # '  AuthorizeResult,'
-[//]: # '  isPermission,'
-[//]: # '  PolicyDecision,'
-[//]: # "} from '@backstage/plugin-permission-common';"
-[//]: # 'import {'
-[//]: # '  PermissionPolicy,'
-[//]: # '  PolicyQuery,'
-[//]: # "} from '@backstage/plugin-permission-node';"
-[//]: # "import { policyExtensionPoint } from '@backstage/plugin-permission-node/alpha';"
-[//]: #
-[//]: # "import { bulkImportPermission } from '@janus-idp/backstage-plugin-bulk-import-common';"
-[//]: #
-[//]: # 'class BulkImportPermissionPolicy implements PermissionPolicy {'
-[//]: # '  async handle('
-[//]: # '     request: PolicyQuery,'
-[//]: # '     user?: BackstageIdentityResponse,'
-[//]: # '   ): Promise<PolicyDecision> {'
-[//]: # '     if (isPermission(request.permission, bulkImportPermission)) {'
-[//]: # '       if ('
-[//]: # '         user?.identity.ownershipEntityRefs.includes('
-[//]: # "           'group:default/backstage-admins',"
-[//]: # '         )'
-[//]: # '       ) {'
-[//]: # '         return { result: AuthorizeResult.ALLOW };'
-[//]: # '       }'
-[//]: # '     }'
-[//]: # '     return { result: AuthorizeResult.DENY };'
-[//]: # '   }'
-[//]: # ' }'
-[//]: #
-[//]: # ' export const BulkImportPermissionBackendModule = createBackendModule({'
-[//]: # "  pluginId: 'permission',"
-[//]: # "   moduleId: 'custom-policy',"
-[//]: # '   register(reg) {'
-[//]: # '     reg.registerInit({'
-[//]: # '       deps: { policy: policyExtensionPoint },'
-[//]: # '       async init({ policy }) {'
-[//]: # '         policy.setPolicy(new BulkImportPermissionPolicy());'
-[//]: # '       },'
-[//]: # '     });'
-[//]: # '   },'
-[//]: # ' });'
-[//]: # '```'
+#### Permission Framework Support
+
+The Bulk Import Backend plugin has support for the permission framework. A basic example permission policy is shown below to disallow access to the bulk import API for all users except those in the `backstage-admins` group.
+
+1. Create a backend module for the permission policy, under a `packages/backend/src/plugins/permissions.ts` file:
+
+```ts title="packages/backend/src/plugins/permissions.ts"
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import { BackstageIdentityResponse } from '@backstage/plugin-auth-node';
+import {
+  AuthorizeResult,
+  isPermission,
+  PolicyDecision,
+} from '@backstage/plugin-permission-common';
+import {
+  PermissionPolicy,
+  PolicyQuery,
+} from '@backstage/plugin-permission-node';
+import { policyExtensionPoint } from '@backstage/plugin-permission-node/alpha';
+
+import { bulkImportPermission } from '@janus-idp/backstage-plugin-bulk-import-common';
+
+class BulkImportPermissionPolicy implements PermissionPolicy {
+  async handle(
+    request: PolicyQuery,
+    user?: BackstageIdentityResponse,
+  ): Promise<PolicyDecision> {
+    if (isPermission(request.permission, bulkImportPermission)) {
+      if (
+        user?.identity.ownershipEntityRefs.includes(
+          'group:default/backstage-admins',
+        )
+      ) {
+        return { result: AuthorizeResult.ALLOW };
+      }
+    }
+    return { result: AuthorizeResult.DENY };
+  }
+}
+
+export const BulkImportPermissionBackendModule = createBackendModule({
+  pluginId: 'permission',
+  moduleId: 'custom-policy',
+  register(reg) {
+    reg.registerInit({
+      deps: { policy: policyExtensionPoint },
+      async init({ policy }) {
+        policy.setPolicy(new BulkImportPermissionPolicy());
+      },
+    });
+  },
+});
+```
+
+2. Import `@backstage/plugin-permission-backend/alpha` and add your permission module to the `packages/backend/src/index.ts` file:
+
+```ts title="packages/backend/src/index.ts"
+import { BulkImportPermissionBackendModule } from './plugins/permissions';
+
+backend.add(BulkImportPermissionBackendModule);
+backend.add(import('@backstage/plugin-permission-backend/alpha'));
+```
 
 ## For Users
 

--- a/plugins/bulk-import-backend/api-docs/Apis/ImportApi.md
+++ b/plugins/bulk-import-backend/api-docs/Apis/ImportApi.md
@@ -1,6 +1,6 @@
 # ImportApi
 
-All URIs are relative to *http://localhost:7007/api/bulk-import-backend*
+All URIs are relative to *http://localhost:7007/api/bulk-import*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|

--- a/plugins/bulk-import-backend/api-docs/Apis/ManagementApi.md
+++ b/plugins/bulk-import-backend/api-docs/Apis/ManagementApi.md
@@ -1,6 +1,6 @@
 # ManagementApi
 
-All URIs are relative to *http://localhost:7007/api/bulk-import-backend*
+All URIs are relative to *http://localhost:7007/api/bulk-import*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|

--- a/plugins/bulk-import-backend/api-docs/Apis/OrganizationApi.md
+++ b/plugins/bulk-import-backend/api-docs/Apis/OrganizationApi.md
@@ -1,6 +1,6 @@
 # OrganizationApi
 
-All URIs are relative to *http://localhost:7007/api/bulk-import-backend*
+All URIs are relative to *http://localhost:7007/api/bulk-import*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|

--- a/plugins/bulk-import-backend/api-docs/Apis/RepositoryApi.md
+++ b/plugins/bulk-import-backend/api-docs/Apis/RepositoryApi.md
@@ -1,6 +1,6 @@
 # RepositoryApi
 
-All URIs are relative to *http://localhost:7007/api/bulk-import-backend*
+All URIs are relative to *http://localhost:7007/api/bulk-import*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|

--- a/plugins/bulk-import-backend/api-docs/README.md
+++ b/plugins/bulk-import-backend/api-docs/README.md
@@ -3,7 +3,7 @@
 <a name="documentation-for-api-endpoints"></a>
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost:7007/api/bulk-import-backend*
+All URIs are relative to *http://localhost:7007/api/bulk-import*
 
 | Class | Method | HTTP request | Description |
 |------------ | ------------- | ------------- | -------------|

--- a/plugins/bulk-import-backend/dev/index.ts
+++ b/plugins/bulk-import-backend/dev/index.ts
@@ -128,7 +128,7 @@ export async function startStandaloneServer(
     .enableCors({
       origin: '*',
     })
-    .addRouter('/api/bulk-import-backend', router)
+    .addRouter('/api/bulk-import', router)
     .addRouter('/api/catalog', await catalog(catalogEnv));
   if (options.enableCors) {
     service = service.enableCors({ origin: 'http://localhost:3000' });

--- a/plugins/bulk-import-backend/package.json
+++ b/plugins/bulk-import-backend/package.json
@@ -57,6 +57,7 @@
     "@backstage/plugin-catalog-node": "^1.12.4",
     "@backstage/plugin-permission-common": "^0.8.0",
     "@backstage/plugin-permission-node": "^0.8.0",
+    "@janus-idp/backstage-plugin-bulk-import-common": "0.2.0",
     "@octokit/auth-app": "^6.0.3",
     "@octokit/core": "^5.1.0",
     "@octokit/rest": "^20.0.2",

--- a/plugins/bulk-import-backend/package.json
+++ b/plugins/bulk-import-backend/package.json
@@ -10,7 +10,7 @@
   "backstage": {
     "role": "backend-plugin",
     "supported-versions": "1.28.4",
-    "pluginId": "bulk-import-backend",
+    "pluginId": "bulk-import",
     "pluginPackages": [
       "@janus-idp/backstage-plugin-bulk-import-backend"
     ]

--- a/plugins/bulk-import-backend/src/openapidocument.ts
+++ b/plugins/bulk-import-backend/src/openapidocument.ts
@@ -28,7 +28,7 @@ const OPENAPI = `
           "default": "7007"
         },
         "basePath": {
-          "default": "api/bulk-import-backend"
+          "default": "api/bulk-import"
         }
       }
     }

--- a/plugins/bulk-import-backend/src/plugin.test.ts
+++ b/plugins/bulk-import-backend/src/plugin.test.ts
@@ -31,7 +31,7 @@ describe('bulkImportPlugin test', () => {
       ],
     });
 
-    const response = await request(server).get('/api/bulk-import-backend/ping');
+    const response = await request(server).get('/api/bulk-import/ping');
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ status: 'ok' });
   });

--- a/plugins/bulk-import-backend/src/plugin.ts
+++ b/plugins/bulk-import-backend/src/plugin.ts
@@ -29,7 +29,7 @@ import { createRouter } from './service/router';
  * @alpha
  */
 export const bulkImportPlugin = createBackendPlugin({
-  pluginId: 'bulk-import-backend',
+  pluginId: 'bulk-import',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/bulk-import-backend/src/schema/openapi.yaml
+++ b/plugins/bulk-import-backend/src/schema/openapi.yaml
@@ -29,7 +29,7 @@ servers:
       port:
         default: '7007'
       basePath:
-        default: 'api/bulk-import-backend'
+        default: 'api/bulk-import'
 paths:
   /ping:
     get:

--- a/plugins/rbac-backend/docs/permissions.md
+++ b/plugins/rbac-backend/docs/permissions.md
@@ -138,3 +138,9 @@ Resource type permissions on the other hand are basic named permissions with a r
 | Name           | Resource Type | Policy | Description                             | Requirements        |
 | -------------- | ------------- | ------ | --------------------------------------- | ------------------- |
 | quay.view.read |               | read   | Allows the user to view the quay plugin | catalog.entity.read |
+
+## Bulk Import
+
+| Name        | Resource Type | Policy | Description                                                                                                                                                                          | Requirements |
+| ----------- | ------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ |
+| bulk.import | bulk-import   |        | Allows the user to access the bulk import endpoints (listing all repositories and organizations accessible by all GitHub integrations, as well as managing the import requests, ...) | X            |


### PR DESCRIPTION
**What does this PR do / why we need it:**

This PR adds RBAC support to the bulk-import backend plugin API endpoints.
Only admins and users with the `bulk.import` permission have access to the bulk import backend API endpoints.

**Which issue(s) this PR fixes:**

Fixes https://issues.redhat.com/browse/RHIDP-1208

**PR acceptance criteria:**

- [x] Unit tests

- [ ] Integration tests

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**

Note that the [`GET /ping` endpoint](https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import-backend/api-docs/Apis/ManagementApi.md#ping) is unauthenticated and does not enforce any permission.

All the other endpoints should check for the `bulk.import` permission.

- [Configure](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import-backend#bulk-import-backend-plugin) the Bulk Import Backend Plugin
- At at least one GitHub integration - see https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import-backend#usage
- Create an RBAC policy CSV file with the following permissions
```csv
g, user:default/<YOUR_USERNAME>, role:default/bulk-import

p, role:default/bulk-import, bulk.import, use, allow
p, role:default/bulk-import, catalog-entity.read, read, allow
p, role:default/bulk-import, catalog-entity.create, create, allow
```
- Reference the CSV file above in the RBAC Backend plugin configuration:
```yaml
permission:
  enabled: true
  rbac:
    policies-csv-file: /path/to/rbac-policy.csv
    policyFileReload: true
```

Now try to query the bulk import backend API endpoints, e.g.:
- Without authentication:

```shell
$ http GET http://localhost:7007/api/bulk-import-backend/organizations

{
    "error": {
        "message": "Missing credentials",
        "name": "AuthenticationError",
        "stack": "AuthenticationError: Missing credentials\n    at DefaultHttpAuthService.credentials (/home/asoro/work/projects/backstage/janus-idp/backstage-plugins/node_modules/@backstage/backend-defaults/src/entrypoints/httpAuth/httpAuthServiceFactory.ts:150:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
    },
    "request": {
        "method": "GET",
        "url": "/api/bulk-import-backend/organizations"
    },
    "response": {
        "statusCode": 401
    }
}
```

- Without the right `bulk-import` permission:

```shell
$ http -A bearer -a "<unathorized_user_jwt_token>" GET http://localhost:7007/api/bulk-import-backend/organizations

{
    "error": {
        "message": "Unauthorized",
        "name": "NotAllowedError",
        "stack": "NotAllowedError: Unauthorized\n    at permissionCheck (/home/asoro/work/projects/backstage/janus-idp/backstage-plugins/plugins/bulk-import-backend/src/helpers/auth.ts:49:11)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at <anonymous> (/home/asoro/work/projects/backstage/janus-idp/backstage-plugins/plugins/bulk-import-backend/src/service/router.ts:128:7)\n    at OpenAPIBackend.handleRequest (/home/asoro/work/projects/backstage/janus-idp/backstage-plugins/node_modules/openapi-backend/src/backend.ts:299:27)"
    },
    "request": {
        "method": "GET",
        "url": "/repositories"
    },
    "response": {
        "statusCode": 403
    }
}
```

- For admins or users with the expected `bulk-import` permission:

```shell
$ http -A bearer -a "<authorized_user_jwt_token>" GET http://localhost:7007/api/bulk-import-backend/organizations

{                                                                                                                                                  
    "errors": [],                                                                                                                                  
    "organizations": [ 
       ...
    ],
    "pagePerIntegration": 1,
    "sizePerIntegration": 20,
    "totalCount": 18
}
```