### PR TITLE
fix(aap): revert downgrade of janus-cli

### DIFF
--- a/plugins/aap-backend/package.json
+++ b/plugins/aap-backend/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.11",
-    "@janus-idp/cli": "1.0.0",
+    "@janus-idp/cli": "1.13.0",
     "@types/supertest": "2.0.16",
     "msw": "1.3.3",
     "supertest": "6.3.4"


### PR DESCRIPTION
## Description

Reverts the downgrade for the `janus-cli` dependency in the AAP plugin.