### PR TITLE
chore(orchestrator): bump default sonata image version to 2024-04-17

### DIFF
--- a/plugins/orchestrator-common/src/constants.ts
+++ b/plugins/orchestrator-common/src/constants.ts
@@ -1,6 +1,6 @@
 // Default values for the orchestrator plugin configuration
 export const DEFAULT_SONATAFLOW_CONTAINER_IMAGE =
-  'quay.io/kiegroup/kogito-swf-devmode-nightly:main-2024-04-03';
+  'quay.io/kiegroup/kogito-swf-devmode-nightly:main-2024-04-17';
 export const DEFAULT_SONATAFLOW_PERSISTENCE_PATH = '/home/kogito/persistence';
 export const DEFAULT_SONATAFLOW_BASE_URL = 'http://localhost';
 


### PR DESCRIPTION
use latest sonataflow nightly container image available in quay.io.