### PR TITLE
fix(orchestrator): revert upgrade to material 5 to resolve dark theme issues

### DIFF
--- a/plugins/orchestrator/package.json
+++ b/plugins/orchestrator/package.json
@@ -59,12 +59,6 @@
     "@kie-tools/serverless-workflow-language-service": "^0.32.0",
     "@kie-tools/serverless-workflow-service-catalog": "^0.32.0",
     "@monaco-editor/react": "^4.6.0",
-    "@mui/icons-material": "^5.15.18",
-    "@mui/material": "^5.15.18",
-    "@rjsf/core": "^5.18.4",
-    "@rjsf/mui": "^5.18.4",
-    "@rjsf/utils": "^5.18.4",
-    "@rjsf/validator-ajv8": "^5.18.4",
     "moment": "^2.29.4",
     "monaco-editor": "^0.49.0",
     "react-json-view": "^1.21.3",
@@ -87,7 +81,16 @@
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "react-router-dom": "^6.0.0"
+    "react-router-dom": "^6.0.0",
+    "@material-ui/core": "^4.12.4",
+    "@material-ui/icons": "^4.11.3",
+    "@material-ui/lab": "^4.0.0-alpha.45",
+    "@monaco-editor/react": "^4.6.0",
+    "@mui/icons-material": "^5.15.8",
+    "@rjsf/core": "^5.17.1",
+    "@rjsf/material-ui": "^5.17.1",
+    "@rjsf/utils": "^5.17.1",
+    "@rjsf/validator-ajv8": "^5.17.1"
   },
   "scalprum": {
     "name": "janus-idp.backstage-plugin-orchestrator",

--- a/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
+++ b/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { JsonObject } from '@backstage/types';
 
-import Grid from '@mui/material/Grid';
+import { Grid } from '@material-ui/core';
 
 import {
   QUERY_PARAM_ASSESSMENT_INSTANCE_ID,

--- a/plugins/orchestrator/src/components/ExecuteWorkflowPage/JsonTextAreaForm.tsx
+++ b/plugins/orchestrator/src/components/ExecuteWorkflowPage/JsonTextAreaForm.tsx
@@ -2,12 +2,9 @@ import React from 'react';
 
 import { JsonObject } from '@backstage/types';
 
+import { Box, Grid, useTheme } from '@material-ui/core';
+import { Alert, AlertTitle } from '@material-ui/lab';
 import { Editor } from '@monaco-editor/react';
-import Alert from '@mui/material/Alert';
-import AlertTitle from '@mui/material/AlertTitle';
-import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
-import { useTheme } from '@mui/material/styles';
 
 import SubmitButton from '../SubmitButton';
 
@@ -43,13 +40,13 @@ const JsonTextAreaForm = ({
         </Alert>
       </Grid>
       <Grid item xs={12}>
-        <Box style={{ border: `1px solid ${theme.palette.divider}` }}>
+        <Box style={{ border: `1px solid ${theme.palette.border}` }}>
           <Editor
             value={jsonText}
             language="json"
             onChange={(value: string | undefined) => setJsonText(value ?? '')}
             height="30rem"
-            theme={theme.palette.mode === 'dark' ? 'vs-dark' : 'light'}
+            theme={theme.palette.type === 'dark' ? 'vs-dark' : 'light'}
             options={{
               minimap: { enabled: false },
             }}

--- a/plugins/orchestrator/src/components/ExecuteWorkflowPage/StepperForm.tsx
+++ b/plugins/orchestrator/src/components/ExecuteWorkflowPage/StepperForm.tsx
@@ -3,22 +3,26 @@ import React from 'react';
 import { Content, StructuredMetadataTable } from '@backstage/core-components';
 import { JsonObject } from '@backstage/types';
 
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Paper from '@mui/material/Paper';
-import Step from '@mui/material/Step';
-import StepContent from '@mui/material/StepContent';
-import StepLabel from '@mui/material/StepLabel';
-import Stepper from '@mui/material/Stepper';
-import Typography from '@mui/material/Typography';
-import { FormProps } from '@rjsf/core';
-import Form from '@rjsf/mui';
+import {
+  Box,
+  Button,
+  Paper,
+  Step,
+  StepContent,
+  StepLabel,
+  Stepper,
+  Typography,
+} from '@material-ui/core';
+import { FormProps, withTheme } from '@rjsf/core';
+import { Theme as MuiTheme } from '@rjsf/material-ui';
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 
 import { WorkflowInputSchemaStep } from '@janus-idp/backstage-plugin-orchestrator-common';
 
 import SubmitButton from '../SubmitButton';
+
+const Form = withTheme(MuiTheme);
 
 const getCombinedData = (
   steps: WorkflowInputSchemaStep[],

--- a/plugins/orchestrator/src/components/InfoDialog.stories.tsx
+++ b/plugins/orchestrator/src/components/InfoDialog.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Button from '@mui/material/Button';
+import { Button } from '@material-ui/core';
 import { useArgs } from '@storybook/preview-api';
 import { Meta, StoryObj } from '@storybook/react';
 

--- a/plugins/orchestrator/src/components/InfoDialog.tsx
+++ b/plugins/orchestrator/src/components/InfoDialog.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import React, { forwardRef, ForwardRefRenderFunction } from 'react';
 
-import CloseIcon from '@mui/icons-material/Close';
-import Box from '@mui/material/Box';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
-import IconButton from '@mui/material/IconButton';
-import { styled } from '@mui/material/styles';
-import Typography from '@mui/material/Typography';
+import {
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
 
 export type InfoDialogProps = {
   title: string;
@@ -19,29 +20,43 @@ export type InfoDialogProps = {
   children?: React.ReactNode;
 };
 
-const CloseButton = styled(IconButton)({
-  position: 'absolute',
-  right: 8,
-  top: 8,
-});
+export type ParentComponentRef = HTMLElement;
 
-export const InfoDialog = (props: InfoDialogProps) => {
+const useStyles = makeStyles(_theme => ({
+  closeBtn: {
+    position: 'absolute',
+    right: 8,
+    top: 8,
+  },
+}));
+
+export const RefForwardingInfoDialog: ForwardRefRenderFunction<
+  ParentComponentRef,
+  InfoDialogProps
+> = (props, forwardedRef): JSX.Element | null => {
   const { title, open = false, onClose, children, dialogActions } = props;
+  const classes = useStyles();
 
   return (
-    <Dialog onClose={_ => onClose} open={open}>
+    <Dialog onClose={_ => onClose} open={open} ref={forwardedRef}>
       <DialogTitle>
         <Box>
           <Typography variant="h5">{title}</Typography>
-          <CloseButton aria-label="close" onClick={onClose}>
+          <IconButton
+            className={classes.closeBtn}
+            aria-label="close"
+            onClick={onClose}
+          >
             <CloseIcon />
-          </CloseButton>
+          </IconButton>
         </Box>
       </DialogTitle>
       <DialogContent>
-        <DialogContentText>{children}</DialogContentText>
+        <Box>{children}</Box>
       </DialogContent>
       <DialogActions>{dialogActions}</DialogActions>
     </Dialog>
   );
 };
+
+export const InfoDialog = forwardRef(RefForwardingInfoDialog);

--- a/plugins/orchestrator/src/components/OrchestratorIcon.tsx
+++ b/plugins/orchestrator/src/components/OrchestratorIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+import { SvgIcon, SvgIconProps } from '@material-ui/core';
 
 const OrchestratorIcon = (props: SvgIconProps) => (
   <SvgIcon viewBox="0 0 126 166.8" {...props}>

--- a/plugins/orchestrator/src/components/Paragraph.tsx
+++ b/plugins/orchestrator/src/components/Paragraph.tsx
@@ -1,12 +1,15 @@
 import React, { PropsWithChildren } from 'react';
 
-import Typography from '@mui/material/Typography';
+import { Typography } from '@material-ui/core';
+import { Variant } from '@material-ui/core/styles/createTypography';
 
-export const Paragraph = (props: PropsWithChildren<{}>) => {
+export const Paragraph = (
+  props: PropsWithChildren<{ variant?: Variant | 'inherit' }>,
+) => {
   return (
     <Typography
       style={{ marginTop: '14px', marginBottom: '14px' }}
-      variant="body2"
+      variant={props.variant ?? 'body2'}
       component="p"
     >
       {props.children}

--- a/plugins/orchestrator/src/components/Selector.tsx
+++ b/plugins/orchestrator/src/components/Selector.tsx
@@ -2,26 +2,25 @@ import React from 'react';
 
 import { Select, SelectedItems } from '@backstage/core-components';
 
-import { styled } from '@mui/material/styles';
-import Typography from '@mui/material/Typography';
+import { makeStyles, Typography } from '@material-ui/core';
 
-const RootDiv = styled('div')({
-  display: 'flex',
-  alignItems: 'baseline',
-  '& label + div': {
-    marginTop: '0px',
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    alignItems: 'baseline',
+    '& label + div': {
+      marginTop: '0px',
+    },
   },
-});
-
-const SelectDiv = styled('div')({
-  width: '10rem',
-});
-
-const StyledLabel = styled(Typography)(({ theme }) => ({
-  color: theme.palette.text.primary,
-  fontSize: theme.typography.fontSize,
-  paddingRight: '0.5rem',
-  fontWeight: 'bold',
+  select: {
+    width: '10rem',
+  },
+  label: {
+    color: theme.palette.text.primary,
+    fontSize: theme.typography.fontSize,
+    paddingRight: '0.5rem',
+    fontWeight: 'bold',
+  },
 }));
 
 const ALL_ITEMS = '___all___';
@@ -36,6 +35,8 @@ export const Selector = ({
   includeAll = true,
   ...otherProps
 }: SelectorProps) => {
+  const styles = useStyles();
+
   const selectItems = React.useMemo(
     () =>
       includeAll
@@ -50,9 +51,9 @@ export const Selector = ({
   );
 
   return (
-    <RootDiv>
-      <StyledLabel>{otherProps.label}</StyledLabel>
-      <SelectDiv>
+    <div className={styles.root}>
+      <Typography className={styles.label}>{otherProps.label}</Typography>
+      <div className={styles.select}>
         <Select
           onChange={handleChange}
           items={selectItems}
@@ -60,8 +61,8 @@ export const Selector = ({
           margin="dense"
           label={otherProps.label}
         />
-      </SelectDiv>
-    </RootDiv>
+      </div>
+    </div>
   );
 };
 Selector.displayName = 'Selector';

--- a/plugins/orchestrator/src/components/SubmitButton.tsx
+++ b/plugins/orchestrator/src/components/SubmitButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
+import { Button, CircularProgress } from '@material-ui/core';
 
 const SubmitButton = ({
   submitting,

--- a/plugins/orchestrator/src/components/WorkflowDefinitionViewerPage/WorkflowDefinitionDetailsCard.tsx
+++ b/plugins/orchestrator/src/components/WorkflowDefinitionViewerPage/WorkflowDefinitionDetailsCard.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 import { InfoCard } from '@backstage/core-components';
 import { AboutField } from '@backstage/plugin-catalog';
 
-import Grid from '@mui/material/Grid';
-import Skeleton from '@mui/material/Skeleton';
-import { styled } from '@mui/material/styles';
+import { Grid, makeStyles } from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
 
 import {
   ProcessInstanceStateValues,
@@ -16,9 +15,11 @@ import { VALUE_UNAVAILABLE } from '../../constants';
 import WorkflowOverviewFormatter from '../../dataFormatters/WorkflowOverviewFormatter';
 import { WorkflowInstanceStatusIndicator } from '../WorkflowInstanceStatusIndicator';
 
-const DetailsInfoCard = styled(InfoCard)({
-  overflowY: 'auto',
-  height: '15rem',
+const useStyles = makeStyles({
+  details: {
+    overflowY: 'auto',
+    height: '15rem',
+  },
 });
 
 const WorkflowDefinitionDetailsCard = ({
@@ -28,6 +29,8 @@ const WorkflowDefinitionDetailsCard = ({
   loading: boolean;
   workflowOverview?: WorkflowOverview;
 }) => {
+  const classes = useStyles();
+
   const formattedWorkflowOverview = React.useMemo(
     () =>
       workflowOverview
@@ -70,7 +73,7 @@ const WorkflowDefinitionDetailsCard = ({
   );
 
   return (
-    <DetailsInfoCard title="Details">
+    <InfoCard title="Details" className={classes.details}>
       <Grid container spacing={3} alignContent="flex-start">
         <Grid container item md={4} spacing={3} alignContent="flex-start">
           {details?.map(({ label, value, children }) => (
@@ -95,7 +98,7 @@ const WorkflowDefinitionDetailsCard = ({
           </AboutField>
         </Grid>
       </Grid>
-    </DetailsInfoCard>
+    </InfoCard>
   );
 };
 

--- a/plugins/orchestrator/src/components/WorkflowDefinitionViewerPage/WorkflowDefinitionViewerPage.tsx
+++ b/plugins/orchestrator/src/components/WorkflowDefinitionViewerPage/WorkflowDefinitionViewerPage.tsx
@@ -9,9 +9,8 @@ import {
   useRouteRefParams,
 } from '@backstage/core-plugin-api';
 
-import Button from '@mui/material/Button';
-import Grid from '@mui/material/Grid';
-import Skeleton from '@mui/material/Skeleton';
+import { Button, Grid } from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
 
 import { orchestratorApiRef } from '../../api';
 import {

--- a/plugins/orchestrator/src/components/WorkflowDescriptionModal.tsx
+++ b/plugins/orchestrator/src/components/WorkflowDescriptionModal.tsx
@@ -1,17 +1,18 @@
-import React from 'react';
+import React, { forwardRef, ForwardRefRenderFunction } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import CloseIcon from '@mui/icons-material/Close';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
-import IconButton from '@mui/material/IconButton';
-import { styled } from '@mui/material/styles';
-import Typography from '@mui/material/Typography';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
 
 import { WorkflowOverview } from '@janus-idp/backstage-plugin-orchestrator-common';
 
@@ -24,16 +25,20 @@ export type WorkflowDescriptionModalProps = {
 
 export type ParentComponentRef = HTMLElement;
 
-const CloseButton = styled(IconButton)({
-  position: 'absolute',
-  right: 8,
-  top: 8,
-});
+const useStyles = makeStyles(_theme => ({
+  closeBtn: {
+    position: 'absolute',
+    right: 8,
+    top: 8,
+  },
+}));
 
-export const WorkflowDescriptionModal = (
-  props: WorkflowDescriptionModalProps,
-) => {
+export const RefForwardingWorkflowDescriptionModal: ForwardRefRenderFunction<
+  ParentComponentRef,
+  WorkflowDescriptionModalProps
+> = (props, forwardedRef): JSX.Element | null => {
   const { workflow, open = false, onClose, runWorkflowLink } = props;
+  const classes = useStyles();
   const navigate = useNavigate();
 
   const handleRunWorkflow = () => {
@@ -43,22 +48,32 @@ export const WorkflowDescriptionModal = (
   };
 
   return (
-    <Dialog onClose={_ => onClose} open={open} maxWidth="sm" fullWidth>
+    <Dialog
+      onClose={_ => onClose}
+      open={open}
+      ref={forwardedRef}
+      maxWidth="sm"
+      fullWidth
+    >
       <DialogTitle>
         <Box>
           <Typography variant="h5">{workflow.name}</Typography>
-          <CloseButton aria-label="close" onClick={onClose}>
+          <IconButton
+            className={classes.closeBtn}
+            aria-label="close"
+            onClick={onClose}
+          >
             <CloseIcon />
-          </CloseButton>
+          </IconButton>
         </Box>
       </DialogTitle>
       <DialogContent>
         {workflow.description ? (
-          <DialogContentText>{workflow.description}</DialogContentText>
+          <Box>{workflow.description}</Box>
         ) : (
-          <DialogContentText>
+          <Box>
             <p>Are you sure you want to run this workflow?</p>
-          </DialogContentText>
+          </Box>
         )}
       </DialogContent>
       <DialogActions>
@@ -72,3 +87,7 @@ export const WorkflowDescriptionModal = (
     </Dialog>
   );
 };
+
+export const WorkflowDescriptionModal = forwardRef(
+  RefForwardingWorkflowDescriptionModal,
+);

--- a/plugins/orchestrator/src/components/WorkflowDialog.tsx
+++ b/plugins/orchestrator/src/components/WorkflowDialog.tsx
@@ -1,13 +1,15 @@
 import React, { forwardRef, ForwardRefRenderFunction } from 'react';
 
-import CloseIcon from '@mui/icons-material/Close';
-import Box from '@mui/material/Box';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import IconButton from '@mui/material/IconButton';
-import { styled } from '@mui/material/styles';
-import Typography from '@mui/material/Typography';
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
 
 import { WorkflowEditor } from './WorkflowEditor';
 import {
@@ -23,41 +25,47 @@ export type OrchestratorWorkflowDialogProps = {
   dialogActions?: React.ReactNode;
 } & WorkflowEditorView;
 
-const EditorBox = styled(Box)({
-  height: '600px',
-  marginBottom: 20,
-});
-
-const CloseButton = styled(IconButton)({
-  position: 'absolute',
-  right: 8,
-  top: 8,
-});
+const useStyles = makeStyles(_theme => ({
+  editor: {
+    height: '600px',
+    marginBottom: 20,
+  },
+  closeBtn: {
+    position: 'absolute',
+    right: 8,
+    top: 8,
+  },
+}));
 
 export const RefForwardingWorkflowDialog: ForwardRefRenderFunction<
   WorkflowEditorRef,
   OrchestratorWorkflowDialogProps
 > = (props, forwardedRef): JSX.Element | null => {
   const { workflowId, title, open, close } = props;
+  const classes = useStyles();
 
   return (
     <Dialog fullWidth maxWidth="lg" onClose={_ => close()} open={open}>
       <DialogTitle>
         <Box>
           <Typography variant="h5">{title}</Typography>
-          <CloseButton aria-label="close" onClick={close}>
+          <IconButton
+            className={classes.closeBtn}
+            aria-label="close"
+            onClick={close}
+          >
             <CloseIcon />
-          </CloseButton>
+          </IconButton>
         </Box>
       </DialogTitle>
       <DialogContent>
-        <EditorBox>
+        <Box className={classes.editor}>
           <WorkflowEditor
             {...props}
             workflowId={workflowId}
             ref={forwardedRef}
           />
-        </EditorBox>
+        </Box>
       </DialogContent>
       {props.dialogActions}
     </Dialog>

--- a/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePage.tsx
@@ -12,8 +12,7 @@ import {
   useRouteRefParams,
 } from '@backstage/core-plugin-api';
 
-import Button from '@mui/material/Button';
-import Grid from '@mui/material/Grid';
+import { Button, Grid } from '@material-ui/core';
 
 import {
   AssessedProcessInstance,

--- a/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
@@ -8,10 +8,7 @@ import {
   useRouteRef,
 } from '@backstage/core-plugin-api';
 
-import CardContent from '@mui/material/CardContent';
-import Chip from '@mui/material/Chip';
-import Grid from '@mui/material/Grid';
-import { styled } from '@mui/material/styles';
+import { Chip, Grid, makeStyles } from '@material-ui/core';
 import moment from 'moment';
 
 import {
@@ -64,18 +61,24 @@ export const mapProcessInstanceToDetails = (
   };
 };
 
-const middleRowHeight = `calc(2 * 16rem)`;
-const topRowHeight = '16rem';
-
-const RecommendedLabelContainer = styled('div')({
-  display: 'flex',
-  alignItems: 'center',
-  whiteSpace: 'nowrap',
-});
-
-const RecommendedLabel = styled(Chip)({
-  margin: '0 0.25rem',
-});
+const useStyles = makeStyles(_ => ({
+  topRowCard: {
+    height: '20rem',
+  },
+  middleRowCard: {
+    height: 'calc(2 * 20rem)',
+  },
+  bottomRowCard: {
+    height: '100%',
+  },
+  autoOverflow: { overflow: 'auto' },
+  recommendedLabelContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    whiteSpace: 'nowrap',
+  },
+  recommendedLabel: { margin: '0 0.25rem' },
+}));
 
 const getNextWorkflows = (
   details: WorkflowRunDetail,
@@ -121,6 +124,7 @@ const getNextWorkflows = (
 export const WorkflowInstancePageContent: React.FC<{
   assessedInstance: AssessedProcessInstance;
 }> = ({ assessedInstance }) => {
+  const styles = useStyles();
   const executeWorkflowLink = useRouteRef(executeWorkflowRouteRef);
   const details = React.useMemo(
     () => mapProcessInstanceToDetails(assessedInstance.instance),
@@ -174,89 +178,104 @@ export const WorkflowInstancePageContent: React.FC<{
     <Content noPadding>
       <Grid container spacing={2}>
         <Grid item xs={6}>
-          <InfoCard title="Details" divider={false}>
-            <CardContent style={{ height: topRowHeight }}>
-              <WorkflowRunDetails
-                details={details}
-                assessedBy={assessedInstance.assessedBy}
-              />
-            </CardContent>
+          <InfoCard
+            title="Details"
+            divider={false}
+            className={styles.topRowCard}
+          >
+            <WorkflowRunDetails
+              details={details}
+              assessedBy={assessedInstance.assessedBy}
+            />
           </InfoCard>
         </Grid>
 
         <Grid item xs={6}>
-          <InfoCard title="Results" divider={false}>
-            <CardContent style={{ height: topRowHeight, overflow: 'auto' }}>
-              {nextWorkflows.length === 0 ? (
-                <WorkflowVariablesViewer variables={instanceVariables} />
-              ) : (
-                <Grid container spacing={3}>
-                  {nextWorkflows.map(item => (
-                    <Grid item xs={4} key={item.title}>
-                      <RecommendedLabelContainer key={item.title}>
-                        <Link
-                          color="primary"
-                          to="#"
-                          onClick={() => {
-                            openWorkflowDescriptionModal(item.id);
-                          }}
-                        >
-                          {item.title}
-                        </Link>
-                        {item.isRecommended ? (
-                          <RecommendedLabel
-                            size="small"
-                            label="Recommended"
-                            color="secondary"
-                          />
-                        ) : null}
-                      </RecommendedLabelContainer>
-                      <WorkflowDescriptionModal
-                        workflow={currentWorkflow}
-                        runWorkflowLink={item.link}
-                        open={
-                          item.id === currentOpenedWorkflowDescriptionModalID
-                        }
-                        onClose={closeWorkflowDescriptionModal}
-                      />
-                    </Grid>
-                  ))}
-                </Grid>
-              )}
-            </CardContent>
+          <InfoCard
+            title="Results"
+            divider={false}
+            className={styles.topRowCard}
+            cardClassName={styles.autoOverflow}
+          >
+            {nextWorkflows.length === 0 ? (
+              <WorkflowVariablesViewer variables={instanceVariables} />
+            ) : (
+              <Grid container spacing={3}>
+                {nextWorkflows.map(item => (
+                  <Grid item xs={4} key={item.title}>
+                    <div
+                      className={styles.recommendedLabelContainer}
+                      key={item.title}
+                    >
+                      <Link
+                        color="primary"
+                        to="#"
+                        onClick={() => {
+                          openWorkflowDescriptionModal(item.id);
+                        }}
+                      >
+                        {item.title}
+                      </Link>
+                      {item.isRecommended ? (
+                        <Chip
+                          size="small"
+                          label="Recommended"
+                          color="secondary"
+                          className={styles.recommendedLabel}
+                        />
+                      ) : null}
+                    </div>
+                    <WorkflowDescriptionModal
+                      workflow={currentWorkflow}
+                      runWorkflowLink={item.link}
+                      open={item.id === currentOpenedWorkflowDescriptionModalID}
+                      onClose={closeWorkflowDescriptionModal}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
+            )}
           </InfoCard>
         </Grid>
 
         <Grid item xs={6}>
-          <InfoCard title="Workflow definition" divider={false}>
-            <CardContent style={{ height: middleRowHeight }}>
-              <WorkflowEditor
-                workflowId={assessedInstance.instance.processId}
-                kind={EditorViewKind.DIAGRAM_VIEWER}
-                editorMode="text"
-              />
-            </CardContent>
+          <InfoCard
+            title="Workflow definition"
+            divider={false}
+            className={styles.middleRowCard}
+          >
+            <WorkflowEditor
+              workflowId={assessedInstance.instance.processId}
+              kind={EditorViewKind.DIAGRAM_VIEWER}
+              editorMode="text"
+            />
           </InfoCard>
         </Grid>
 
         <Grid item xs={6}>
-          <InfoCard title="Workflow progress" divider={false}>
-            <CardContent style={{ height: middleRowHeight, overflow: 'auto' }}>
-              <WorkflowProgress
-                workflowError={assessedInstance.instance.error}
-                workflowNodes={assessedInstance.instance.nodes}
-                workflowStatus={assessedInstance.instance.state}
-              />
-            </CardContent>
+          <InfoCard
+            title="Workflow progress"
+            divider={false}
+            className={styles.middleRowCard}
+            cardClassName={styles.autoOverflow}
+          >
+            <WorkflowProgress
+              workflowError={assessedInstance.instance.error}
+              workflowNodes={assessedInstance.instance.nodes}
+              workflowStatus={assessedInstance.instance.state}
+            />
           </InfoCard>
         </Grid>
 
         {nextWorkflows.length > 0 ? (
           <Grid item xs={12}>
-            <InfoCard title="Variables" divider={false}>
-              <CardContent style={{ height: '100%', overflow: 'auto' }}>
-                <WorkflowVariablesViewer variables={instanceVariables} />
-              </CardContent>
+            <InfoCard
+              title="Variables"
+              divider={false}
+              className={styles.bottomRowCard}
+              cardClassName={styles.autoOverflow}
+            >
+              <WorkflowVariablesViewer variables={instanceVariables} />
             </InfoCard>
           </Grid>
         ) : null}

--- a/plugins/orchestrator/src/components/WorkflowInstanceStatusIndicator.tsx
+++ b/plugins/orchestrator/src/components/WorkflowInstanceStatusIndicator.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Link } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 
-import DotIcon from '@mui/icons-material/FiberManualRecord';
+import DotIcon from '@material-ui/icons/FiberManualRecord';
 
 import {
   capitalize,
@@ -30,7 +30,7 @@ export const WorkflowInstanceStatusIndicator = ({
 
   return (
     <>
-      <DotIcon style={{ fontSize: '0.75rem', color: iconColor }} />{' '}
+      <DotIcon style={{ fontSize: '0.75rem' }} className={iconColor} />{' '}
       {lastRunId ? (
         <Link to={workflowInstanceLink({ instanceId: lastRunId })}>
           {capitalize(status)}

--- a/plugins/orchestrator/src/components/WorkflowProgressNode.tsx
+++ b/plugins/orchestrator/src/components/WorkflowProgressNode.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import Moment from 'react-moment';
 
-import CancelIcon from '@mui/icons-material/Cancel';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { Tooltip } from '@material-ui/core';
+import CancelIcon from '@material-ui/icons/Cancel';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import HourglassTopIcon from '@mui/icons-material/HourglassTop';
 import PauseCircleIcon from '@mui/icons-material/PauseCircle';
-import Tooltip from '@mui/material/Tooltip';
 
 import { VALUE_UNAVAILABLE } from '../constants';
 import { useWorkflowInstanceStateColors } from '../hooks/useWorkflowInstanceStatusColors';
@@ -27,14 +27,14 @@ const WorkflowProgressNodeIcon: React.FC<{
             'Additional details about this error are not available'
           }
         >
-          <ErrorIcon style={{ color }} />
+          <ErrorIcon className={color} />
         </Tooltip>
       );
     }
     case 'COMPLETED': {
       return (
         <Tooltip title="Completed">
-          <CheckCircleIcon style={{ color }} />
+          <CheckCircleIcon className={color} />
         </Tooltip>
       );
     }

--- a/plugins/orchestrator/src/components/WorkflowRunDetails.stories.tsx
+++ b/plugins/orchestrator/src/components/WorkflowRunDetails.stories.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { Content, InfoCard } from '@backstage/core-components';
 import { wrapInTestApp } from '@backstage/test-utils';
 
-import Grid from '@mui/material/Grid';
-import { styled } from '@mui/material/styles';
+import { makeStyles } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid/Grid';
 import { Meta, StoryObj } from '@storybook/react';
 
 import { fakeCompletedInstance } from '../__fixtures__/fakeProcessInstance';
@@ -13,9 +13,11 @@ import { veryLongString } from '../__fixtures__/veryLongString';
 import { orchestratorRootRouteRef } from '../routes';
 import { WorkflowRunDetails } from './WorkflowRunDetails';
 
-const TopRowCard = styled(InfoCard)({
-  height: '20rem',
-});
+const useStyles = makeStyles(_ => ({
+  topRowCard: {
+    height: '20rem',
+  },
+}));
 
 const meta = {
   title: 'Orchestrator/WorkflowDetails',
@@ -32,14 +34,22 @@ const meta = {
         <Content noPadding>
           <Grid container spacing={2}>
             <Grid item xs={6}>
-              <TopRowCard title="Details" divider={false}>
+              <InfoCard
+                title="Details"
+                divider={false}
+                className={useStyles().topRowCard}
+              >
                 <Story />
-              </TopRowCard>
+              </InfoCard>
             </Grid>
             <Grid item xs={6}>
-              <TopRowCard title="Another card" divider={false}>
+              <InfoCard
+                title="Another card"
+                divider={false}
+                className={useStyles().topRowCard}
+              >
                 <p>Nothing fancy here...</p>
-              </TopRowCard>
+              </InfoCard>
             </Grid>
           </Grid>
         </Content>,

--- a/plugins/orchestrator/src/components/WorkflowRunDetails.tsx
+++ b/plugins/orchestrator/src/components/WorkflowRunDetails.tsx
@@ -4,9 +4,7 @@ import { Link } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { AboutField } from '@backstage/plugin-catalog';
 
-import Grid from '@mui/material/Grid';
-import { styled } from '@mui/material/styles';
-import Typography from '@mui/material/Typography';
+import { Grid, makeStyles, Typography } from '@material-ui/core';
 
 import {
   capitalize,
@@ -24,19 +22,22 @@ type WorkflowDetailsCardProps = {
   details: WorkflowRunDetail;
 };
 
-const RootGrid = styled(Grid)({
-  overflowY: 'auto',
-  height: '15rem',
+const useStyles = makeStyles({
+  root: {
+    overflowY: 'auto',
+    height: '15rem',
+  },
 });
 
 export const WorkflowRunDetails: React.FC<WorkflowDetailsCardProps> = ({
   assessedBy,
   details,
 }) => {
+  const styles = useStyles();
   const workflowInstanceLink = useRouteRef(workflowInstanceRouteRef);
 
   return (
-    <RootGrid container alignContent="flex-start">
+    <Grid container className={styles.root} alignContent="flex-start">
       <Grid item md={4} key="Category">
         <AboutField label="Category">
           <Typography variant="subtitle2" component="div">
@@ -103,7 +104,7 @@ export const WorkflowRunDetails: React.FC<WorkflowDetailsCardProps> = ({
           </Typography>
         </AboutField>
       </Grid>
-    </RootGrid>
+    </Grid>
   );
 };
 WorkflowRunDetails.displayName = 'WorkflowDetails';

--- a/plugins/orchestrator/src/components/WorkflowRunsTabContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowRunsTabContent.tsx
@@ -9,7 +9,7 @@ import {
 } from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 
-import Grid from '@mui/material/Grid';
+import { Grid } from '@material-ui/core';
 
 import {
   capitalize,

--- a/plugins/orchestrator/src/components/WorkflowVariablesViewer.tsx
+++ b/plugins/orchestrator/src/components/WorkflowVariablesViewer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactJson from 'react-json-view';
 
-import { useTheme } from '@mui/material/styles';
+import { useTheme } from '@material-ui/core';
 
 import { ProcessInstanceVariables } from '@janus-idp/backstage-plugin-orchestrator-common';
 
@@ -24,7 +24,7 @@ export const WorkflowVariablesViewer: React.FC<ProcessVariablesViewerProps> = ({
     <ReactJson
       src={variables}
       name={false}
-      theme={theme.palette.mode === 'dark' ? 'monokai' : 'rjv-default'}
+      theme={theme.palette.type === 'dark' ? 'monokai' : 'rjv-default'}
     />
   );
 };

--- a/plugins/orchestrator/src/components/WorkflowsTabContent.tsx
+++ b/plugins/orchestrator/src/components/WorkflowsTabContent.tsx
@@ -7,7 +7,7 @@ import {
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
-import Grid from '@mui/material/Grid';
+import Grid from '@material-ui/core/Grid/Grid';
 
 import { WorkflowOverview } from '@janus-idp/backstage-plugin-orchestrator-common';
 

--- a/plugins/orchestrator/src/components/WorkflowsTable.tsx
+++ b/plugins/orchestrator/src/components/WorkflowsTable.tsx
@@ -4,8 +4,8 @@ import { useNavigate } from 'react-router-dom';
 import { Link, TableColumn, TableProps } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 
-import Pageview from '@mui/icons-material/Pageview';
-import PlayArrow from '@mui/icons-material/PlayArrow';
+import Pageview from '@material-ui/icons/Pageview';
+import PlayArrow from '@material-ui/icons/PlayArrow';
 
 import {
   capitalize,
@@ -62,13 +62,13 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
   const actions = useMemo(() => {
     const actionItems: TableProps<FormattedWorkflowOverview>['actions'] = [
       {
-        icon: () => <PlayArrow />,
+        icon: PlayArrow,
         tooltip: 'Execute',
         onClick: (_, rowData) =>
           handleExecute(rowData as FormattedWorkflowOverview),
       },
       {
-        icon: () => <Pageview />,
+        icon: Pageview,
         tooltip: 'View',
         onClick: (_, rowData) =>
           handleView(rowData as FormattedWorkflowOverview),

--- a/plugins/orchestrator/src/components/ui/OverrideBackstageTable.tsx
+++ b/plugins/orchestrator/src/components/ui/OverrideBackstageTable.tsx
@@ -5,26 +5,29 @@ import {
   TableProps,
 } from '@backstage/core-components';
 
-import { styled } from '@mui/material/styles';
+import { makeStyles } from '@material-ui/core';
 
 // Workaround by issue created from overriding the tab theme in the backstage-showcase to add a gray background to disabled tabs.
 // This is achieved by overriding the global Mui-disabled class, which results in the actions column header background turning gray.
 // See https://github.com/janus-idp/backstage-showcase/blob/main/packages/app/src/themes/componentOverrides.ts#L59
 
-const TableDiv = styled('div')({
-  '& .Mui-disabled': {
-    backgroundColor: 'transparent',
+const useStyles = makeStyles({
+  orchestratorTable: {
+    '& .Mui-disabled': {
+      backgroundColor: 'transparent',
+    },
   },
 });
 
 const OverrideBackstageTable = <T extends object>(props: TableProps<T>) => {
+  const classes = useStyles();
   return (
-    <TableDiv>
+    <div className={classes.orchestratorTable}>
       <BackstageTable
         {...props}
         options={{ ...props.options, thirdSortClick: false }}
       />
-    </TableDiv>
+    </div>
   );
 };
 

--- a/plugins/orchestrator/src/hooks/useWorkflowInstanceStatusColors.ts
+++ b/plugins/orchestrator/src/hooks/useWorkflowInstanceStatusColors.ts
@@ -1,4 +1,4 @@
-import { useTheme } from '@mui/material/styles';
+import { makeStyles } from '@material-ui/core';
 
 import {
   ProcessInstanceState,
@@ -8,14 +8,30 @@ import {
 export const useWorkflowInstanceStateColors = (
   value?: ProcessInstanceStateValues,
 ) => {
-  const theme = useTheme();
-  const colors = {
-    [ProcessInstanceState.Active]: theme.palette.primary.main,
-    [ProcessInstanceState.Completed]: theme.palette.success.main,
-    [ProcessInstanceState.Suspended]: theme.palette.warning.main,
-    [ProcessInstanceState.Aborted]: theme.palette.error.main,
-    [ProcessInstanceState.Error]: theme.palette.error.main,
-    [ProcessInstanceState.Pending]: theme.palette.grey[500],
-  };
-  return value ? colors[value] : undefined;
+  const useStyles = makeStyles(
+    theme =>
+      ({
+        [ProcessInstanceState.Active]: {
+          color: theme.palette.primary.main,
+        },
+        [ProcessInstanceState.Completed]: {
+          color: theme.palette.success.main,
+        },
+        [ProcessInstanceState.Suspended]: {
+          color: theme.palette.warning.main,
+        },
+        [ProcessInstanceState.Aborted]: {
+          color: theme.palette.error.main,
+        },
+        [ProcessInstanceState.Error]: {
+          color: theme.palette.error.main,
+        },
+        [ProcessInstanceState.Pending]: {
+          color: theme.palette.grey[500],
+        },
+      }) as const,
+  );
+
+  const styles = useStyles();
+  return value ? styles[value] : undefined;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9456,17 +9456,6 @@
     nanoid "^3.3.7"
     prop-types "^15.8.1"
 
-"@rjsf/core@^5.18.4":
-  version "5.18.4"
-  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.18.4.tgz#a0e5a77a54dd07bcd40dd287db7002b8973421f4"
-  integrity sha512-OUPC+l44X1geYT9sSsmQC2pakvFWCQB+5Iy/ITfLMJq3MIjJn0gakCwYHXMMBGUAKM1SSMIyKWyCazt3kY9fhg==
-  dependencies:
-    lodash "^4.17.21"
-    lodash-es "^4.17.21"
-    markdown-to-jsx "^7.4.1"
-    nanoid "^3.3.7"
-    prop-types "^15.8.1"
-
 "@rjsf/material-ui@5.17.1":
   version "5.17.1"
   resolved "https://registry.yarnpkg.com/@rjsf/material-ui/-/material-ui-5.17.1.tgz#009f31d0e8b0c5801bc858847060081a074e0a1d"
@@ -9476,11 +9465,6 @@
   version "5.18.3"
   resolved "https://registry.yarnpkg.com/@rjsf/mui/-/mui-5.18.3.tgz#25569fe9951795487813357f74ac3aeceb85aad6"
   integrity sha512-zcudsSECpm3hSTEjWsRLnrT5IMzG4Q3/muBaYtdlapzTaK0Mb3ktEPyXN+iZ6NjxZQTwH7aYn1vo/msbend4ww==
-
-"@rjsf/mui@^5.18.4":
-  version "5.18.4"
-  resolved "https://registry.yarnpkg.com/@rjsf/mui/-/mui-5.18.4.tgz#d81fa5aa189bab593866e4d4c30f9c3eddfe49c0"
-  integrity sha512-SDKBcp/LOCdb8Rn4f4mBiEV8M+FCFQWK8KB4ymyzqjB5/2sVf5rw9u7o84SSXmdnQKt4SAztQf3Sd8tLhEzvPg==
 
 "@rjsf/utils@5.17.1":
   version "5.17.1"
@@ -9504,17 +9488,6 @@
     lodash-es "^4.17.21"
     react-is "^18.2.0"
 
-"@rjsf/utils@^5.18.4":
-  version "5.18.4"
-  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.18.4.tgz#098c767f6bfbbf660f201d864bf8bba247453dfd"
-  integrity sha512-svLMk5aW6q3JQRYVTJradFc9tLeQ1vX5/k6fPwxf+08eweqPbINq7aokLBSStUNr8FfYgThTl8IfehLoVP2dvw==
-  dependencies:
-    json-schema-merge-allof "^0.8.1"
-    jsonpointer "^5.0.1"
-    lodash "^4.17.21"
-    lodash-es "^4.17.21"
-    react-is "^18.2.0"
-
 "@rjsf/validator-ajv8@5.17.1":
   version "5.17.1"
   resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.17.1.tgz#9b5e4b22f3ab47316c7a19da22639812e4a91193"
@@ -9529,16 +9502,6 @@
   version "5.18.3"
   resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.18.3.tgz#0e162f199c92869b7078cd5196fd9e971d3bff40"
   integrity sha512-geEVuNuYulHVUBnnkLCS7QZRvAuD1clOjuUbwNjFzSpnYHVO0+mvvi4uHTia/eSvRyDy4vdkxu320uPe4TsgeQ==
-  dependencies:
-    ajv "^8.12.0"
-    ajv-formats "^2.1.1"
-    lodash "^4.17.21"
-    lodash-es "^4.17.21"
-
-"@rjsf/validator-ajv8@^5.18.4":
-  version "5.18.4"
-  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.18.4.tgz#ffdf91f0641affc0b40b3259d07528cc5b147753"
-  integrity sha512-D0bUtruWbUmXG8z3VBbCky0Cx65rmcdG/QypB9ri5YTSNTQIxuq28StBpZUZn84CO/oMOtociGy4afW1aj5C0g==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"
@@ -33029,7 +32992,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -33116,7 +33088,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -33129,6 +33101,13 @@ strip-ansi@5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@6.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -35963,7 +35942,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -35976,6 +35955,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Revert https://github.com/janus-idp/backstage-plugins/pull/1727
Upgrade to material 5 proved to be none compatible with the dark theme. 
The only solution was to downgrade back to material 4. 
This also resolves issue of workflow run details not showing spaces correctly between fields
In addition, moved @rjsf and @material dependencies to peerDependencies to avoid conflicting versions.

Made the change only in 1.2.x branch, since main branch will be maintained in community plugins repo and we are still in the process of moving there.

resolves:

[FLPATH-1504](https://issues.redhat.com/browse/FLPATH-1504)
[FLPATH-1505](https://issues.redhat.com/browse/FLPATH-1505)
[FLPATH-1506](https://issues.redhat.com/browse/FLPATH-1506)
[FLPATH-1507](https://issues.redhat.com/browse/FLPATH-1507)

