### PR TITLE
fix(rbac): log when plugin has no permissions

### DIFF
--- a/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
@@ -124,7 +124,7 @@ describe('plugin-endpoint', () => {
       ]);
     });
 
-    it('should skip not found error for not found endpoint', async () => {
+    it('should log warning for not found endpoint', async () => {
       backendPluginIDsProviderMock.getPluginIds.mockReturnValue([
         'permission',
         'unknown-plugin-id',
@@ -145,6 +145,7 @@ describe('plugin-endpoint', () => {
         '{"permissions":[{"type":"resource","resourceType":"policy-entity","name":"policy.entity.read","attributes":{"action":"read"}}]}',
       );
 
+      const errorSpy = jest.spyOn(logger, 'warn').mockClear();
       const collector = new PluginPermissionMetadataCollector(
         mockPluginEndpointDiscovery,
         backendPluginIDsProviderMock,
@@ -162,6 +163,10 @@ describe('plugin-endpoint', () => {
           policy: 'read',
         },
       ]);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'No permission metadata found for unknown-plugin-id. NotFoundError',
+      );
     });
 
     it('should log error when it is not possible to retrieve permission metadata for known endpoint', async () => {

--- a/plugins/rbac-backend/src/service/plugin-endpoints.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoints.ts
@@ -142,6 +142,9 @@ export class PluginPermissionMetadataCollector {
       }
     } catch (err) {
       if (isError(err) && err.name === 'NotFoundError') {
+        this.logger.warn(
+          `No permission metadata found for ${pluginId}. ${err}`,
+        );
         return undefined;
       }
       this.logger.error(


### PR DESCRIPTION
### Description:
Log whenever a plugin captured by the RBAC Backend plugin does not have permissions.

### Fixes:
[RHIDP-2059](https://issues.redhat.com/browse/RHIDP-2059)