### PR TITLE
docs(quay): add documentation for the new credential settings in proxy backend

### DIFF
--- a/plugins/quay/README.md
+++ b/plugins/quay/README.md
@@ -20,6 +20,7 @@ The Quay plugin displays the information about your container images within the 
    proxy:
      '/quay/api':
        target: 'https://quay.io'
+       credentials: require
        headers:
          X-Requested-With: 'XMLHttpRequest'
          # Uncomment the following line to access a private Quay Repository using a token
@@ -32,6 +33,15 @@ The Quay plugin displays the information about your container images within the 
      # The UI url for Quay, used to generate the link to Quay
      uiUrl: 'https://quay.io'
    ```
+
+> [!NOTE]
+> The value inside each route is either a simple URL string, or an object on the format accepted by [http-proxy-middleware](https://www.npmjs.com/package/http-proxy-middleware). Additionally, it has an optional `credentials` key which can have the following values:
+>
+> - `require`: Callers must provide Backstage user or service credentials with each request. The credentials are not forwarded to the proxy target. This is the **default**.
+> - `forward`: Callers must provide Backstage user or service credentials with each request, and those credentials are forwarded to the proxy target.
+> - `dangerously-allow-unauthenticated`: No Backstage credentials are required to access this proxy target. The target can still apply its own credentials checks, but the proxy will not help block non-Backstage-blessed callers. If you also add allowedHeaders: ['Authorization'] to an endpoint configuration, then the Backstage token (if provided) WILL be forwarded.
+>
+> Note that if you have `backend.auth.dangerouslyDisableDefaultAuthPolicy` set to true, the credentials value does not apply; the proxy will behave as if all endpoints were set to dangerously-allow-unauthenticated.
 
 2. Enable an additional tab on the entity view page in `packages/app/src/components/catalog/EntityPage.tsx`:
 


### PR DESCRIPTION

Fixes: 

https://github.com/janus-idp/backstage-plugins/issues/1901

This PR adds more context around the new optional credential settings in the backstage 1.28 to explain different settings available to the users. 

See Backstage 1.28 release notes about the `BREAKING: Proxy backend plugin protected by default` -
https://github.com/backstage/backstage/releases/tag/v1.28.0

> [!Note]
> Quay plugin works without any additional changes in the  `app.config.yaml` for the existing users.


/cc @kim-tsao @rohitkrai03 