### PR TITLE
fix(deps): downgrade shared-react in acr

### DIFF
--- a/plugins/acr/package.json
+++ b/plugins/acr/package.json
@@ -37,7 +37,7 @@
     "@backstage/core-plugin-api": "^1.9.3",
     "@backstage/plugin-catalog-react": "^1.12.2",
     "@backstage/theme": "^0.5.6",
-    "@janus-idp/shared-react": "2.10.0",
+    "@janus-idp/shared-react": "2.9.0",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.45",


### PR DESCRIPTION
## Description

Release process failed mid way through causing the acr plugin to get an update to the shared-react dependency but the shared-react plugin did not get released. Downgrades the dependency in an attempt to get it to re-release