### PR TITLE
fix(deps): move backend-test-utils to devDependencies

### DIFF
--- a/plugins/acr/package.json
+++ b/plugins/acr/package.json
@@ -37,7 +37,7 @@
     "@backstage/core-plugin-api": "^1.9.3",
     "@backstage/plugin-catalog-react": "^1.12.1",
     "@backstage/theme": "^0.5.6",
-    "@janus-idp/shared-react": "2.8.0",
+    "@janus-idp/shared-react": "^2.7.1",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.45",

--- a/plugins/rbac-backend/package.json
+++ b/plugins/rbac-backend/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@backstage/backend-common": "^0.23.2",
     "@backstage/backend-plugin-api": "^0.6.21",
-    "@backstage/backend-test-utils": "^0.4.3",
     "@backstage/catalog-client": "^1.6.5",
     "@backstage/catalog-model": "^1.5.0",
     "@backstage/config": "^1.2.0",
@@ -60,6 +59,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.10",
+    "@backstage/backend-test-utils": "^0.4.3",
     "@types/express": "4.17.21",
     "@types/node": "18.19.34",
     "@types/supertest": "2.0.16",


### PR DESCRIPTION
## Description

Two part PR, first downgrade `shared-react` so that we can try to get a release going. Second, move `"@backstage/backend-test-utils"` to devDependencies in the RBAC backend plugin