### PR TITLE
fix(argocd): fix argocd naming

### DIFF
--- a/plugins/argocd-common/README.md
+++ b/plugins/argocd-common/README.md
@@ -4,7 +4,7 @@ Welcome to the argocd-common plugin!
 
 This plugin contains common utilities for the argocd plugin.
 
-# Argocd plugin for Backstage
+# Argo CD plugin for Backstage
 
 The Argocd plugin displays the information about your argocd applications in your Backstage application.
 

--- a/plugins/argocd/package.json
+++ b/plugins/argocd/package.json
@@ -39,7 +39,7 @@
     "@backstage/core-plugin-api": "^1.9.3",
     "@backstage/plugin-catalog-react": "^1.12.2",
     "@backstage/plugin-permission-react": "^0.4.24",
-    "@janus-idp/backstage-plugin-argocd-common": "1.0.0",
+    "@janus-idp/backstage-plugin-argocd-common": "0.1.0",
     "@backstage/theme": "^0.5.6",
     "@kubernetes/client-node": "^0.20.0",
     "@material-ui/core": "^4.9.13",


### PR DESCRIPTION
## Description

Fixes two issues that we are facing with the argocd plugin.

First, the argocd-common plugin has not had a `1.0.0` release, setting the release back to `0.1.0`
Second, the argocd plugin keeps updating to the argocd-common version `1.0.0`, so included is a minor nit fix to get the argocd-common plugin to update