### PR TITLE
Update renovate to manage the noise

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,10 +16,11 @@
   "npm": {
     "minimumReleaseAge": "1 day"
   },
-
+  "major": {
+    "dependencyDashboardApproval": true
+  },
   "recreateWhen": "never",
   "prCreation": "status-success",
-
   "packageRules": [
     {
       "description": "Do automerge and pin actions in GH workflows, except for versions starting with 0",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,9 +16,10 @@
   "npm": {
     "minimumReleaseAge": "1 day"
   },
-  "major": {
-    "dependencyDashboardApproval": true
-  },
+
+  "recreateWhen": "never",
+  "prCreation": "status-success",
+
   "packageRules": [
     {
       "description": "Do automerge and pin actions in GH workflows, except for versions starting with 0",


### PR DESCRIPTION
- prevent immortal PRs from re-opening
- only create prs if tests pass