### PR TITLE
fix(rbac): reduce number of transactions for admin role

### DIFF
--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -90,6 +90,7 @@ const useAdminsFromConfig = async (
     await roleMetadataStorage.findRoleMetadata(ADMIN_ROLE_NAME);
 
   const trx = await knex.transaction();
+  let addedRoleMembers;
   try {
     if (!adminRoleMeta) {
       // even if there are no user, we still create default role metadata for admins
@@ -101,14 +102,19 @@ const useAdminsFromConfig = async (
         trx,
       );
     }
+
+    addedRoleMembers = Array.from<string[]>(newGroupPolicies.entries());
+    await enf.addGroupingPolicies(
+      addedRoleMembers,
+      getAdminRoleMetadata(),
+      trx,
+    );
+
     await trx.commit();
   } catch (error) {
     await trx.rollback(error);
     throw error;
   }
-
-  const addedRoleMembers = Array.from<string[]>(newGroupPolicies.entries());
-  await enf.addGroupingPolicies(addedRoleMembers, getAdminRoleMetadata());
 
   await auditLogger.auditLog<RoleAuditInfo>({
     actorId: RBAC_BACKEND,


### PR DESCRIPTION
## Description

Fixes the issue where an error is thrown whenever the RBAC Backend plugin configuration values are not set within the app-config. Namely, the problem happened whenever an admin was not set in the app-config.

The issue seemed to be happening because a transaction was not being committed properly and was not freeing up. This in turn would result in the following error

```
ForwardedError [KnexTimeoutError]: Plugin 'permission' startup failed; caused by KnexTimeoutError: Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?
```

The fix was to have it so that the role metadata transaction and the admin roles transaction are now shared.

## Fixes

- Fixes: [RHIDP-3282](https://issues.redhat.com/browse/RHIDP-3282)