### PR TITLE
feat(bulk-import): return the total count of repos per org in the `GET /organizations` backend API [RHIDP-3337]

### DIFF
--- a/plugins/bulk-import-backend/api-docs/Models/Organization.md
+++ b/plugins/bulk-import-backend/api-docs/Models/Organization.md
@@ -7,6 +7,7 @@
 | **name** | **String** | organization name | [optional] [default to null] |
 | **description** | **String** | organization description | [optional] [default to null] |
 | **url** | **String** | organization URL | [optional] [default to null] |
+| **totalRepoCount** | **BigDecimal** | total number of repositories in this Organization | [optional] [default to null] |
 | **errors** | **List** |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/plugins/bulk-import-backend/src/openapi.d.ts
+++ b/plugins/bulk-import-backend/src/openapi.d.ts
@@ -130,6 +130,10 @@ declare namespace Components {
              * organization URL
              */
             url?: string;
+            /**
+             * total number of repositories in this Organization
+             */
+            totalRepoCount?: number;
             errors?: string[];
         }
         /**

--- a/plugins/bulk-import-backend/src/openapidocument.ts
+++ b/plugins/bulk-import-backend/src/openapidocument.ts
@@ -551,6 +551,10 @@ const OPENAPI = `
             "type": "string",
             "description": "organization URL"
           },
+          "totalRepoCount": {
+            "type": "number",
+            "description": "total number of repositories in this Organization"
+          },
           "errors": {
             "type": "array",
             "items": {
@@ -791,18 +795,21 @@ const OPENAPI = `
               "id": "unique-org-id-1",
               "name": "pet-org",
               "url": "https://github.com/pet-org",
-              "description": "A great Pet Org"
+              "description": "A great Pet Org",
+              "totalRepoCount": 10
             },
             {
               "id": "unique-org-id-2",
               "name": "org-zero",
-              "url": "https://ghe.example.com/org-zero"
+              "url": "https://ghe.example.com/org-zero",
+              "totalRepoCount": 0
             },
             {
               "id": "unique-id-2",
               "name": "org-one",
               "url": "https://ghe.example.com/org-one",
-              "description": "Org One description"
+              "description": "Org One description",
+              "totalRepoCount": 1234
             }
           ]
         }

--- a/plugins/bulk-import-backend/src/schema/openapi.yaml
+++ b/plugins/bulk-import-backend/src/schema/openapi.yaml
@@ -355,6 +355,9 @@ components:
         url:
           type: string
           description: organization URL
+        totalRepoCount:
+          type: number
+          description: total number of repositories in this Organization
         errors:
           type: array
           items:
@@ -540,13 +543,16 @@ components:
             name: 'pet-org'
             url: 'https://github.com/pet-org'
             description: 'A great Pet Org'
+            totalRepoCount: 10
           - id: 'unique-org-id-2'
             name: 'org-zero'
             url: 'https://ghe.example.com/org-zero'
+            totalRepoCount: 0
           - id: 'unique-id-2'
             name: 'org-one'
             url: 'https://ghe.example.com/org-one'
             description: 'Org One description'
+            totalRepoCount: 1234
 
     orgListErrors:
       summary: Errors when listing organizations

--- a/plugins/bulk-import-backend/src/service/githubApiService.ts
+++ b/plugins/bulk-import-backend/src/service/githubApiService.ts
@@ -154,7 +154,8 @@ export class GithubApiService {
         sort: 'full_name',
         direction: 'asc',
       });
-      resp?.data?.forEach(org => {
+      for (const org of resp?.data ?? []) {
+        const orgData = await octokit.request(org.url);
         const ghOrg: GithubOrganization = {
           id: org.id,
           name: org.login,
@@ -166,9 +167,11 @@ export class GithubApiService {
           members_url: org.members_url,
           public_members_url: org.public_members_url,
           avatar_url: org.avatar_url,
+          public_repos: orgData?.data?.public_repos,
+          total_private_repos: orgData?.data?.total_private_repos,
         };
         orgs.set(org.url, ghOrg);
-      });
+      }
 
       totalCount = await this.computeTotalCountFromGitHubToken(
         async (lastPageNumber: number) =>

--- a/plugins/bulk-import-backend/src/service/handlers/organizations.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/organizations.ts
@@ -58,13 +58,21 @@ export async function findAllOrganizations(
   const orgMap = new Map<string, Components.Schemas.Organization>();
   if (allOrgsAccessible.organizations) {
     for (const org of allOrgsAccessible.organizations) {
-      const errors: string[] = [];
+      let totalRepoCount: number | undefined;
+      if (
+        org.public_repos !== undefined ||
+        org.total_private_repos !== undefined
+      ) {
+        totalRepoCount =
+          (org.public_repos ?? 0) + (org.total_private_repos ?? 0);
+      }
       orgMap.set(org.name, {
         id: `${org.id}`,
         name: org.name,
         description: org.description,
         url: org.url,
-        errors: errors,
+        totalRepoCount,
+        errors: [],
       });
     }
   }

--- a/plugins/bulk-import-backend/src/service/handlers/organizations.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/organizations.ts
@@ -61,10 +61,12 @@ export async function findAllOrganizations(
       let totalRepoCount: number | undefined;
       if (
         org.public_repos !== undefined ||
-        org.total_private_repos !== undefined
+        org.total_private_repos !== undefined ||
+        org.owned_private_repos !== undefined
       ) {
         totalRepoCount =
-          (org.public_repos ?? 0) + (org.total_private_repos ?? 0);
+          (org.public_repos ?? 0) +
+          (org.owned_private_repos ?? org.total_private_repos ?? 0);
       }
       orgMap.set(org.name, {
         id: `${org.id}`,
@@ -83,6 +85,8 @@ export async function findAllOrganizations(
       errors: errorList,
       organizations: Array.from(orgMap.values()),
       totalCount: allOrgsAccessible.totalCount,
+      pagePerIntegration: pageNumber,
+      sizePerIntegration: pageSize,
     },
   };
 }

--- a/plugins/bulk-import-backend/src/service/router.test.ts
+++ b/plugins/bulk-import-backend/src/service/router.test.ts
@@ -28,6 +28,7 @@ import request from 'supertest';
 import { CatalogInfoGenerator } from '../helpers';
 import { GithubOrganizationResponse, GithubRepositoryResponse } from '../types';
 import { GithubApiService } from './githubApiService';
+import { DefaultPageNumber, DefaultPageSize } from './handlers/handlers';
 import { createRouter } from './router';
 
 const mockedAuthorize: jest.MockedFunction<PermissionEvaluator['authorize']> =
@@ -121,11 +122,25 @@ describe('createRouter', () => {
               name: 'my-org-ent-1',
               url: 'https://api.github.com/users/my-org-ent-1',
               description: 'an awesome org',
+              public_repos: 10,
+              total_private_repos: 25,
             },
             {
               id: 266016847,
               name: 'my-org-ent-2',
               url: 'https://api.github.com/users/my-org-ent-2',
+              total_private_repos: 1234,
+            },
+            {
+              id: 987654321,
+              name: 'my-org-ent-3-undefined-repo-count',
+              url: 'https://api.github.com/users/my-org-ent-3-undefined-repo-count',
+            },
+            {
+              id: 123,
+              name: 'my-org-ent-4-only-internal-repos',
+              url: 'https://api.github.com/users/my-org-ent-4-only-internal-repos',
+              owned_private_repos: 7,
             },
           ],
           errors: [],
@@ -135,18 +150,35 @@ describe('createRouter', () => {
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({
         errors: [],
+        pagePerIntegration: DefaultPageNumber,
+        sizePerIntegration: DefaultPageSize,
         organizations: [
           {
             id: '166016847',
             name: 'my-org-ent-1',
             url: 'https://api.github.com/users/my-org-ent-1',
             description: 'an awesome org',
+            totalRepoCount: 35,
             errors: [],
           },
           {
             id: '266016847',
             name: 'my-org-ent-2',
             url: 'https://api.github.com/users/my-org-ent-2',
+            totalRepoCount: 1234,
+            errors: [],
+          },
+          {
+            id: '987654321',
+            name: 'my-org-ent-3-undefined-repo-count',
+            url: 'https://api.github.com/users/my-org-ent-3-undefined-repo-count',
+            errors: [],
+          },
+          {
+            id: '123',
+            name: 'my-org-ent-4-only-internal-repos',
+            url: 'https://api.github.com/users/my-org-ent-4-only-internal-repos',
+            totalRepoCount: 7,
             errors: [],
           },
         ],
@@ -190,6 +222,8 @@ describe('createRouter', () => {
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({
         errors: ['Github App with ID 2 failed spectacularly'],
+        pagePerIntegration: DefaultPageNumber,
+        sizePerIntegration: DefaultPageSize,
         organizations: [
           {
             id: '166016847',

--- a/plugins/bulk-import-backend/src/service/router.ts
+++ b/plugins/bulk-import-backend/src/service/router.ts
@@ -160,8 +160,8 @@ export async function createRouter(
         errors: response.responseBody?.errors,
         organizations: response.responseBody?.organizations,
         totalCount: response.responseBody?.totalCount,
-        pagePerIntegration: q.pagePerIntegration,
-        sizePerIntegration: q.sizePerIntegration,
+        pagePerIntegration: response.responseBody?.pagePerIntegration,
+        sizePerIntegration: response.responseBody?.sizePerIntegration,
       } as Components.Schemas.OrganizationList);
     },
   );

--- a/plugins/bulk-import-backend/src/types.ts
+++ b/plugins/bulk-import-backend/src/types.ts
@@ -48,6 +48,8 @@ export type GithubOrganization = {
   members_url?: string;
   public_members_url?: string;
   avatar_url?: string;
+  public_repos?: number;
+  total_private_repos?: number;
 };
 
 export type GithubRepository = {

--- a/plugins/bulk-import-backend/src/types.ts
+++ b/plugins/bulk-import-backend/src/types.ts
@@ -50,6 +50,10 @@ export type GithubOrganization = {
   avatar_url?: string;
   public_repos?: number;
   total_private_repos?: number;
+  /**
+   * Number of internal repositories, accessible to all members in a GH enterprise
+   */
+  owned_private_repos?: number;
 };
 
 export type GithubRepository = {


### PR DESCRIPTION
**What does this PR do / why we need it:**

This PR adds a new `totalRepoCount` field in each item in the `GET /organizations` response.
This is needed in the related frontend plugin to show the users how many repos have been already selected from all the repos in that org:

![image](https://github.com/user-attachments/assets/8ae1d71f-b389-45a4-9f88-206a756e68fe)

**Which issue(s) this PR fixes:**

Fixes https://issues.redhat.com/browse/RHIDP-3337

**PR acceptance criteria:**

- [x] Unit tests

- [ ] Integration tests

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**

- Add at least one GitHub integration - see https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import-backend#usage
- Start the bulk import backend:

```
yarn workspace @janus-idp/backstage-plugin-bulk-import-backend run start
```

- Example request and response:

```
$ http GET http://localhost:7007/api/bulk-import-backend/organizations

{
  "errors": [],
  "organizations": [
    {
      "id": "REDACTED",
      "name": "ododev",
      "description": "odo - Fast, Iterative and Simplified container-based application development. The main repo for odo is at https://github.com/redhat-developer/odo",
      "url": "https://api.github.com/orgs/ododev",
      "totalRepoCount": 1,
      "errors": []
    },
    {
      "id": "REDACTED",
      "name": "janus-idp",
      "description": "A Red Hat sponsored community for building Internal Development Platforms and Plugins with backstage.io ",
      "url": "https://api.github.com/orgs/janus-idp",
      "totalRepoCount": xxx,
      "errors": []
    },
    {
      "id": "REDACTED",
      "name": "lemra-org",
      "url": "https://api.github.com/orgs/lemra-org",
      "totalRepoCount": 5,
      "errors": []
    },
...
  ],
  "totalCount": 12,
  "pagePerIntegration": 1,
  "sizePerIntegration": 20
}

```

</details>