### PR TITLE
fix: remove crashing process from playwright tests

### DIFF
--- a/.github/workflows/pr-playwright.yaml
+++ b/.github/workflows/pr-playwright.yaml
@@ -67,28 +67,6 @@ jobs:
           # enable permission support and RBAC plugins
           printf "\npermission:\n  enabled: true\n" >> ${root}/app-config.yaml
 
-          # Start backend
-          echo "Starting backend"
-          logfile=$(mktemp)
-          yarn start >$logfile 2>&1 &
-
-          for attempt in $(seq 1 45); do
-            sleep 1
-            if grep -q "Error:" $logfile; then
-              cat $logfile
-              exit 1
-            fi
-            if grep -q "Listening on" $logfile; then
-              echo "Backend started"
-              break
-            fi
-            if [[ attempt -eq 45 ]]; then
-              echo "Failed to launch backend"
-              cat $logfile
-              exit 1
-            fi
-          done
-
           cd $root/plugins
 
           # Launch suitable plugins with changes
@@ -122,15 +100,10 @@ jobs:
             
             # Kill the plugin
             pid=$(lsof -i :3000 -Fp | grep p | sed s/p//)
-            kill -9 $pid || true 
+            kill -9 $pid
             echo "$f shut down"
             cd $root/plugins
           done
-
-          # Kill backend
-          pid=$(lsof -i :7007 -Fp | grep p | sed s/p//)
-          kill -9 $pid || true
-          echo "Backend shut down"
       - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         if: always()
         with:


### PR DESCRIPTION
UI tests don't seem to need the backend process running anymore, and it keeps crashing.
Removing so it doesn't fail the action.