### PR TITLE
fix: argocd dependency package version

### DIFF
--- a/plugins/argocd/package.json
+++ b/plugins/argocd/package.json
@@ -39,7 +39,7 @@
     "@backstage/core-plugin-api": "^1.9.3",
     "@backstage/plugin-catalog-react": "^1.12.2",
     "@backstage/plugin-permission-react": "^0.4.24",
-    "@janus-idp/backstage-plugin-argocd-common": "1.0.0",
+    "@janus-idp/backstage-plugin-argocd-common": "0.1.0",
     "@backstage/theme": "^0.5.6",
     "@kubernetes/client-node": "^0.20.0",
     "@material-ui/core": "^4.9.13",


### PR DESCRIPTION
The release bot created [commit](https://github.com/janus-idp/backstage-plugins/commit/6405cf54a1ad2a5875964ecb4217dbd45bd5552c) overwrote the "@janus-idp/backstage-plugin-argocd-common" version updated in #1990  and it causes CI check failures.