### PR TITLE
feat(orchestrator): use v2 endpoint fot getWorkflowSource

### DIFF
--- a/plugins/orchestrator-backend/src/service/api/v1.ts
+++ b/plugins/orchestrator-backend/src/service/api/v1.ts
@@ -26,19 +26,6 @@ export class V1 {
     return definition;
   }
 
-  public async getWorkflowSourceById(definitionId: string): Promise<string> {
-    const source = await this.orchestratorService.fetchWorkflowSource({
-      definitionId,
-      cacheHandler: 'throw',
-    });
-
-    if (!source) {
-      throw new Error(`Couldn't fetch workflow source for ${definitionId}`);
-    }
-
-    return source;
-  }
-
   public async retriggerInstanceInError(
     instanceId: string,
     inputData: ProcessInstanceVariables,

--- a/plugins/orchestrator-backend/src/service/api/v2.test.ts
+++ b/plugins/orchestrator-backend/src/service/api/v2.test.ts
@@ -23,7 +23,6 @@ import {
   generateTestWorkflowOverviewList,
   generateWorkflowDefinition,
 } from './test-utils';
-import { V1 } from './v1';
 import { V2 } from './v2';
 
 jest.mock('../Helper.ts', () => ({
@@ -56,7 +55,7 @@ const createMockOrchestratorService = (): OrchestratorService => {
   return mockOrchestratorService;
 };
 const mockOrchestratorService = createMockOrchestratorService();
-const v2 = new V2(mockOrchestratorService, new V1(mockOrchestratorService));
+const v2 = new V2(mockOrchestratorService);
 
 describe('getWorkflowOverview', () => {
   beforeEach(() => {

--- a/plugins/orchestrator-backend/src/service/api/v2.ts
+++ b/plugins/orchestrator-backend/src/service/api/v2.ts
@@ -26,16 +26,12 @@ import {
   mapToWorkflowOverviewDTO,
   mapToWorkflowRunStatusDTO,
 } from './mapping/V2Mappings';
-import { V1 } from './v1';
 
 const FETCH_INSTANCE_MAX_ATTEMPTS = 10;
 const FETCH_INSTANCE_RETRY_DELAY_MS = 1000;
 
 export class V2 {
-  constructor(
-    private readonly orchestratorService: OrchestratorService,
-    private readonly v1: V1,
-  ) {}
+  constructor(private readonly orchestratorService: OrchestratorService) {}
 
   public async getWorkflowsOverview(
     pagination: Pagination,
@@ -74,13 +70,21 @@ export class V2 {
   }
 
   public async getWorkflowById(workflowId: string): Promise<WorkflowDTO> {
-    const resultV1 = await this.v1.getWorkflowSourceById(workflowId);
+    const resultV1 = await this.getWorkflowSourceById(workflowId);
     return mapToWorkflowDTO(resultV1);
   }
 
   public async getWorkflowSourceById(workflowId: string): Promise<string> {
-    const resultV1 = await this.v1.getWorkflowSourceById(workflowId);
-    return resultV1;
+    const source = await this.orchestratorService.fetchWorkflowSource({
+      definitionId: workflowId,
+      cacheHandler: 'throw',
+    });
+
+    if (!source) {
+      throw new Error(`Couldn't fetch workflow source for ${workflowId}`);
+    }
+
+    return source;
   }
 
   public async getInstances(

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -353,12 +353,12 @@ function setupInternalRoutes(
 
       try {
         const result = await routerApi.v2.getWorkflowSourceById(workflowId);
-        res.status(200).contentType('plain/text').send(result);
+        res.status(200).contentType('text/plain').send(result);
       } catch (error) {
         auditLogRequestError(error, endpointName, endpoint, _req);
         res
           .status(500)
-          .contentType('plain/text')
+          .contentType('text/plain')
           .send((error as Error)?.message || INTERNAL_SERVER_ERROR_MESSAGE);
         next();
       }

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -215,7 +215,7 @@ async function initRouterApi(
   });
   await openApiBackend.init();
   const v1 = new V1(orchestratorService);
-  const v2 = new V2(orchestratorService, v1);
+  const v2 = new V2(orchestratorService);
   return { v1, v2, openApiBackend };
 }
 
@@ -323,44 +323,6 @@ function setupInternalRoutes(
         });
     },
   );
-
-  // v1
-  router.get('/workflows/:workflowId/source', async (req, res) => {
-    const {
-      params: { workflowId },
-    } = req;
-    const endpointName = 'WorkflowsWorkflowIdSource';
-    const endpoint = `/v1/workflows/${workflowId}/source`;
-
-    auditLogger.auditLog({
-      eventName: endpointName,
-      stage: 'start',
-      status: 'succeeded',
-      level: 'debug',
-      request: req,
-      message: `Received request to '${endpoint}' endpoint`,
-    });
-
-    const decision = await authorize(
-      req,
-      orchestratorWorkflowReadPermission,
-      permissions,
-      httpAuth,
-    );
-    if (decision.result === AuthorizeResult.DENY) {
-      manageDenyAuthorization(endpointName, endpoint, req);
-    }
-
-    try {
-      const result = await routerApi.v1.getWorkflowSourceById(workflowId);
-      res.status(200).contentType('text/plain').send(result);
-    } catch (error) {
-      res
-        .status(500)
-        .contentType('text/plain')
-        .send((error as Error)?.message || INTERNAL_SERVER_ERROR_MESSAGE);
-    }
-  });
 
   // v2
   routerApi.openApiBackend.register(

--- a/plugins/orchestrator/src/api/MockOrchestratorClient.ts
+++ b/plugins/orchestrator/src/api/MockOrchestratorClient.ts
@@ -87,7 +87,7 @@ export class MockOrchestratorClient implements OrchestratorApi {
     return Promise.resolve(this._mockData.listInstancesResponse);
   }
 
-  getWorkflowSource(_workflowId: string): Promise<string> {
+  getWorkflowSource(_workflowId: string): Promise<AxiosResponse<string>> {
     if (
       !hasOwnProp(this._mockData, 'getWorkflowSourceResponse') ||
       !isNonNullable(this._mockData.getWorkflowSourceResponse)

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -270,7 +270,8 @@ describe('OrchestratorClient', () => {
       // Given
       const workflowId = 'workflow123';
       const mockWorkflowSource = 'test workflow source';
-
+      const responseConfigOptions = getDefaultTestRequestConfig();
+      responseConfigOptions.responseType = 'text';
       const mockResponse: AxiosResponse<string> = {
         data: mockWorkflowSource,
         status: 200,
@@ -300,11 +301,12 @@ describe('OrchestratorClient', () => {
         headers: {
           ...defaultAuthHeaders,
         },
+        responseType: 'text',
       });
       expect(getSourceSpy).toHaveBeenCalledTimes(1);
       expect(getSourceSpy).toHaveBeenCalledWith(
         workflowId,
-        getDefaultTestRequestConfig(),
+        responseConfigOptions,
       );
     });
 

--- a/plugins/orchestrator/src/api/OrchestratorClient.test.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.test.ts
@@ -271,34 +271,51 @@ describe('OrchestratorClient', () => {
       const workflowId = 'workflow123';
       const mockWorkflowSource = 'test workflow source';
 
-      // Mock fetch to simulate a successful response
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        text: jest.fn().mockResolvedValue(mockWorkflowSource),
-      });
+      const mockResponse: AxiosResponse<string> = {
+        data: mockWorkflowSource,
+        status: 200,
+        statusText: 'OK',
+        headers: {} as RawAxiosResponseHeaders,
+        config: {} as InternalAxiosRequestConfig,
+      };
+      // Mock axios request to simulate a successful response
+      jest.spyOn(axios, 'request').mockResolvedValueOnce(mockResponse);
+
+      // Spy DefaultApi
+      const getSourceSpy = jest.spyOn(
+        DefaultApi.prototype,
+        'getWorkflowSourceById',
+      );
 
       // When
       const result = await orchestratorClient.getWorkflowSource(workflowId);
 
       // Then
-      expect(fetch).toHaveBeenCalledWith(
-        `${baseUrl}/workflows/${workflowId}/source`,
-        { headers: defaultAuthHeaders },
+      expect(result).toBeDefined();
+      expect(result.data).toEqual(mockWorkflowSource);
+      expect(axios.request).toHaveBeenCalledTimes(1);
+      expect(axios.request).toHaveBeenCalledWith({
+        ...getAxiosTestRequest(`/v2/workflows/${workflowId}/source`),
+        method: 'GET',
+        headers: {
+          ...defaultAuthHeaders,
+        },
+      });
+      expect(getSourceSpy).toHaveBeenCalledTimes(1);
+      expect(getSourceSpy).toHaveBeenCalledWith(
+        workflowId,
+        getDefaultTestRequestConfig(),
       );
-      expect(result).toEqual(mockWorkflowSource);
     });
 
     it('should throw a ResponseError when fetching the workflow source fails', async () => {
       // Given
       const workflowId = 'workflow123';
 
-      // Mock fetch to simulate a failed response
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-      });
-
+      // Mock fetch to simulate a failure
+      axios.request = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('Simulated error'));
       // When
       const promise = orchestratorClient.getWorkflowSource(workflowId);
 

--- a/plugins/orchestrator/src/api/OrchestratorClient.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.ts
@@ -109,6 +109,7 @@ export class OrchestratorClient implements OrchestratorApi {
     const defaultApi = await this.getDefaultAPI();
     const reqConfigOption: AxiosRequestConfig =
       await this.getDefaultReqConfig();
+    reqConfigOption.responseType = 'text';
     return await defaultApi.getWorkflowSourceById(workflowId, reqConfigOption);
   }
 

--- a/plugins/orchestrator/src/api/OrchestratorClient.ts
+++ b/plugins/orchestrator/src/api/OrchestratorClient.ts
@@ -105,11 +105,11 @@ export class OrchestratorClient implements OrchestratorApi {
     );
   }
 
-  async getWorkflowSource(workflowId: string): Promise<string> {
-    const baseUrl = await this.getBaseUrl();
-    return await this.fetcher(`${baseUrl}/workflows/${workflowId}/source`).then(
-      r => r.text(),
-    );
+  async getWorkflowSource(workflowId: string): Promise<AxiosResponse<string>> {
+    const defaultApi = await this.getDefaultAPI();
+    const reqConfigOption: AxiosRequestConfig =
+      await this.getDefaultReqConfig();
+    return await defaultApi.getWorkflowSourceById(workflowId, reqConfigOption);
   }
 
   async listWorkflowOverviews(

--- a/plugins/orchestrator/src/api/api.ts
+++ b/plugins/orchestrator/src/api/api.ts
@@ -32,7 +32,7 @@ export interface OrchestratorApi {
 
   getWorkflowDefinition(workflowId: string): Promise<WorkflowDefinition>;
 
-  getWorkflowSource(workflowId: string): Promise<string>;
+  getWorkflowSource(workflowId: string): Promise<AxiosResponse<string>>;
 
   getInstance(
     instanceId: string,

--- a/plugins/orchestrator/src/components/WorkflowEditor/WorkflowEditor.tsx
+++ b/plugins/orchestrator/src/components/WorkflowEditor/WorkflowEditor.tsx
@@ -217,10 +217,10 @@ const RefForwardingWorkflowEditor: ForwardRefRenderFunction<
             if (canceled.get()) {
               return;
             }
-            const definition = fromWorkflowSource(source);
+            const definition = fromWorkflowSource(source.data);
             setWorkflowDefinitionPromise({ data: definition });
 
-            const workflowFormat = extractWorkflowFormat(source);
+            const workflowFormat = extractWorkflowFormat(source.data);
 
             if (format && workflowId && format !== workflowFormat) {
               const link = viewWorkflowLink({


### PR DESCRIPTION
Use v2 endpoints in orchestrator plugin UI for getting workflow source.

Warning: This DELETES corresponding v1 endpoints.