### PR TITLE
fix(bulk-import): set initial value of annotations, labels and specs

### DIFF
--- a/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequest.tsx
+++ b/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequest.tsx
@@ -28,7 +28,10 @@ import {
   PullRequestPreview,
   PullRequestPreviewData,
 } from '../../types';
-import { getYamlKeyValuePairs } from '../../utils/repository-utils';
+import {
+  convertKeyValuePairsToString,
+  getYamlKeyValuePairs,
+} from '../../utils/repository-utils';
 import KeyValueTextField from './KeyValueTextField';
 
 const useDrawerContentStyles = makeStyles(theme => ({
@@ -234,14 +237,30 @@ export const PreviewPullRequest = ({
     {
       label: 'Annotations',
       name: 'prAnnotations',
-      value: pullRequest?.[repoName]?.prAnnotations,
+      value:
+        pullRequest?.[repoName]?.prAnnotations ??
+        convertKeyValuePairsToString(
+          pullRequest?.[repoName]?.yaml?.metadata?.annotations,
+        ),
     },
     {
       label: 'Labels',
       name: 'prLabels',
-      value: pullRequest?.[repoName]?.prLabels,
+      value:
+        pullRequest?.[repoName]?.prLabels ??
+        convertKeyValuePairsToString(
+          pullRequest?.[repoName]?.yaml?.metadata?.labels,
+        ),
     },
-    { label: 'Spec', name: 'prSpec', value: pullRequest?.[repoName]?.prSpec },
+    {
+      label: 'Spec',
+      name: 'prSpec',
+      value:
+        pullRequest?.[repoName]?.prSpec ??
+        convertKeyValuePairsToString(
+          pullRequest?.[repoName]?.yaml?.spec as Record<string, string>,
+        ),
+    },
   ];
 
   return (

--- a/plugins/bulk-import/src/utils/repository-utils.tsx
+++ b/plugins/bulk-import/src/utils/repository-utils.tsx
@@ -107,6 +107,16 @@ export const getYamlKeyValuePairs = (
   return keyValuePairs;
 };
 
+export const convertKeyValuePairsToString = (
+  keyValuePairs?: Record<string, string>,
+): string => {
+  return keyValuePairs
+    ? Object.entries(keyValuePairs)
+        .map(([key, value]) => `${key.trim()}: ${value.trim()}`)
+        .join('; ')
+    : '';
+};
+
 export const createData = (
   id: number,
   name: string,


### PR DESCRIPTION
Found this bug when testing #2013 .
Fixes: [RHIDP-3553](https://issues.redhat.com/browse/RHIDP-3533)
 Annotations, Labels, and Spec text field will have initial values as shown in Preview entities section.

Screen recording:

https://github.com/user-attachments/assets/f09c68dc-06bd-41ba-9db9-e7dae94a62af

