### PR TITLE
chore(release): remove private from manually released argocd-common

### DIFF
--- a/plugins/argocd-common/package.json
+++ b/plugins/argocd-common/package.json
@@ -4,7 +4,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",
@@ -25,7 +24,7 @@
     "build": "backstage-cli package build",
     "clean": "backstage-cli package clean",
     "lint": "backstage-cli package lint",
-    "postpack": "backstage-cli packag e postpack",
+    "postpack": "backstage-cli package postpack",
     "prepack": "backstage-cli package prepack",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "tsc": "tsc"


### PR DESCRIPTION
## Description

Remove the private field now that the argocd-common plugin has been released