### PR TITLE
Revert "chore: switch to ssh login for GH......

### DIFF
--- a/.github/actions/yarn-lock/action.yaml
+++ b/.github/actions/yarn-lock/action.yaml
@@ -30,9 +30,6 @@ runs:
           export GITHUB_TOKEN="${GITHUB_TOKEN}"
           set -x
           echo "$(git config user.name) <$(git config user.email)>"; echo; gh auth status
-          # switch to ssh login for GH repo
-          git config remote.origin.url git@github.com:$(git config remote.origin.url | sed -r -e "s#.+github.com(/|:)(.*)#\2#")
-          git config remote.origin.url
           git push origin "${PR_BRANCH}"
           gh pr create -B "${CURRENT_BRANCH}" -H "${PR_BRANCH}" --title "chore(deps): regen yarn.lock" --body "Created by Github action due to dirty workspace."
         fi


### PR DESCRIPTION
### What does this PR do?

Revert "chore: switch to ssh login for GH... (#2023)"

This reverts commit a775440c9333d50652153de3a6e17d3acc00963d.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.