### PR TITLE
chore(release): fix downgrade of janus-cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/cli",
   "description": "CLI for developing Backstage plugins and apps",
-  "version": "1.0.0",
+  "version": "1.13.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Description

MSR doing MSR things, reverts the "upgrade" from `1.0.0` back to `1.13.0` that MSR attempted.