### PR TITLE
chore(metadata): bump tekton-common to 0.1.1...

### DIFF
--- a/plugins/tekton-common/package.json
+++ b/plugins/tekton-common/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@janus-idp/backstage-plugin-tekton-common",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",
@@ -15,6 +14,7 @@
     "role": "common-library",
     "supported-versions": "1.28.4",
     "pluginId": "tekton",
+    "pluginPackage": "@janus-idp/backstage-plugin-tekton-common",
     "pluginPackages": [
       "@janus-idp/backstage-plugin-tekton",
       "@janus-idp/backstage-plugin-tekton-common"
@@ -41,7 +41,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/janus-idp/backstage-plugins",
+    "url": "git+https://github.com/janus-idp/backstage-plugins.git",
     "directory": "plugins/tekton-common"
   },
   "keywords": [
@@ -50,10 +50,10 @@
     "backstage",
     "plugin"
   ],
-  "author": "Red Hat",
   "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
   "maintainers": [
-    "janus-idp/rhtap"
-  ]
+    "@janus-idp/rhtap"
+  ],
+  "author": "Red Hat"
 }


### PR DESCRIPTION
### What does this PR do?

chore(metadata): bump tekton-common to 0.1.1 after manual release; add missing metadata and mark non-private

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.