### PR TITLE
docs(ocm): fix instruction to start dev backend

### DIFF
--- a/plugins/ocm-backend/CONTRIBUTING.md
+++ b/plugins/ocm-backend/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 You can run a development setup using the following command:
 
 ```console
-yarn workspace @janus-idp/backstage-plugin-ocm-backend run start
+LEGACY_BACKEND_START=true yarn workspace @janus-idp/backstage-plugin-ocm-backend run start
 ```
 
 When you run the previous command, the Kubernetes API is mocked to provide two clusters: `foo` (works as the hub) and `cluster1`. Also, an error response is mocked for non-existent clusters.

--- a/plugins/ocm/CONTRIBUTING.md
+++ b/plugins/ocm/CONTRIBUTING.md
@@ -7,7 +7,7 @@ To start a development setup in isolation with a faster setup and hot reloads, c
 1. Run the `ocm-backend` plugin in the `plugins/ocm-backend` directory by executing the following command:
 
    ```console
-   yarn start
+   LEGACY_BACKEND_START=true yarn start
    ```
 
 2. Run the `ocm` frontend plugin in the `plugins/ocm` directory using the following command:


### PR DESCRIPTION
## Description
Fixes outdated instruction to start development environment for OCM backend plugin.