### PR TITLE
chore(release): fix downgrade of lightspeed

### DIFF
--- a/plugins/lightspeed/package.json
+++ b/plugins/lightspeed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-lightspeed",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

Some more of MSR doing big things, reverts another "upgrade" attempt from `1.0.0` to `1.0.1` of the lightspeed plugin.