### PR TITLE
fix(ocm): call OCM only for kubernetes-cluster entities

### DIFF
--- a/plugins/ocm/src/components/ClusterContext/ClusterContext.test.tsx
+++ b/plugins/ocm/src/components/ClusterContext/ClusterContext.test.tsx
@@ -1,27 +1,31 @@
 import React from 'react';
 
+import { useEntity } from '@backstage/plugin-catalog-react';
+
 import { render } from '@testing-library/react';
 
 import data from '../../../__fixtures__/cluster1.json';
 import { ClusterContextProvider } from './ClusterContext';
+
+const mockEntity = {
+  apiVersion: 'backstage.io/v1beta1',
+  kind: 'Resource',
+  spec: { owner: 'unknown', type: 'kubernetes-cluster' },
+  metadata: {
+    name: 'foo',
+    namespace: 'default',
+    annotations: {
+      'janus-idp.io/ocm-provider-id': 'hub',
+    },
+  },
+};
 
 jest.mock('../ClusterContext/', () => ({
   useCluster: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('@backstage/plugin-catalog-react', () => ({
-  useEntity: () => ({
-    apiVersion: 'backstage.io/v1beta1',
-    kind: 'Resource',
-    spec: { owner: 'unknown', type: 'kubernetes-cluster' },
-    metadata: {
-      name: 'foo',
-      namespace: 'default',
-      annotations: {
-        'janus-idp.io/ocm-provider-id': 'hub',
-      },
-    },
-  }),
+  useEntity: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('@backstage/core-plugin-api', () => ({
@@ -32,7 +36,12 @@ jest.mock('@backstage/core-plugin-api', () => ({
 }));
 
 describe('ClusterContext', () => {
+  beforeEach(() => {
+    (useEntity as jest.Mock).mockClear();
+  });
+
   it('should render children', () => {
+    (useEntity as jest.Mock).mockReturnValue({ entity: mockEntity });
     const { getByText } = render(
       <ClusterContextProvider>Child</ClusterContextProvider>,
     );

--- a/plugins/ocm/src/components/ClusterContext/ClusterContext.tsx
+++ b/plugins/ocm/src/components/ClusterContext/ClusterContext.tsx
@@ -59,6 +59,10 @@ export const ClusterContextProvider = (props: any) => {
     [cluster, isError, loading, error],
   );
 
+  if (!providerId) {
+    return <>{props.children}</>;
+  }
+
   return (
     <ClusterContext.Provider value={value}>
       {props.children}

--- a/plugins/ocm/src/components/ClusterContext/ClusterContext.tsx
+++ b/plugins/ocm/src/components/ClusterContext/ClusterContext.tsx
@@ -26,16 +26,19 @@ const ClusterContext = createContext<ClusterContextType>(
 export const ClusterContextProvider = (props: any) => {
   const { entity } = useEntity();
   const ocmApi = useApi(OcmApiRef);
+  const providerId = entity.metadata.annotations![ANNOTATION_PROVIDER_ID];
   const [{ value: cluster, loading, error: asyncError }, refresh] = useAsyncFn(
     async () => {
-      const providerId = entity.metadata.annotations![ANNOTATION_PROVIDER_ID];
-      const cl = await ocmApi.getClusterByName(
-        providerId,
-        entity.metadata.name,
-      );
-      return cl;
+      if (providerId) {
+        const cl = await ocmApi.getClusterByName(
+          providerId,
+          entity.metadata.name,
+        );
+        return cl;
+      }
+      return null;
     },
-    [],
+    [providerId, entity.metadata.name],
     { loading: true },
   );
   useDebounce(refresh, 10);


### PR DESCRIPTION
## Description
This is a temporary fix to not call OCM on `entity.page.overview` mount for entities without `isType: kubernetes-cluster`.
Will need to sync with someone from dynamic plugins about context mounting, as `if` is supported only for `cards`.

## Fixes
https://issues.redhat.com/browse/RHIDP-2438