### PR TITLE
feat(orchestrator): use v2 endpoint for abortWorkflow

### DIFF
--- a/plugins/orchestrator-backend/src/service/api/v1.ts
+++ b/plugins/orchestrator-backend/src/service/api/v1.ts
@@ -39,13 +39,6 @@ export class V1 {
     return source;
   }
 
-  public async abortWorkflow(instanceId: string): Promise<void> {
-    await this.orchestratorService.abortWorkflowInstance({
-      instanceId,
-      cacheHandler: 'throw',
-    });
-  }
-
   public async retriggerInstanceInError(
     instanceId: string,
     inputData: ProcessInstanceVariables,

--- a/plugins/orchestrator-backend/src/service/api/v2.ts
+++ b/plugins/orchestrator-backend/src/service/api/v2.ts
@@ -188,7 +188,10 @@ export class V2 {
   }
 
   public async abortWorkflow(instanceId: string): Promise<string> {
-    await this.v1.abortWorkflow(instanceId);
+    await this.orchestratorService.abortWorkflowInstance({
+      instanceId,
+      cacheHandler: 'throw',
+    });
     return `Workflow instance ${instanceId} successfully aborted`;
   }
 

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -900,45 +900,6 @@ function setupInternalRoutes(
     },
   );
 
-  // v1
-  router.delete('/instances/:instanceId/abort', async (req, res) => {
-    const {
-      params: { instanceId },
-    } = req;
-    const endpointName = 'InstancesInstanceIdAbort';
-    const endpoint = `/v1/instances/${instanceId}/abort`;
-
-    auditLogger.auditLog({
-      eventName: endpointName,
-      stage: 'start',
-      status: 'succeeded',
-      level: 'debug',
-      request: req,
-      message: `Received request to '${endpoint}' endpoint`,
-    });
-
-    const decision = await authorize(
-      req,
-      orchestratorWorkflowInstanceAbortPermission,
-      permissions,
-      httpAuth,
-    );
-    if (decision.result === AuthorizeResult.DENY) {
-      manageDenyAuthorization(endpointName, endpoint, req);
-    }
-
-    try {
-      await routerApi.v1.abortWorkflow(instanceId);
-      res.status(200).send();
-    } catch (error) {
-      auditLogRequestError(error, endpointName, endpoint, req);
-      res
-        .status(500)
-        .contentType('plain/text')
-        .send((error as Error)?.message || INTERNAL_SERVER_ERROR_MESSAGE);
-    }
-  });
-
   // v2
   routerApi.openApiBackend.register(
     'abortWorkflow',

--- a/plugins/orchestrator/src/api/MockOrchestratorClient.ts
+++ b/plugins/orchestrator/src/api/MockOrchestratorClient.ts
@@ -148,7 +148,7 @@ export class MockOrchestratorClient implements OrchestratorApi {
     return Promise.resolve(this._mockData.getWorkflowOverviewResponse);
   }
 
-  abortWorkflowInstance(_instanceId: string): Promise<void> {
+  abortWorkflowInstance(_instanceId: string): Promise<AxiosResponse<string>> {
     if (
       !hasOwnProp(this._mockData, 'abortWorkflowInstanceResponse') ||
       !isNonNullable(this._mockData.abortWorkflowInstanceResponse)

--- a/plugins/orchestrator/src/api/OrchestratorClient.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.ts
@@ -89,11 +89,13 @@ export class OrchestratorClient implements OrchestratorApi {
     );
   }
 
-  async abortWorkflowInstance(instanceId: string): Promise<void> {
-    const baseUrl = await this.getBaseUrl();
-    return await this.fetcher(`${baseUrl}/instances/${instanceId}/abort`, {
-      method: 'DELETE',
-    }).then(_ => undefined);
+  async abortWorkflowInstance(
+    instanceId: string,
+  ): Promise<AxiosResponse<string>> {
+    const defaultApi = await this.getDefaultAPI();
+    const reqConfigOption: AxiosRequestConfig =
+      await this.getDefaultReqConfig();
+    return await defaultApi.abortWorkflow(instanceId, reqConfigOption);
   }
 
   async getWorkflowDefinition(workflowId: string): Promise<WorkflowDefinition> {

--- a/plugins/orchestrator/src/api/api.ts
+++ b/plugins/orchestrator/src/api/api.ts
@@ -17,7 +17,7 @@ import {
 } from '@janus-idp/backstage-plugin-orchestrator-common';
 
 export interface OrchestratorApi {
-  abortWorkflowInstance(instanceId: string): Promise<void>;
+  abortWorkflowInstance(instanceId: string): Promise<AxiosResponse<string>>;
 
   executeWorkflow(args: {
     workflowId: string;


### PR DESCRIPTION
Use v2 endpoints in orchestrator plugin UI for aborting workflows.

Warning: This DELETES corresponding v1 endpoints.