### PR TITLE
fix(acr): new credential settings in proxy backend

### DIFF
--- a/plugins/acr/README.md
+++ b/plugins/acr/README.md
@@ -20,6 +20,7 @@ The Azure Container Registry (ACR) plugin displays information about your contai
      endpoints:
        '/acr/api':
          target: 'https://mycontainerregistry.azurecr.io/acr/v1/'
+         credentials: require
          changeOrigin: true
          headers:
            # If you use Bearer Token for authorization, please replace the 'Basic' with 'Bearer' in the following line.
@@ -27,6 +28,15 @@ The Azure Container Registry (ACR) plugin displays information about your contai
          # Change to "false" in case of using self hosted artifactory instance with a self-signed certificate
          secure: true
    ```
+
+   > [!NOTE]
+   > The value inside each route is either a simple URL string, or an object on the format accepted by [http-proxy-middleware](https://www.npmjs.com/package/http-proxy-middleware). Additionally, it has an optional `credentials` key which can have the following values:
+   >
+   > - `require`: Callers must provide Backstage user or service credentials with each request. The credentials are not forwarded to the proxy target. This is the **default**.
+   > - `forward`: Callers must provide Backstage user or service credentials with each request, and those credentials are forwarded to the proxy target.
+   > - `dangerously-allow-unauthenticated`: No Backstage credentials are required to access this proxy target. The target can still apply its own credentials checks, but the proxy will not help block non-Backstage-blessed callers. If you also add allowedHeaders: ['Authorization'] to an endpoint configuration, then the Backstage token (if provided) WILL be forwarded.
+   >
+   > Note that if you have `backend.auth.dangerouslyDisableDefaultAuthPolicy` set to true, the credentials value does not apply; the proxy will behave as if all endpoints were set to dangerously-allow-unauthenticated.
 
 1. Set the authorization using one of the following options:
 

--- a/plugins/acr/src/api/index.ts
+++ b/plugins/acr/src/api/index.ts
@@ -2,6 +2,7 @@ import {
   ConfigApi,
   createApiRef,
   DiscoveryApi,
+  IdentityApi,
 } from '@backstage/core-plugin-api';
 
 import { TagsResponse } from '../types';
@@ -20,6 +21,7 @@ export const AzureContainerRegistryApiRef =
 export type Options = {
   discoveryApi: DiscoveryApi;
   configApi: ConfigApi;
+  identityApi: IdentityApi;
 };
 
 export class AzureContainerRegistryApiClient
@@ -28,10 +30,12 @@ export class AzureContainerRegistryApiClient
   // @ts-ignore
   private readonly discoveryApi: DiscoveryApi;
   private readonly configApi: ConfigApi;
+  private readonly identityApi: IdentityApi;
 
   constructor(options: Options) {
     this.discoveryApi = options.discoveryApi;
     this.configApi = options.configApi;
+    this.identityApi = options.identityApi;
   }
 
   private async getBaseUrl() {
@@ -41,8 +45,12 @@ export class AzureContainerRegistryApiClient
   }
 
   private async fetcher(url: string) {
+    const { token: idToken } = await this.identityApi.getCredentials();
     const response = await fetch(url, {
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(idToken && { Authorization: `Bearer ${idToken}` }),
+      },
       method: 'GET',
     });
     if (!response.ok) {

--- a/plugins/acr/src/plugin.ts
+++ b/plugins/acr/src/plugin.ts
@@ -5,6 +5,7 @@ import {
   createComponentExtension,
   createPlugin,
   discoveryApiRef,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
 
 import {
@@ -25,9 +26,14 @@ export const acrPlugin = createPlugin({
       deps: {
         discoveryApi: discoveryApiRef,
         configApi: configApiRef,
+        identityApi: identityApiRef,
       },
-      factory: ({ discoveryApi, configApi }) =>
-        new AzureContainerRegistryApiClient({ discoveryApi, configApi }),
+      factory: ({ discoveryApi, configApi, identityApi }) =>
+        new AzureContainerRegistryApiClient({
+          discoveryApi,
+          configApi,
+          identityApi,
+        }),
     }),
   ],
 });

--- a/plugins/quay/README.md
+++ b/plugins/quay/README.md
@@ -18,16 +18,17 @@ The Quay plugin displays the information about your container images within the 
 
    ```yaml title="app-config.yaml"
    proxy:
-     '/quay/api':
-       target: 'https://quay.io'
-       credentials: require
-       headers:
-         X-Requested-With: 'XMLHttpRequest'
-         # Uncomment the following line to access a private Quay Repository using a token
-         # Authorization: 'Bearer <YOUR TOKEN>'
-       changeOrigin: true
-       # Change to "false" in case of using self hosted quay instance with a self-signed certificate
-       secure: true
+     endpoints:
+       '/quay/api':
+         target: 'https://quay.io'
+         credentials: require
+         headers:
+           X-Requested-With: 'XMLHttpRequest'
+           # Uncomment the following line to access a private Quay Repository using a token
+           # Authorization: 'Bearer <YOUR TOKEN>'
+         changeOrigin: true
+         # Change to "false" in case of using self hosted quay instance with a self-signed certificate
+         secure: true
 
    quay:
      # The UI url for Quay, used to generate the link to Quay


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHIDP-3592 

This PR updated the credentials to be passed for the proxy and added more context around the new optional credential settings in the backstage 1.28 to explain different settings available to the users.

See Backstage 1.28 release notes about the BREAKING: Proxy backend plugin protected by default -
https://github.com/backstage/backstage/releases/tag/v1.28.0