### PR TITLE
chore(release): remove private from manually released tekton-common

### DIFF
--- a/plugins/tekton-common/package.json
+++ b/plugins/tekton-common/package.json
@@ -4,7 +4,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",
@@ -41,7 +40,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/janus-idp/backstage-plugins",
+    "url": "git+https://github.com/janus-idp/backstage-plugins.git",
     "directory": "plugins/tekton-common"
   },
   "keywords": [


### PR DESCRIPTION
## Description

Remove the `private` field now that the tekton-common plugin has been released