### PR TITLE
feat(bulk-import): perform more dry-run checks in the `POST /imports` backend endpoint [RHIDP-3339]

### DIFF
--- a/plugins/bulk-import-backend/src/service/githubApiService.ts
+++ b/plugins/bulk-import-backend/src/service/githubApiService.ts
@@ -42,6 +42,8 @@ import {
 } from '../types';
 import { DefaultPageNumber, DefaultPageSize } from './handlers/handlers';
 
+const GITHUB_DEFAULT_API_ENDPOINT = 'https://api.github.com';
+
 export class GithubApiService {
   private readonly logger: Logger;
   private readonly integrations: ScmIntegrations;
@@ -200,16 +202,12 @@ export class GithubApiService {
         resp?.headers?.link,
       );
     } catch (err) {
-      this.logger.error(
-        `Fetching repositories with token from token failed with ${err}`,
-      );
-      const credentialError = this.createCredentialError(
+      this.handleError(
+        'Fetching orgs with token from token',
         credential,
-        err as Error,
+        errors,
+        err,
       );
-      if (credentialError) {
-        errors.set(-1, credentialError);
-      }
     }
     return { totalCount };
   }
@@ -234,15 +232,14 @@ export class GithubApiService {
       });
       const repos = resp?.data?.repositories ?? resp?.data;
       repos?.forEach(repo => {
-        const githubRepo: GithubRepository = {
+        repositories.set(repo.full_name, {
           name: repo.name,
           full_name: repo.full_name,
           url: repo.url,
           html_url: repo.html_url,
           default_branch: repo.default_branch,
           updated_at: repo.updated_at,
-        };
-        repositories.set(githubRepo.full_name, githubRepo);
+        });
       });
       totalCount = resp?.data?.total_count;
     } catch (err) {
@@ -286,15 +283,14 @@ export class GithubApiService {
         direction: 'asc',
       });
       resp?.data?.forEach(repo => {
-        const githubRepo: GithubRepository = {
+        repositories.set(repo.full_name, {
           name: repo.name,
           full_name: repo.full_name,
           url: repo.url,
           html_url: repo.html_url,
           default_branch: repo.default_branch,
           updated_at: repo.updated_at,
-        };
-        repositories.set(githubRepo.full_name, githubRepo);
+        });
       });
 
       totalCount = await this.computeTotalCountFromGitHubToken(
@@ -310,18 +306,30 @@ export class GithubApiService {
         resp?.headers?.link,
       );
     } catch (err) {
-      this.logger.error(
-        `Fetching repositories with token from token failed with ${err}`,
-      );
-      const credentialError = this.createCredentialError(
+      this.handleError(
+        'Fetching repositories with token from token',
         credential,
-        err as Error,
+        errors,
+        err,
       );
-      if (credentialError) {
-        errors.set(-1, credentialError);
-      }
     }
     return { totalCount };
+  }
+
+  private handleError(
+    desc: string,
+    credential: ExtendedGithubCredentials,
+    errors: Map<number, GithubFetchError>,
+    err: any,
+  ) {
+    this.logger.error(`${desc} failed with ${err}`);
+    const credentialError = this.createCredentialError(
+      credential,
+      err as Error,
+    );
+    if (credentialError) {
+      errors.set(-1, credentialError);
+    }
   }
 
   private async addGithubTokenOrgRepositories(
@@ -373,16 +381,12 @@ export class GithubApiService {
         resp?.headers?.link,
       );
     } catch (err) {
-      this.logger.error(
-        `Fetching repositories with token from token failed with ${err}`,
-      );
-      const credentialError = this.createCredentialError(
+      this.handleError(
+        'Fetching org repositories with token from token',
         credential,
-        err as Error,
+        errors,
+        err,
       );
-      if (credentialError) {
-        errors.set(-1, credentialError);
-      }
     }
     return { totalCount };
   }
@@ -445,24 +449,13 @@ export class GithubApiService {
     const errors = new Map<number, GithubFetchError>();
     let repository: GithubRepository | undefined = undefined;
     for (const credential of credentials) {
-      if ('error' in credential) {
-        if (credential.error?.name !== 'NotFoundError') {
-          this.logger.error(
-            `Obtaining the Access Token Github App with appId: ${credential.appId} failed with ${credential.error}`,
-          );
-          const credentialError = this.createCredentialError(credential);
-          if (credentialError) {
-            errors.set(credential.appId, credentialError);
-          }
-        }
+      const octokit = this.buildOcto(
+        { credential, errors, owner: gitUrl.owner },
+        ghConfig.apiBaseUrl,
+      );
+      if (!octokit) {
         continue;
       }
-
-      const octokit = new Octokit({
-        baseUrl: ghConfig.apiBaseUrl ?? 'https://api.github.com',
-        auth: credential.token,
-      });
-
       const resp = await octokit.rest.repos.get({
         owner: gitUrl.owner,
         repo: gitUrl.name,
@@ -504,24 +497,13 @@ export class GithubApiService {
         `Got ${credentials.length} credential(s) for ${ghConfig.host}`,
       );
       for (const credential of credentials) {
-        if ('error' in credential) {
-          if (credential.error?.name !== 'NotFoundError') {
-            this.logger.error(
-              `Obtaining the Access Token Github App with appId: ${credential.appId} failed with ${credential.error}`,
-            );
-            const credentialError = this.createCredentialError(credential);
-            if (credentialError) {
-              errors.set(credential.appId, credentialError);
-            }
-          }
+        const octokit = this.buildOcto(
+          { credential, errors },
+          ghConfig.apiBaseUrl,
+        );
+        if (!octokit) {
           continue;
         }
-
-        const octokit = new Octokit({
-          baseUrl: ghConfig.apiBaseUrl ?? 'https://api.github.com',
-          auth: credential.token,
-        });
-
         let resp: { totalCount?: number } = {};
         if (isGithubAppCredential(credential)) {
           resp = await this.addGithubAppOrgs(
@@ -573,24 +555,13 @@ export class GithubApiService {
         `Got ${credentials.length} credential(s) for ${ghConfig.host}`,
       );
       for (const credential of credentials) {
-        if ('error' in credential) {
-          if (credential.error?.name !== 'NotFoundError') {
-            this.logger.error(
-              `Obtaining the Access Token Github App with appId: ${credential.appId} failed with ${credential.error}`,
-            );
-            const credentialError = this.createCredentialError(credential);
-            if (credentialError) {
-              errors.set(credential.appId, credentialError);
-            }
-          }
+        const octokit = this.buildOcto(
+          { credential, errors },
+          ghConfig.apiBaseUrl,
+        );
+        if (!octokit) {
           continue;
         }
-
-        const octokit = new Octokit({
-          baseUrl: ghConfig.apiBaseUrl ?? 'https://api.github.com',
-          auth: credential.token,
-        });
-
         let resp: { totalCount?: number };
         if (isGithubAppCredential(credential)) {
           if (credential.accountLogin !== orgName) {
@@ -616,7 +587,7 @@ export class GithubApiService {
           );
         }
         this.logger.debug(
-          `Got ${resp.totalCount} repo(s) for ${ghConfig.host}`,
+          `Got ${resp.totalCount} org repo(s) for ${ghConfig.host}`,
         );
         if (resp.totalCount) {
           totalCount += resp.totalCount;
@@ -651,24 +622,13 @@ export class GithubApiService {
         `Got ${credentials.length} credential(s) for ${ghConfig.host}`,
       );
       for (const credential of credentials) {
-        if ('error' in credential) {
-          if (credential.error?.name !== 'NotFoundError') {
-            this.logger.error(
-              `Obtaining the Access Token Github App with appId: ${credential.appId} failed with ${credential.error}`,
-            );
-            const credentialError = this.createCredentialError(credential);
-            if (credentialError) {
-              errors.set(credential.appId, credentialError);
-            }
-          }
+        const octokit = this.buildOcto(
+          { credential, errors },
+          ghConfig.apiBaseUrl,
+        );
+        if (!octokit) {
           continue;
         }
-
-        const octokit = new Octokit({
-          baseUrl: ghConfig.apiBaseUrl ?? 'https://api.github.com',
-          auth: credential.token,
-        });
-
         let resp: { totalCount?: number };
         if (isGithubAppCredential(credential)) {
           resp = await this.addGithubAppRepositories(
@@ -767,31 +727,10 @@ export class GithubApiService {
 
     const branchName = getBranchName(this.config);
     for (const credential of credentials) {
-      if ('error' in credential) {
-        if (credential.error?.name !== 'NotFoundError') {
-          this.logger.error(
-            `Obtaining the Access Token Github App with appId: ${credential.appId} failed with ${credential.error}`,
-          );
-          const credentialError = this.createCredentialError(credential);
-          if (credentialError) {
-            logger.debug(`${credential.appId}: ${credentialError}`);
-          }
-        }
+      const octo = this.buildOcto({ credential, owner }, ghConfig.apiBaseUrl);
+      if (!octo) {
         continue;
       }
-
-      if (
-        isGithubAppCredential(credential) &&
-        credential.accountLogin !== owner
-      ) {
-        continue;
-      }
-
-      const octo = new Octokit({
-        baseUrl: ghConfig.apiBaseUrl ?? 'https://api.github.com',
-        auth: credential.token,
-      });
-
       try {
         return await this.findOpenPRForBranch(
           logger,
@@ -923,30 +862,10 @@ export class GithubApiService {
     const fileName = getCatalogFilename(this.config);
     const errors: any[] = [];
     for (const credential of credentials) {
-      if ('error' in credential) {
-        if (credential.error?.name !== 'NotFoundError') {
-          this.logger.error(
-            `Obtaining the Access Token Github App with appId: ${credential.appId} failed with ${credential.error}`,
-          );
-          const credentialError = this.createCredentialError(credential);
-          if (credentialError) {
-            logger.debug(`${credential.appId}: ${credentialError}`);
-          }
-        }
+      const octo = this.buildOcto({ credential, owner }, ghConfig.apiBaseUrl);
+      if (!octo) {
         continue;
       }
-
-      if (
-        isGithubAppCredential(credential) &&
-        credential.accountLogin !== owner
-      ) {
-        continue;
-      }
-
-      const octo = new Octokit({
-        baseUrl: ghConfig.apiBaseUrl ?? 'https://api.github.com',
-        auth: credential.token,
-      });
       try {
         // Check if there is already a catalogInfo in the default branch
         const catalogInfoFileExists = await this.fileExistsInDefaultBranch(
@@ -1128,23 +1047,13 @@ export class GithubApiService {
       await this.extractConfigAndCreds(input);
 
     for (const credential of credentials) {
-      if ('error' in credential) {
-        if (credential.error?.name !== 'NotFoundError') {
-          this.logger.error(
-            `Obtaining the Access Token Github App with appId: ${credential.appId} failed with ${credential.error}`,
-          );
-          const credentialError = this.createCredentialError(credential);
-          if (credentialError) {
-            logger.debug(`${credential.appId}: ${credentialError}`);
-          }
-        }
+      const octo = this.buildOcto(
+        { credential, owner: gitUrl.owner },
+        ghConfig.apiBaseUrl,
+      );
+      if (!octo) {
         continue;
       }
-      const octo = new Octokit({
-        baseUrl: ghConfig.apiBaseUrl ?? 'https://api.github.com',
-        auth: credential.token,
-      });
-
       const exists = await this.fileExistsInDefaultBranch(
         logger,
         octo,
@@ -1208,28 +1117,10 @@ export class GithubApiService {
 
     const branchName = getBranchName(this.config);
     for (const credential of credentials) {
-      if ('error' in credential) {
-        if (credential.error?.name !== 'NotFoundError') {
-          this.logger.error(
-            `Obtaining the Access Token Github App with appId: ${credential.appId} failed with ${credential.error}`,
-          );
-          const credentialError = this.createCredentialError(credential);
-          if (credentialError) {
-            logger.debug(`${credential.appId}: ${credentialError}`);
-          }
-        }
+      const octo = this.buildOcto({ credential, owner }, ghConfig.apiBaseUrl);
+      if (!octo) {
         continue;
       }
-      if (
-        isGithubAppCredential(credential) &&
-        credential.accountLogin !== owner
-      ) {
-        continue;
-      }
-      const octo = new Octokit({
-        baseUrl: ghConfig.apiBaseUrl ?? 'https://api.github.com',
-        auth: credential.token,
-      });
       try {
         const existingPrForBranch = await this.findOpenPRForBranch(
           logger,
@@ -1254,6 +1145,42 @@ export class GithubApiService {
     }
   }
 
+  private buildOcto(
+    input: {
+      credential: ExtendedGithubCredentials;
+      owner?: string;
+      errors?: Map<number, GithubFetchError>;
+    },
+    apiBaseUrl: string = GITHUB_DEFAULT_API_ENDPOINT,
+  ): Octokit | undefined {
+    if ('error' in input.credential) {
+      if (input.credential.error?.name !== 'NotFoundError') {
+        this.logger.error(
+          `Obtaining the Access Token Github App with appId: ${input.credential.appId} failed with ${input.credential.error}`,
+        );
+        const credentialError = this.createCredentialError(input.credential);
+        if (credentialError) {
+          this.logger.debug(`${input.credential.appId}: ${credentialError}`);
+          if (input.errors) {
+            input.errors.set(input.credential.appId, credentialError);
+          }
+        }
+      }
+      return undefined;
+    }
+    if (
+      isGithubAppCredential(input.credential) &&
+      input.owner &&
+      input.credential.accountLogin !== input.owner
+    ) {
+      return undefined;
+    }
+    return new Octokit({
+      baseUrl: apiBaseUrl,
+      auth: input.credential.token,
+    });
+  }
+
   private async closePRWithComment(
     octo: Octokit,
     owner: string,
@@ -1275,34 +1202,17 @@ export class GithubApiService {
     });
   }
 
-  async isRepoEmpty(
-    logger: Logger,
-    input: {
-      repoUrl: string;
-    },
-  ) {
+  async isRepoEmpty(input: { repoUrl: string }) {
     const { ghConfig, credentials, gitUrl } =
       await this.extractConfigAndCreds(input);
     const owner = gitUrl.organization;
     const repo = gitUrl.name;
 
     for (const credential of credentials) {
-      if ('error' in credential) {
-        if (credential.error?.name !== 'NotFoundError') {
-          this.logger.error(
-            `Obtaining the Access Token Github App with appId: ${credential.appId} failed with ${credential.error}`,
-          );
-          const credentialError = this.createCredentialError(credential);
-          if (credentialError) {
-            logger.debug(`${credential.appId}: ${credentialError}`);
-          }
-        }
+      const octo = this.buildOcto({ credential, owner }, ghConfig.apiBaseUrl);
+      if (!octo) {
         continue;
       }
-      const octo = new Octokit({
-        baseUrl: ghConfig.apiBaseUrl ?? 'https://api.github.com',
-        auth: credential.token,
-      });
       const resp = await octo.rest.repos.listContributors({
         owner,
         repo,

--- a/plugins/bulk-import-backend/src/service/githubApiService.ts
+++ b/plugins/bulk-import-backend/src/service/githubApiService.ts
@@ -1084,7 +1084,7 @@ export class GithubApiService {
         return false;
       }
       logger.debug(
-        `Unable to determine if catalog-info already exists in repo ${repo}: ${error}`,
+        `Unable to determine if a file named ${fileName} already exists in repo ${repo}: ${error}`,
       );
       return undefined;
     }
@@ -1097,10 +1097,36 @@ export class GithubApiService {
       defaultBranch?: string;
     },
   ) {
+    return this.hasFileInRepo(logger, {
+      ...input,
+      fileName: getCatalogFilename(this.config),
+    });
+  }
+
+  async doesCodeOwnersAlreadyExistInRepo(
+    logger: Logger,
+    input: {
+      repoUrl: string;
+      defaultBranch?: string;
+    },
+  ) {
+    return this.hasFileInRepo(logger, {
+      ...input,
+      fileName: '.github/CODEOWNERS',
+    });
+  }
+
+  async hasFileInRepo(
+    logger: Logger,
+    input: {
+      repoUrl: string;
+      defaultBranch?: string;
+      fileName: string;
+    },
+  ) {
     const { ghConfig, credentials, gitUrl } =
       await this.extractConfigAndCreds(input);
 
-    const fileName = getCatalogFilename(this.config);
     for (const credential of credentials) {
       if ('error' in credential) {
         if (credential.error?.name !== 'NotFoundError') {
@@ -1124,7 +1150,7 @@ export class GithubApiService {
         octo,
         gitUrl.owner,
         gitUrl.name,
-        fileName,
+        input.fileName,
         input.defaultBranch,
       );
       if (exists === undefined) {
@@ -1133,7 +1159,7 @@ export class GithubApiService {
       return exists;
     }
     throw new Error(
-      `Could not determine if ${input.repoUrl} already had a catalog-info file`,
+      `Could not determine if repo at ${input.repoUrl} already has a file named ${input.fileName} in its default branch (${input.defaultBranch})`,
     );
   }
 

--- a/plugins/bulk-import-backend/src/service/githubApiService.ts
+++ b/plugins/bulk-import-backend/src/service/githubApiService.ts
@@ -1097,19 +1097,8 @@ export class GithubApiService {
       defaultBranch?: string;
     },
   ) {
-    const ghConfig = this.integrations.github.byUrl(input.repoUrl)?.config;
-    if (!ghConfig) {
-      throw new Error(`Could not find GH integration from ${input.repoUrl}`);
-    }
-
-    const credentials = await this.githubCredentialsProvider.getAllCredentials({
-      host: ghConfig.host,
-    });
-    if (credentials.length === 0) {
-      throw new Error(`No credentials for GH integration`);
-    }
-
-    const gitUrl = gitUrlParse(input.repoUrl);
+    const { ghConfig, credentials, gitUrl } =
+      await this.extractConfigAndCreds(input);
 
     const fileName = getCatalogFilename(this.config);
     for (const credential of credentials) {
@@ -1146,6 +1135,26 @@ export class GithubApiService {
     throw new Error(
       `Could not determine if ${input.repoUrl} already had a catalog-info file`,
     );
+  }
+
+  private async extractConfigAndCreds(input: {
+    repoUrl: string;
+    defaultBranch?: string;
+  }) {
+    const ghConfig = this.integrations.github.byUrl(input.repoUrl)?.config;
+    if (!ghConfig) {
+      throw new Error(`Could not find GH integration from ${input.repoUrl}`);
+    }
+
+    const credentials = await this.githubCredentialsProvider.getAllCredentials({
+      host: ghConfig.host,
+    });
+    if (credentials.length === 0) {
+      throw new Error(`No credentials for GH integration`);
+    }
+
+    const gitUrl = gitUrlParse(input.repoUrl);
+    return { ghConfig, credentials, gitUrl };
   }
 
   async closePR(
@@ -1246,19 +1255,8 @@ export class GithubApiService {
       repoUrl: string;
     },
   ) {
-    const ghConfig = this.integrations.github.byUrl(input.repoUrl)?.config;
-    if (!ghConfig) {
-      throw new Error(`Could not find GH integration from ${input.repoUrl}`);
-    }
-
-    const credentials = await this.githubCredentialsProvider.getAllCredentials({
-      host: ghConfig.host,
-    });
-    if (credentials.length === 0) {
-      throw new Error(`No credentials for GH integration`);
-    }
-
-    const gitUrl = gitUrlParse(input.repoUrl);
+    const { ghConfig, credentials, gitUrl } =
+      await this.extractConfigAndCreds(input);
     const owner = gitUrl.organization;
     const repo = gitUrl.name;
 

--- a/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
@@ -388,7 +388,7 @@ async function performDryRunChecks(
     dryRunStatuses?: CreateImportDryRunStatus[];
     errors?: string[];
   }> => {
-    const empty = await githubApiService.isRepoEmpty(logger, {
+    const empty = await githubApiService.isRepoEmpty({
       repoUrl: req.repository.url,
     });
     if (empty) {
@@ -454,8 +454,10 @@ async function performDryRunChecks(
     }
   });
 
+  dryRunStatuses.sort((a, b) => a.localeCompare(b));
+
   return {
-    dryRunStatuses: dryRunStatuses.sort(),
+    dryRunStatuses,
     errors,
   };
 }

--- a/plugins/bulk-import-backend/src/service/router.test.ts
+++ b/plugins/bulk-import-backend/src/service/router.test.ts
@@ -890,6 +890,20 @@ describe('createRouter', () => {
               );
             },
           );
+        jest
+          .spyOn(GithubApiService.prototype, 'doesCodeOwnersAlreadyExistInRepo')
+          .mockImplementation(
+            async (
+              _logger: Logger,
+              input: {
+                repoUrl: string;
+              },
+            ) => {
+              return (
+                input.repoUrl !== 'https://github.com/my-org-ent-2/my-repo-c'
+              );
+            },
+          );
         const response = await request(app)
           .post('/imports')
           .query({ dryRun: true })
@@ -939,7 +953,7 @@ describe('createRouter', () => {
             },
           },
           {
-            errors: ['REPO_EMPTY'],
+            errors: ['CODEOWNERS_FILE_NOT_FOUND_IN_REPO', 'REPO_EMPTY'],
             catalogEntityName: 'my-entity-c',
             repository: {
               url: 'https://github.com/my-org-ent-2/my-repo-c',

--- a/plugins/bulk-import-backend/src/service/router.test.ts
+++ b/plugins/bulk-import-backend/src/service/router.test.ts
@@ -24,6 +24,7 @@ import {
 
 import express from 'express';
 import request from 'supertest';
+import { Logger } from 'winston';
 
 import { CatalogInfoGenerator } from '../helpers';
 import { GithubOrganizationResponse, GithubRepositoryResponse } from '../types';
@@ -830,58 +831,71 @@ describe('createRouter', () => {
     });
 
     describe('dry run', () => {
-      it('error if there are missing catalogEntityName in any of the request body items', async () => {
-        mockedPermissionQuery.mockImplementation(allowAll);
-        mockCatalogClient.queryEntities = jest
-          .fn()
-          .mockResolvedValue({ items: [] });
-        const response = await request(app)
-          .post('/imports')
-          .query({ dryRun: true })
-          .send([
-            {
-              repository: {
-                url: 'https://github.com/my-org-ent-1/my-repo-a',
-                defaultBranch: 'dev',
-              },
-            },
-            {
-              catalogEntityName: 'my-entity-b',
-              repository: {
-                url: 'https://github.com/my-org-ent-1/my-repo-b',
-                defaultBranch: 'dev',
-              },
-            },
-          ]);
-        expect(response.status).toEqual(400);
-        expect(response.body.errors as string[]).toContain(
-          "ERROR: 'catalogEntityName' field must be specified in request body for https://github.com/my-org-ent-1/my-repo-a for dry-run operations",
-        );
-      });
-
       it('return dry-run results in errors array for each item in request body', async () => {
         mockedPermissionQuery.mockImplementation(allowAll);
-        mockCatalogClient.queryEntities = jest
-          .fn()
-          .mockResolvedValueOnce({ items: [] })
-          .mockResolvedValueOnce({
-            totalItems: 1,
-            items: [
-              {
-                apiVersion: 'backstage.io/v1alpha1',
-                kind: 'Component',
-                component: {
-                  name: 'my-entity-b',
-                },
+        mockCatalogClient.queryEntities = jest.fn().mockImplementation(
+          async (req: {
+            filter: {
+              'metadata.name': string;
+            };
+          }) => {
+            const n = req.filter['metadata.name'];
+            switch (n) {
+              case 'my-entity-b':
+                return {
+                  totalItems: 1,
+                  items: [
+                    {
+                      apiVersion: 'backstage.io/v1alpha1',
+                      kind: 'Component',
+                      component: {
+                        name: 'my-entity-b',
+                      },
+                    },
+                  ],
+                };
+              default:
+                return { items: [] };
+            }
+          },
+        );
+        jest
+          .spyOn(
+            GithubApiService.prototype,
+            'doesCatalogInfoAlreadyExistInRepo',
+          )
+          .mockImplementation(
+            async (
+              _logger: Logger,
+              input: {
+                repoUrl: string;
               },
-            ],
-          });
+            ) => {
+              return (
+                input.repoUrl === 'https://github.com/my-org-ent-2/my-repo-b'
+              );
+            },
+          );
+        jest
+          .spyOn(GithubApiService.prototype, 'isRepoEmpty')
+          .mockImplementation(
+            async (
+              _logger: Logger,
+              input: {
+                repoUrl: string;
+              },
+            ) => {
+              return (
+                input.repoUrl === 'https://github.com/my-org-ent-2/my-repo-c'
+              );
+            },
+          );
         const response = await request(app)
           .post('/imports')
           .query({ dryRun: true })
           .send([
             {
-              catalogEntityName: 'my-entity-a',
+              // catalogEntityName not specified => catalog entity checks will be skipped
               repository: {
                 url: 'https://github.com/my-org-ent-1/my-repo-a',
                 defaultBranch: 'dev',
@@ -894,12 +908,18 @@ describe('createRouter', () => {
                 defaultBranch: 'main',
               },
             },
+            {
+              catalogEntityName: 'my-entity-c',
+              repository: {
+                url: 'https://github.com/my-org-ent-2/my-repo-c',
+                defaultBranch: 'trunk',
+              },
+            },
           ]);
         expect(response.status).toEqual(202);
         expect(response.body).toEqual([
           {
             errors: [],
-            catalogEntityName: 'my-entity-a',
             repository: {
               url: 'https://github.com/my-org-ent-1/my-repo-a',
               name: 'my-repo-a',
@@ -907,11 +927,23 @@ describe('createRouter', () => {
             },
           },
           {
-            errors: ['CONFLICT'],
+            errors: [
+              'CATALOG_ENTITY_CONFLICT',
+              'CATALOG_INFO_FILE_EXISTS_IN_REPO',
+            ],
             catalogEntityName: 'my-entity-b',
             repository: {
               url: 'https://github.com/my-org-ent-2/my-repo-b',
               name: 'my-repo-b',
+              organization: 'my-org-ent-2',
+            },
+          },
+          {
+            errors: ['REPO_EMPTY'],
+            catalogEntityName: 'my-entity-c',
+            repository: {
+              url: 'https://github.com/my-org-ent-2/my-repo-c',
+              name: 'my-repo-c',
               organization: 'my-org-ent-2',
             },
           },


### PR DESCRIPTION
**What does this PR do / why we need it:**

The `POST /imports` endpoint supports a `dryRun` parameter, which currently only checks if the specified entities do exist in the catalog. It won't attempt to create any PRs in the specified repos.
This PR adds additional checks:
- if the repo already has a catalog-info YAML file in its default branch; it adds a new possible error string: `CATALOG_INFO_FILE_EXISTS_IN_REPO`
- if the repo is empty; it adds a new possible error string: `REPO_EMPTY`
- if the repo does not have a `.github/CODEOWNERS` file, it adds a new possible error string: `CODEOWNERS_FILE_NOT_FOUND_IN_REPO`

This is needed to improve the related frontend plugin.

**BREAKING CHANGES**:
- The error when the specified entity already exists in the catalog has been renamed from `CONFLICT` to `CATALOG_ENTITY_CONFLICT`
- Previous, when the `dryRun` query param was set to `true`, all items in the request body needed to have a non-blank `catalogEntityName` field, otherwise a `400 Bad Request` was returned. This field is no longer mandatory. If it is missing, the catalog entity check will be skipped, but the new checks will still be performed. So the API now always returns a `202` status with the checks errors.

**Which issue(s) this PR fixes:**

Fixes https://issues.redhat.com/browse/RHIDP-3339

**PR acceptance criteria:**

- [x] Unit tests

- [ ] Integration tests

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**

- Add at least one GitHub integration - see https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import-backend#usage
- Start the bulk import backend:

```
yarn workspace @janus-idp/backstage-plugin-bulk-import-backend run start
```

- Example response:

```json

[
  {
    "errors": [],
    "catalogEntityName": "animated-happiness",
    "repository": {
      "url": "https://github.com/lemra-org-ent-2/animated-happiness",
      "name": "animated-happiness",
      "organization": "lemra-org-ent-2"
    }
  },
  {
    "errors": [
      "CATALOG_ENTITY_CONFLICT",
      "CATALOG_INFO_FILE_EXISTS_IN_REPO"
    ],
    "catalogEntityName": "java-quarkus-starter",
    "repository": {
      "url": "https://github.com/lemra-org-ent-1/java-quarkus-starter",
      "name": "java-quarkus-starter",
      "organization": "lemra-org-ent-1"
    }
  },
  {
    "errors": [
      "REPO_EMPTY",
      "CODEOWNERS_FILE_NOT_FOUND_IN_REPO",
    ],
    "catalogEntityName": "reimagined-octo-spork-empty",
    "repository": {
      "url": "https://github.com/lemra-org/reimagined-octo-spork-empty",
      "name": "reimagined-octo-spork-empty",
      "organization": "lemra-org"
    }
  }
]

```