### PR TITLE
docs(rbac): fix condition rules api url

### DIFF
--- a/plugins/rbac-backend/docs/apis.md
+++ b/plugins/rbac-backend/docs/apis.md
@@ -507,7 +507,7 @@ Conditional permission policies are fairly complex. For more information on how 
 
 ### GET conditional rules
 
-GET <api/plugins/condition-rules>
+GET <api/permission/plugins/condition-rules>
 
 Provides conditional rule parameter schemas.
 

--- a/plugins/rbac-backend/docs/conditions.md
+++ b/plugins/rbac-backend/docs/conditions.md
@@ -23,9 +23,9 @@ The structure of the condition JSON object is as follows:
 | resourceType      | Resource type provided by the plugin (e.g., "catalog-entity")         | String       |
 | conditions        | Condition JSON with parameters or array parameters joined by criteria | JSON         |
 
-To get the available conditional rules that can be used to create conditional permission policies, use the GET API request `api/plugins/condition-rules` as seen below.
+To get the available conditional rules that can be used to create conditional permission policies, use the GET API request `api/permission/plugins/condition-rules` as seen below.
 
-GET <api/plugins/condition-rules>
+GET <api/permission/plugins/condition-rules>
 
 Provides condition parameters schemas.
 


### PR DESCRIPTION
Fixes RBAC API url: `api/plugins/condition-rules` -> `api/permission/plugins/condition-rules`.
