### PR TITLE
fix(rbac): clean up policies when policies files are detached

### DIFF
--- a/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
@@ -92,7 +92,6 @@ export class CSVFileWatcher extends AbstractFileWatcher<string[][]> {
    */
   async initialize(): Promise<void> {
     if (!this.filePath) {
-      this.logger.info('csv policies file feature was disabled');
       return;
     }
     let content: string[][] = [];

--- a/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
@@ -475,7 +475,7 @@ export class CSVFileWatcher extends AbstractFileWatcher<string[][]> {
     this.csvFilePolicies.removedGroupPolicies = [];
   }
 
-  async cleanUpPolicies(): Promise<void> {
+  async cleanUpRolesAndPolicies(): Promise<void> {
     const roleMetadatas =
       await this.roleMetadataStorage.filterRoleMetadata('csv-file');
     const fileRoles = roleMetadatas.map(meta => meta.roleEntityRef);

--- a/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
@@ -485,10 +485,14 @@ export class CSVFileWatcher extends AbstractFileWatcher<string[][]> {
     const fileRoles = roleMetadatas.map(meta => meta.roleEntityRef);
 
     if (fileRoles.length > 0) {
-      this.csvFilePolicies.removedGroupPolicies =
-        await this.enforcer.getFilteredGroupingPolicy(1, ...fileRoles);
-      this.csvFilePolicies.removedPolicies =
-        await this.enforcer.getFilteredPolicy(0, ...fileRoles);
+      for (const fileRole of fileRoles) {
+        this.csvFilePolicies.removedGroupPolicies.push(
+          ...(await this.enforcer.getFilteredGroupingPolicy(1, fileRole)),
+        );
+        this.csvFilePolicies.removedPolicies.push(
+          ...(await this.enforcer.getFilteredPolicy(0, fileRole)),
+        );
+      }
     }
     await this.removePermissionPolicies();
     await this.removeRoles();

--- a/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
+++ b/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
@@ -474,4 +474,19 @@ export class CSVFileWatcher extends AbstractFileWatcher<string[][]> {
     }
     this.csvFilePolicies.removedGroupPolicies = [];
   }
+
+  async cleanUpPolicies(): Promise<void> {
+    const roleMetadatas =
+      await this.roleMetadataStorage.filterRoleMetadata('csv-file');
+    const fileRoles = roleMetadatas.map(meta => meta.roleEntityRef);
+
+    if (fileRoles.length > 0) {
+      this.csvFilePolicies.removedGroupPolicies =
+        await this.enforcer.getFilteredGroupingPolicy(1, ...fileRoles);
+      this.csvFilePolicies.removedPolicies =
+        await this.enforcer.getFilteredPolicy(0, ...fileRoles);
+    }
+    await this.removePermissionPolicies();
+    await this.removeRoles();
+  }
 }

--- a/plugins/rbac-backend/src/file-permissions/file-watcher.ts
+++ b/plugins/rbac-backend/src/file-permissions/file-watcher.ts
@@ -52,6 +52,4 @@ export abstract class AbstractFileWatcher<T> {
    * @returns The file parsed into a type <T>.
    */
   abstract parse(): T;
-
-  abstract cleanUpPolicies(): Promise<void>;
 }

--- a/plugins/rbac-backend/src/file-permissions/file-watcher.ts
+++ b/plugins/rbac-backend/src/file-permissions/file-watcher.ts
@@ -9,7 +9,7 @@ import fs from 'fs';
  */
 export abstract class AbstractFileWatcher<T> {
   constructor(
-    protected readonly filePath: string,
+    protected readonly filePath: string | undefined,
     protected readonly allowReload: boolean,
     protected readonly logger: LoggerService,
   ) {}
@@ -23,6 +23,9 @@ export abstract class AbstractFileWatcher<T> {
    * watchFile initializes the file watcher and sets it to begin watching for changes.
    */
   watchFile(): void {
+    if (!this.filePath) {
+      throw new Error('File path is not specified');
+    }
     const watcher = chokidar.watch(this.filePath);
     watcher.on('change', async path => {
       this.logger.info(`file ${path} has changed`);
@@ -44,6 +47,9 @@ export abstract class AbstractFileWatcher<T> {
    * @returns The current contents of the file.
    */
   getCurrentContents(): string {
+    if (!this.filePath) {
+      throw new Error('File path is not specified');
+    }
     return fs.readFileSync(this.filePath, 'utf-8');
   }
 

--- a/plugins/rbac-backend/src/file-permissions/file-watcher.ts
+++ b/plugins/rbac-backend/src/file-permissions/file-watcher.ts
@@ -52,4 +52,6 @@ export abstract class AbstractFileWatcher<T> {
    * @returns The file parsed into a type <T>.
    */
   abstract parse(): T;
+
+  abstract cleanUpPolicies(): Promise<void>;
 }

--- a/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -244,7 +244,7 @@ export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
     });
   }
 
-  async cleanUpPolicies(): Promise<void> {
+  async cleanUpConditionalPolicies(): Promise<void> {
     const csvFileRoles =
       await this.roleMetadataStorage.filterRoleMetadata('csv-file');
     const existedFileConds = (

--- a/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -55,7 +55,6 @@ export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
 
   async initialize(): Promise<void> {
     if (!this.filePath) {
-      this.logger.info('conditional policies file feature was disabled');
       return;
     }
     const fileExists = fs.existsSync(this.filePath);

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -270,31 +270,38 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       );
     }
 
+    const csvFile = new CSVFileWatcher(
+      policiesFile ?? '',
+      allowReload,
+      logger,
+      enforcerDelegate,
+      roleMetadataStorage,
+      auditLogger,
+    );
     if (policiesFile) {
-      const csvFile = new CSVFileWatcher(
-        policiesFile,
-        allowReload,
-        logger,
-        enforcerDelegate,
-        roleMetadataStorage,
-        auditLogger,
-      );
       await csvFile.initialize();
     }
 
+    const conditionalFile = new YamlConditinalPoliciesFileWatcher(
+      conditionalPoliciesFile ?? '',
+      allowReload,
+      logger,
+      conditionalStorage,
+      auditLogger,
+      auth,
+      pluginMetadataCollector,
+      roleMetadataStorage,
+      enforcerDelegate,
+    );
     if (conditionalPoliciesFile) {
-      const conditionalFile = new YamlConditinalPoliciesFileWatcher(
-        conditionalPoliciesFile,
-        allowReload,
-        logger,
-        conditionalStorage,
-        auditLogger,
-        auth,
-        pluginMetadataCollector,
-        roleMetadataStorage,
-        enforcerDelegate,
-      );
       await conditionalFile.initialize();
+    }
+
+    if (!conditionalPoliciesFile) {
+      await conditionalFile.cleanUpPolicies();
+    }
+    if (!policiesFile) {
+      await csvFile.cleanUpPolicies();
     }
 
     return new RBACPermissionPolicy(

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -295,12 +295,12 @@ export class RBACPermissionPolicy implements PermissionPolicy {
 
     if (!conditionalPoliciesFile) {
       // clean up conditional policies corresponding to roles from csv file
-      logger.info('csv policies file feature was disabled');
+      logger.info('conditional policies file feature was disabled');
       await conditionalFile.cleanUpConditionalPolicies();
     }
     if (!policiesFile) {
       // remove roles and policies from csv file
-      logger.info('conditional policies file feature was disabled');
+      logger.info('csv policies file feature was disabled');
       await csvFile.cleanUpRolesAndPolicies();
     }
 

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -271,19 +271,17 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     }
 
     const csvFile = new CSVFileWatcher(
-      policiesFile ?? '',
+      policiesFile,
       allowReload,
       logger,
       enforcerDelegate,
       roleMetadataStorage,
       auditLogger,
     );
-    if (policiesFile) {
-      await csvFile.initialize();
-    }
+    await csvFile.initialize();
 
     const conditionalFile = new YamlConditinalPoliciesFileWatcher(
-      conditionalPoliciesFile ?? '',
+      conditionalPoliciesFile,
       allowReload,
       logger,
       conditionalStorage,
@@ -293,9 +291,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       roleMetadataStorage,
       enforcerDelegate,
     );
-    if (conditionalPoliciesFile) {
-      await conditionalFile.initialize();
-    }
+    await conditionalFile.initialize();
 
     if (!conditionalPoliciesFile) {
       // clean up conditional policies corresponding to roles from csv file

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -298,10 +298,12 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     }
 
     if (!conditionalPoliciesFile) {
-      await conditionalFile.cleanUpPolicies();
+      // clean up conditional policies corresponding to roles from csv file
+      await conditionalFile.cleanUpConditionalPolicies();
     }
     if (!policiesFile) {
-      await csvFile.cleanUpPolicies();
+      // remove roles and policies from csv file
+      await csvFile.cleanUpRolesAndPolicies();
     }
 
     return new RBACPermissionPolicy(

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -295,10 +295,12 @@ export class RBACPermissionPolicy implements PermissionPolicy {
 
     if (!conditionalPoliciesFile) {
       // clean up conditional policies corresponding to roles from csv file
+      logger.info('csv policies file feature was disabled');
       await conditionalFile.cleanUpConditionalPolicies();
     }
     if (!policiesFile) {
       // remove roles and policies from csv file
+      logger.info('conditional policies file feature was disabled');
       await csvFile.cleanUpRolesAndPolicies();
     }
 


### PR DESCRIPTION
# What does pull request do:
Clean up RBAC conditional policies, permission policies, roles from files after removing external files from configuration

# What does this pull request fix:

https://issues.redhat.com/browse/RHIDP-3601