### PR TITLE
fix(cli): support BackendFeatureCompat in export-dynamic cli

### DIFF
--- a/packages/cli/src/commands/export-dynamic-plugin/backend-utils.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-utils.ts
@@ -109,7 +109,7 @@ export function isValidPluginModule(pluginModule: any): boolean {
 function isBackendFeature(value: unknown): boolean {
   return (
     !!value &&
-    typeof value === 'object' &&
+    (typeof value === 'object' || typeof value === 'function') &&
     (value as any).$$type === '@backstage/BackendFeature'
   );
 }


### PR DESCRIPTION
This is as a result of a new [change](https://backstage.io/docs/reference/backend-plugin-api.createbackendmodule) where createBackendModule() now returns `BackendFeatureCompat`, which can have a call signature/ can be a function. This change allows both the old and new behaviour to be recognized as valid backend features. 

Fixes [RHIDP-2529](https://issues.redhat.com/browse/RHIDP-2529)
* More details on the error in the issue

Tested this change locally and can confirm that the `yarn export-dynamic` cli now succeeds with no errors