### PR TITLE
feat(argocd): add support for fetching an application by app name

### DIFF
--- a/plugins/argocd/README.md
+++ b/plugins/argocd/README.md
@@ -114,15 +114,31 @@ const cicdcontent = (
 );
 ```
 
-- The following annotation is added to the entity's `catalog-info.yaml` file to enable Argo CD features in the backstage instance:
+- Add one of the following annotations to the entity's `catalog-info.yaml` file to enable Argo CD features in the backstage instance:
+
+  - To get all the applications matching the metadata labels.
 
   ```yaml
   annotations:
     ...
 
-    argocd/app-selector: 'rht-gitops.com/janus-argocd=quarkus-app'
+    argocd/app-selector: 'rht-gitops.com/janus-argocd=quarkus-app' # format: `label.key=label.value`
 
   ```
+
+      **or**
+
+  - To fetch a single application, use the following annotation in `catalog-info.yaml` file:
+
+  ```yaml
+  annotations:
+    ...
+
+    argocd/app-name: 'quarkus-app'
+
+  ```
+
+  > [!Note] > **You should not add both the annotations in the same catalog, adding both annotations will result in error in the plugin.**
 
 - To switch between argocd instances, you can use the following annotation
 
@@ -132,7 +148,7 @@ const cicdcontent = (
     argocd/instance-name: 'argoInstance2'
 ```
 
-**_Note: If this annotation is not set, the plugin will default to the first Argo CD instance configured in the `app.config.yaml`_**
+> [!Note] > **If this annotation is not set, the plugin will default to the first Argo CD instance configured in the `app.config.yaml`**
 
 ## Loading as Dynamic Plugin
 

--- a/plugins/argocd/dev/index.tsx
+++ b/plugins/argocd/dev/index.tsx
@@ -14,6 +14,7 @@ import { createDevAppThemes } from '@redhat-developer/red-hat-developer-hub-them
 import {
   ArgoCDApi,
   argoCDApiRef,
+  GetApplicationOptions,
   listAppsOptions,
   RevisionDetailsListOptions,
   RevisionDetailsOptions,
@@ -23,6 +24,7 @@ import {
   ArgocdDeploymentSummary,
   argocdPlugin,
 } from '../src/plugin';
+import { Application } from '../src/types';
 import {
   mockApplication,
   mockArgocdConfig,
@@ -61,6 +63,9 @@ export class MockArgoCDApiClient implements ArgoCDApi {
     _options: RevisionDetailsListOptions,
   ): Promise<any> {
     return mockRevisions;
+  }
+  async getApplication(_options: GetApplicationOptions): Promise<Application> {
+    return mockApplication;
   }
 }
 

--- a/plugins/argocd/src/api/__tests__/index.test.ts
+++ b/plugins/argocd/src/api/__tests__/index.test.ts
@@ -42,12 +42,13 @@ describe('API calls', () => {
 
       await client.listApps({
         url: '',
+        appSelector: 'janus.io%253Dquarkus-app',
         projectName: 'test',
         appNamespace: 'my-test-ns',
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'https://test.com/api/argocd/applications?project=test',
+        'https://test.com/api/argocd/applications/selector/janus.io%253Dquarkus-app?selector=janus.io%25253Dquarkus-app&project=test',
         expect.objectContaining({
           headers: {
             'Content-Type': 'application/json',
@@ -124,13 +125,68 @@ describe('API calls', () => {
       await client.listApps({
         url: '',
         projectName: 'test',
+        appSelector: 'janus.io%253Dquarkus-app',
         appNamespace: 'my-test-ns',
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'https://test.com/api/argocd/applications?project=test',
+        'https://test.com/api/argocd/applications/selector/janus.io%253Dquarkus-app?selector=janus.io%25253Dquarkus-app&project=test',
         expect.objectContaining({
           headers: undefined,
+        }),
+      );
+    });
+  });
+
+  describe('getApplication', () => {
+    beforeEach(() => {
+      fetchSpy.mockImplementation(() =>
+        Promise.resolve<Response>({
+          ok: true,
+          json: () => Promise.resolve({}),
+        } as Response),
+      );
+    });
+
+    test('should return empty object as response', async () => {
+      const client = new ArgoCDApiClient({
+        backendBaseUrl: 'https://test.com',
+        useNamespacedApps: false,
+        identityApi: getIdentityApiStub,
+      });
+
+      const data = await client.getApplication({
+        url: '',
+        appName: 'quarkus-app',
+        appNamespace: '',
+      });
+      expect(Object.keys(data)).toHaveLength(0);
+    });
+
+    test('should return application object', async () => {
+      fetchSpy.mockImplementation(() =>
+        Promise.resolve<Response>({
+          ok: true,
+          json: () => Promise.resolve(mockApplication),
+        } as Response),
+      );
+
+      const client = new ArgoCDApiClient({
+        backendBaseUrl: 'https://test.com',
+        useNamespacedApps: false,
+        identityApi: getIdentityApiStub,
+      });
+
+      const data = await client.getApplication({
+        url: '',
+        appName: 'quarkus-app',
+        appNamespace: '',
+      });
+      expect(data).toEqual(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            name: 'quarkus-app-dev',
+          }),
         }),
       );
     });

--- a/plugins/argocd/src/api/index.ts
+++ b/plugins/argocd/src/api/index.ts
@@ -23,6 +23,13 @@ export type RevisionDetailsListOptions = {
   instanceName?: string;
   apps: Application[];
 };
+
+export type GetApplicationOptions = {
+  url: string;
+  appName: string;
+  appNamespace?: string;
+  instance?: string;
+};
 export interface ArgoCDApi {
   listApps(options: listAppsOptions): Promise<{ items: Application[] }>;
   getRevisionDetails(
@@ -31,6 +38,7 @@ export interface ArgoCDApi {
   getRevisionDetailsList(
     options: RevisionDetailsListOptions,
   ): Promise<ArgoCDAppDeployRevisionDetails[]>;
+  getApplication(options: GetApplicationOptions): Promise<Application>;
 }
 
 export const argoCDApiRef = createApiRef<ArgoCDApi>({
@@ -107,9 +115,19 @@ export class ArgoCDApiClient implements ArgoCDApi {
       appNamespace: options.appNamespace,
     });
     return this.fetcher(
-      options.appSelector
-        ? `${proxyUrl}${options.url}/applications/selector/${options.appSelector}${query}`
-        : `${proxyUrl}${options.url}/applications${query}`,
+      `${proxyUrl}${options.url}/applications/selector/${options.appSelector}${query}`,
+    );
+  }
+
+  async getApplication(options: GetApplicationOptions) {
+    const proxyUrl = await this.getBaseUrl();
+    const query = this.getQueryParams({
+      appNamespace: options.appNamespace,
+    });
+    return this.fetcher(
+      `${proxyUrl}${options.url}/applications/${encodeURIComponent(
+        options.appName,
+      )}${query}`,
     );
   }
 
@@ -128,10 +146,8 @@ export class ArgoCDApiClient implements ArgoCDApi {
       `${proxyUrl}/argoInstance/${
         options.instanceName
       }/applications/name/${encodeURIComponent(
-        options.app as string,
-      )}/revisions/${encodeURIComponent(
-        options.revisionID as string,
-      )}/metadata${query}`,
+        options.app,
+      )}/revisions/${encodeURIComponent(options.revisionID)}/metadata${query}`,
     );
   }
 

--- a/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
@@ -12,7 +12,7 @@ import { useArgocdConfig } from '../../hooks/useArgocdConfig';
 import { useArgocdViewPermission } from '../../hooks/useArgocdViewPermission';
 import { Application, Revision } from '../../types';
 import {
-  getAppSelector,
+  getArgoCdAppConfig,
   getInstanceName,
   getUniqueRevisions,
 } from '../../utils/utils';
@@ -46,10 +46,16 @@ const DeploymentLifecycle = () => {
 
   const { instances, intervalMs } = useArgocdConfig();
   const instanceName = getInstanceName(entity) || instances?.[0]?.name;
+  const { appSelector, appName, projectName, appNamespace } =
+    getArgoCdAppConfig({ entity });
+
   const { apps, loading, error } = useApplications({
     instanceName,
     intervalMs,
-    appSelector: encodeURIComponent(getAppSelector(entity)),
+    appSelector,
+    appName,
+    appNamespace,
+    projectName,
   });
 
   const hasArgocdViewAccess = useArgocdViewPermission();

--- a/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
@@ -21,7 +21,7 @@ import GitLabIcon from '@patternfly/react-icons/dist/esm/icons/gitlab-icon';
 import moment from 'moment';
 
 import { Application, Revision } from '../../types';
-import { getCommitUrl } from '../../utils/utils';
+import { getCommitUrl, isAppHelmChartType } from '../../utils/utils';
 import AppNamespace from '../AppStatus/AppNamespace';
 import StatusHeading from '../AppStatus/StatusHeading';
 import DeploymentLifecycleHeader from './DeploymentLifecycleHeader';
@@ -102,14 +102,12 @@ const DeploymentLifecycleCard: React.FC<DeploymentLifecycleCardProps> = ({
               {app?.spec?.destination?.server}{' '}
               {app?.spec?.destination?.server ===
               'https://kubernetes.default.svc' ? (
-                <>
-                  <Tooltip
-                    data-testid="local-cluster-tooltip"
-                    title="This is the local cluster where Argo CD is installed."
-                  >
-                    <span>(in-cluster) </span>
-                  </Tooltip>
-                </>
+                <Tooltip
+                  data-testid="local-cluster-tooltip"
+                  title="This is the local cluster where Argo CD is installed."
+                >
+                  <span>(in-cluster) </span>
+                </Tooltip>
               ) : (
                 ''
               )}
@@ -122,7 +120,7 @@ const DeploymentLifecycleCard: React.FC<DeploymentLifecycleCardProps> = ({
 
             <AppNamespace app={app} />
           </Grid>
-          {!app?.spec?.source?.chart && (
+          {!isAppHelmChartType(app) && (
             <Grid item xs={12}>
               <Typography color="textPrimary">Commit</Typography>
               {revisionsMap && latestRevision ? (

--- a/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleDrawer.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleDrawer.tsx
@@ -23,7 +23,7 @@ import GitLabIcon from '@patternfly/react-icons/dist/esm/icons/gitlab-icon';
 import moment from 'moment';
 
 import { Application, Revision } from '../../types';
-import { getCommitUrl } from '../../utils/utils';
+import { getCommitUrl, isAppHelmChartType } from '../../utils/utils';
 import AppNamespace from '../AppStatus/AppNamespace';
 import StatusHeading from '../AppStatus/StatusHeading';
 import DeploymentLifecycledHeader from './DeploymentLifecycleHeader';
@@ -124,11 +124,9 @@ const DeploymentLifecycleDrawer: React.FC<DeploymentLifecycleDrawerProps> = ({
               {app?.spec?.destination?.server}{' '}
               {app?.spec?.destination?.server ===
               'https://kubernetes.default.svc' ? (
-                <>
-                  <Tooltip title="This is the local cluster where Argo CD is installed.">
-                    <span>(in-cluster) </span>
-                  </Tooltip>
-                </>
+                <Tooltip title="This is the local cluster where Argo CD is installed.">
+                  <span>(in-cluster) </span>
+                </Tooltip>
               ) : (
                 ''
               )}
@@ -139,7 +137,7 @@ const DeploymentLifecycleDrawer: React.FC<DeploymentLifecycleDrawerProps> = ({
 
             <AppNamespace app={app} />
           </Grid>
-          {!app?.spec?.source?.chart && (
+          {!isAppHelmChartType(app) && (
             <Grid item xs={12}>
               <Typography color="textPrimary">Commit</Typography>
               {latestRevision ? (
@@ -159,11 +157,13 @@ const DeploymentLifecycleDrawer: React.FC<DeploymentLifecycleDrawerProps> = ({
                       const repoUrl = app?.spec?.source?.repoURL ?? '';
                       if (repoUrl) {
                         window.open(
-                          getCommitUrl(
-                            repoUrl,
-                            latestRevision?.revision,
-                            entity?.metadata?.annotations ?? {},
-                          ),
+                          isAppHelmChartType(app)
+                            ? repoUrl
+                            : getCommitUrl(
+                                repoUrl,
+                                latestRevision?.revision,
+                                entity?.metadata?.annotations ?? {},
+                              ),
                           '_blank',
                         );
                       }
@@ -215,11 +215,15 @@ const DeploymentLifecycleDrawer: React.FC<DeploymentLifecycleDrawerProps> = ({
                     <br />
                     {revisionsMap[latestRevision?.revision]?.message}{' '}
                     <Link
-                      href={getCommitUrl(
-                        app?.spec?.source?.repoURL ?? '',
-                        latestRevision?.revision,
-                        entity?.metadata?.annotations ?? {},
-                      )}
+                      href={
+                        isAppHelmChartType(app)
+                          ? app?.spec?.source?.repoURL
+                          : getCommitUrl(
+                              app?.spec?.source?.repoURL ?? '',
+                              latestRevision?.revision,
+                              entity?.metadata?.annotations ?? {},
+                            )
+                      }
                       target="_blank"
                       rel="noopener"
                     >

--- a/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycle.test.tsx
+++ b/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycle.test.tsx
@@ -27,7 +27,9 @@ jest.mock('@backstage/core-plugin-api', () => ({
 }));
 
 jest.mock('@backstage/plugin-catalog-react', () => ({
-  useEntity: () => mockEntity,
+  useEntity: () => ({
+    entity: mockEntity,
+  }),
 }));
 
 jest.mock('@backstage/core-components', () => ({

--- a/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -12,10 +12,10 @@ import { useArgocdConfig } from '../../hooks/useArgocdConfig';
 import { useArgocdViewPermission } from '../../hooks/useArgocdViewPermission';
 import { Application, HealthStatus, SyncStatuses } from '../../types';
 import {
-  getAppSelector,
+  getArgoCdAppConfig,
   getCommitUrl,
   getInstanceName,
-  getProjectName,
+  isAppHelmChartType,
 } from '../../utils/utils';
 import AppSyncStatus from '../AppStatus/AppSyncStatus';
 import { AppHealthIcon } from '../AppStatus/StatusIcons';
@@ -26,11 +26,16 @@ const DeploymentSummary = () => {
   const { baseUrl, instances, intervalMs } = useArgocdConfig();
   const instanceName = getInstanceName(entity) || instances?.[0]?.name;
 
+  const { appSelector, appName, projectName, appNamespace } =
+    getArgoCdAppConfig({ entity });
+
   const { apps, loading, error } = useApplications({
     instanceName,
     intervalMs,
-    appSelector: encodeURIComponent(getAppSelector(entity)),
-    projectName: getProjectName(entity),
+    appSelector,
+    projectName,
+    appName,
+    appNamespace,
   });
 
   const hasArgocdViewAccess = useArgocdViewPermission();
@@ -51,18 +56,16 @@ const DeploymentSummary = () => {
       field: 'name',
       render: (row: Application): React.ReactNode =>
         getBaseUrl(row) ? (
-          <>
-            <Link
-              href={`${getBaseUrl(row)}/applications/${row?.metadata?.name}`}
-              target="_blank"
-              rel="noopener"
-            >
-              {row.metadata.name}{' '}
-              <IconButton color="primary" size="small">
-                <ExternalLinkIcon />
-              </IconButton>
-            </Link>
-          </>
+          <Link
+            href={`${getBaseUrl(row)}/applications/${row?.metadata?.name}`}
+            target="_blank"
+            rel="noopener"
+          >
+            {row.metadata.name}{' '}
+            <IconButton color="primary" size="small">
+              <ExternalLinkIcon />
+            </IconButton>
+          </Link>
         ) : (
           row.metadata.name
         ),
@@ -78,7 +81,7 @@ const DeploymentSummary = () => {
       title: 'Instance',
       field: 'instance',
       render: (row: Application): React.ReactNode => {
-        return <>{row.metadata?.instance.name}</>;
+        return <>{row.metadata?.instance?.name || instanceName}</>;
       },
     },
     {
@@ -94,11 +97,14 @@ const DeploymentSummary = () => {
       render: (row: Application): React.ReactNode => {
         const historyList = row.status?.history ?? [];
         const latestRev = historyList[historyList.length - 1];
-        const commitUrl = getCommitUrl(
-          row?.spec?.source?.repoURL,
-          latestRev?.revision,
-          entity?.metadata?.annotations || {},
-        );
+        const repoUrl = row?.spec?.source?.repoURL;
+        const commitUrl = isAppHelmChartType(row)
+          ? repoUrl
+          : getCommitUrl(
+              repoUrl,
+              latestRev?.revision,
+              entity?.metadata?.annotations || {},
+            );
         return (
           <Link href={commitUrl} target="_blank" rel="noopener">
             {latestRev?.revision?.substring(0, 7) ?? '-'}
@@ -136,7 +142,7 @@ const DeploymentSummary = () => {
       title: 'Sync status',
       field: 'syncstatus',
       customSort: (a: Application, b: Application): number => {
-        const syncStatusOrder: String[] = Object.values(SyncStatuses);
+        const syncStatusOrder: string[] = Object.values(SyncStatuses);
         return (
           syncStatusOrder.indexOf(a?.status?.sync?.status) -
           syncStatusOrder.indexOf(b?.status?.sync?.status)
@@ -150,7 +156,7 @@ const DeploymentSummary = () => {
       title: 'Health status',
       field: 'healthstatus',
       customSort: (a: Application, b: Application): number => {
-        const healthStatusOrder: String[] = Object.values(HealthStatus);
+        const healthStatusOrder: string[] = Object.values(HealthStatus);
         return (
           healthStatusOrder.indexOf(a?.status?.health?.status) -
           healthStatusOrder.indexOf(b?.status?.health?.status)
@@ -175,7 +181,7 @@ const DeploymentSummary = () => {
         padding: 'dense',
       }}
       isLoading={loading}
-      data={apps as Application[]}
+      data={apps}
       columns={columns}
     />
   ) : null;

--- a/plugins/argocd/src/components/DeploymentSummary/__tests__/DeploymentSummary.test.tsx
+++ b/plugins/argocd/src/components/DeploymentSummary/__tests__/DeploymentSummary.test.tsx
@@ -33,7 +33,9 @@ const mockUsePermission = usePermission as jest.MockedFunction<
 >;
 
 jest.mock('@backstage/plugin-catalog-react', () => ({
-  useEntity: () => mockEntity,
+  useEntity: () => ({
+    entity: mockEntity,
+  }),
 }));
 
 describe('DeploymentSummary', () => {

--- a/plugins/argocd/src/hooks/__tests__/useApplications.test.ts
+++ b/plugins/argocd/src/hooks/__tests__/useApplications.test.ts
@@ -13,6 +13,9 @@ jest.mock('@backstage/core-plugin-api', () => ({
 describe('useApplications', () => {
   beforeEach(() => {
     (useApi as any).mockReturnValue({
+      getApplication: async () => {
+        return Promise.resolve({ items: [mockApplication] });
+      },
       listApps: async () => {
         return Promise.resolve({ items: [mockApplication] });
       },
@@ -101,6 +104,116 @@ describe('useApplications', () => {
       instanceName: 'main',
       intervalMs: 10000,
       appSelector: 'rht.gitops.com/quarkus-app-bootstrap',
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.apps).toHaveLength(1);
+    });
+  });
+
+  test('should invoke listApps method when appSelector is passed', async () => {
+    const mockListApps = jest.fn();
+    const mockgetApplication = jest.fn();
+
+    (useApi as any).mockReturnValue({
+      getApplication: mockgetApplication,
+      listApps: mockListApps,
+    });
+
+    renderHook(() =>
+      useApplications({
+        instanceName: 'main',
+        intervalMs: 10000,
+        appSelector: 'rht.gitops.com/quarkus-app-bootstrap',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockListApps).toHaveBeenCalled();
+      expect(mockgetApplication).not.toHaveBeenCalled();
+    });
+  });
+
+  test('should invoke getApplication method if appName is passed', async () => {
+    const mockListApps = jest.fn();
+    const mockgetApplication = jest.fn();
+    (useApi as any).mockReturnValue({
+      getApplication: mockgetApplication,
+      listApps: mockListApps,
+    });
+
+    renderHook(() =>
+      useApplications({
+        instanceName: 'main',
+        intervalMs: 10000,
+        appSelector: null as unknown as string,
+        appName: 'quarkus-app-bootstrap',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockgetApplication).toHaveBeenCalled();
+      expect(mockListApps).not.toHaveBeenCalled();
+    });
+  });
+
+  test('should return single application and loading state when the appName is passed', async () => {
+    (useApi as any).mockReturnValue({
+      getApplication: async () => {
+        return Promise.resolve({ items: [mockApplication] });
+      },
+    });
+
+    const { result } = renderHook(prop => useApplications(prop), {
+      initialProps: {
+        instanceName: 'main',
+        intervalMs: 10000,
+        appSelector: null as unknown as string,
+        appName: 'quarkus-app-test',
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.apps).toHaveLength(1);
+    });
+  });
+
+  test('should return the applications and loading state when the app name updates', async () => {
+    (useApi as any).mockReturnValue({
+      getApplication: async () => {
+        return Promise.resolve({ items: [mockApplication] });
+      },
+    });
+
+    const { result, rerender } = renderHook(prop => useApplications(prop), {
+      initialProps: {
+        instanceName: 'main',
+        intervalMs: 10000,
+        appSelector: null as unknown as string,
+        appName: 'quarkus-app',
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.apps).toHaveLength(1);
+    });
+
+    rerender({
+      instanceName: 'main',
+      intervalMs: 10000,
+      appSelector: null as unknown as string,
+      appName: 'quarkus-test-app',
     });
 
     await waitFor(() => {

--- a/plugins/argocd/src/utils/isArgocdConfigured.ts
+++ b/plugins/argocd/src/utils/isArgocdConfigured.ts
@@ -4,5 +4,4 @@ import { ArgoCdLabels } from './utils';
 
 export const isArgocdConfigured = (entity: Entity) =>
   Boolean(entity?.metadata.annotations?.[ArgoCdLabels.appSelector]) ||
-  Boolean(entity?.metadata.annotations?.[ArgoCdLabels.instanceName]) ||
-  Boolean(entity?.metadata.annotations?.[ArgoCdLabels.projectName]);
+  Boolean(entity?.metadata.annotations?.[ArgoCdLabels.appName]);


### PR DESCRIPTION
### Fixes:

https://issues.redhat.com/browse/RHTAP-2849

### Description:

Add support  to fetch only the application thats matches the name defined in  `argocd/app-name` annotation.


### How to test

1. Add a Gitops Application in a namespace
2. Use the following annotation to fetch that single application in Argo CD plugin
 
 ```yaml
         metadata:
             annotations:
                ....
                argocd/app-name: quarkus-app
 ```
 
 ### Screenshots
 
 
<img width="1789" alt="Argocd_application" src="https://github.com/user-attachments/assets/f6c5ee5a-6517-46c1-abc7-1c778614a7f1">


cc: @rohitkrai03 
      
      