### PR TITLE
fix(rbac): validate name and namespace of entities

### DIFF
--- a/plugins/rbac-backend/src/validation/policies-validation.test.ts
+++ b/plugins/rbac-backend/src/validation/policies-validation.test.ts
@@ -203,6 +203,10 @@ describe('rest data validation', () => {
           ref: 'admin:default/test',
           expectedError: `Unsupported kind admin. List supported values ["user", "group", "role"]`,
         },
+        {
+          ref: 'user:default/doe/developer',
+          expectedError: `The name and namespace in the entity reference 'user:default/doe/developer' must not contain '/'`,
+        },
       ];
       for (const entityRef of invalidOrUnsupportedEntityRefs) {
         const err = validateEntityReference(entityRef.ref);
@@ -215,7 +219,6 @@ describe('rest data validation', () => {
       const invalidOrUnsupportedEntityRefs = [
         'user:default/guest',
         'user:default/John Doe',
-        'user:default/John Doe/developer',
         'role:default/team-a',
       ];
       for (const entityRef of invalidOrUnsupportedEntityRefs) {

--- a/plugins/rbac-backend/src/validation/policies-validation.test.ts
+++ b/plugins/rbac-backend/src/validation/policies-validation.test.ts
@@ -203,10 +203,6 @@ describe('rest data validation', () => {
           ref: 'admin:default/test',
           expectedError: `Unsupported kind admin. List supported values ["user", "group", "role"]`,
         },
-        {
-          ref: 'user:default/doe/developer',
-          expectedError: `The name and namespace in the entity reference 'user:default/doe/developer' must not contain '/'`,
-        },
       ];
       for (const entityRef of invalidOrUnsupportedEntityRefs) {
         const err = validateEntityReference(entityRef.ref);
@@ -215,13 +211,53 @@ describe('rest data validation', () => {
       }
     });
 
-    it('should pass entity reference validation', () => {
-      const invalidOrUnsupportedEntityRefs = [
-        'user:default/guest',
-        'user:default/John Doe',
-        'role:default/team-a',
+    it('should return an error when entity reference name is invalid', () => {
+      const invalidEntityNames = [
+        'john@doe',
+        'John Doe',
+        'John/Doe',
+        'invalid-',
+        'invalid_',
+        '.invalid',
+        `too-long${'1'.repeat(60)}`,
       ];
-      for (const entityRef of invalidOrUnsupportedEntityRefs) {
+
+      for (const invalidName of invalidEntityNames) {
+        const expectedError = `The name '${invalidName}' in the entity reference must be a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total`;
+        const entityRef = `user:default/${invalidName}`;
+        const err = validateEntityReference(entityRef);
+        expect(err).toBeTruthy();
+        expect(err?.message).toEqual(expectedError);
+      }
+    });
+
+    it('should return an error when entity reference namespace is invalid', () => {
+      const invalidEntityNamespaces = [
+        'INVALID',
+        'invalid-',
+        '-invalid',
+        'invalid$namespace',
+        `too-long${'1'.repeat(60)}`,
+      ];
+
+      for (const invalidNamespace of invalidEntityNamespaces) {
+        const expectedError = `The namespace '${invalidNamespace}' in the entity reference must be a string that is sequences of [a-z0-9] separated by [-], at most 63 characters in total`;
+        const entityRef = `user:${invalidNamespace}/doe`;
+        const err = validateEntityReference(entityRef);
+        expect(err).toBeTruthy();
+        expect(err?.message).toEqual(expectedError);
+      }
+    });
+
+    it('should pass entity reference validation', () => {
+      const validEntityRefs = [
+        'user:default/guest',
+        'role:default/team-a',
+        'role:default/team_1',
+        'role:default/team.A',
+        'role:custom-1/doe',
+      ];
+      for (const entityRef of validEntityRefs) {
         const err = validateEntityReference(entityRef);
         expect(err).toBeFalsy();
       }

--- a/plugins/rbac-backend/src/validation/policies-validation.ts
+++ b/plugins/rbac-backend/src/validation/policies-validation.ts
@@ -109,6 +109,16 @@ function isValidEffectValue(effect: string): boolean {
   );
 }
 
+function isValidEntityName(name: string): boolean {
+  const validNamePattern = /^[a-zA-Z0-9]+([._-][a-zA-Z0-9]+)*$/;
+  return validNamePattern.test(name) && name.length <= 63;
+}
+
+function isValidEntityNamespace(namespace: string): boolean {
+  const validNamespacePattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+  return validNamespacePattern.test(namespace) && namespace.length <= 63;
+}
+
 // We supports only full form entity reference: [<kind>:][<namespace>/]<name>
 export function validateEntityReference(
   entityRef?: string,
@@ -148,12 +158,15 @@ export function validateEntityReference(
     );
   }
 
-  if (
-    entityRefCompound.name.includes('/') ||
-    entityRefCompound.namespace.includes('/')
-  ) {
+  if (!isValidEntityName(entityRefCompound.name)) {
     return new Error(
-      `The name and namespace in the entity reference '${entityRef}' must not contain '/'`,
+      `The name '${entityRefCompound.name}' in the entity reference must be a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total`,
+    );
+  }
+
+  if (!isValidEntityNamespace(entityRefCompound.namespace)) {
+    return new Error(
+      `The namespace '${entityRefCompound.namespace}' in the entity reference must be a string that is sequences of [a-z0-9] separated by [-], at most 63 characters in total`,
     );
   }
 

--- a/plugins/rbac-backend/src/validation/policies-validation.ts
+++ b/plugins/rbac-backend/src/validation/policies-validation.ts
@@ -148,6 +148,15 @@ export function validateEntityReference(
     );
   }
 
+  if (
+    entityRefCompound.name.includes('/') ||
+    entityRefCompound.namespace.includes('/')
+  ) {
+    return new Error(
+      `The name and namespace in the entity reference '${entityRef}' must not contain '/'`,
+    );
+  }
+
   return undefined;
 }
 

--- a/plugins/rbac/src/api/RBACBackendClient.ts
+++ b/plugins/rbac/src/api/RBACBackendClient.ts
@@ -1,3 +1,4 @@
+import { parseEntityRef } from '@backstage/catalog-model';
 import {
   ConfigApi,
   createApiRef,
@@ -18,7 +19,6 @@ import {
   RoleBasedConditions,
   RoleError,
 } from '../types';
-import { getKindNamespaceName } from '../utils/rbac-utils';
 
 // @public
 export type RBACAPI = {
@@ -122,7 +122,7 @@ export class RBACBackendClient implements RBACAPI {
   }
 
   async getAssociatedPolicies(entityReference: string) {
-    const { kind, namespace, name } = getKindNamespaceName(entityReference);
+    const { kind, namespace, name } = parseEntityRef(entityReference);
     const { token: idToken } = await this.identityApi.getCredentials();
     const backendUrl = this.configApi.getString('backend.baseUrl');
     const jsonResponse = await fetch(
@@ -142,7 +142,7 @@ export class RBACBackendClient implements RBACAPI {
   async deleteRole(role: string) {
     const { token: idToken } = await this.identityApi.getCredentials();
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const { kind, namespace, name } = getKindNamespaceName(role);
+    const { kind, namespace, name } = parseEntityRef(role);
     const jsonResponse = await fetch(
       `${backendUrl}/api/permission/roles/${kind}/${namespace}/${name}`,
       {
@@ -159,7 +159,7 @@ export class RBACBackendClient implements RBACAPI {
   async getRole(role: string) {
     const { token: idToken } = await this.identityApi.getCredentials();
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const { kind, namespace, name } = getKindNamespaceName(role);
+    const { kind, namespace, name } = parseEntityRef(role);
     const jsonResponse = await fetch(
       `${backendUrl}/api/permission/roles/${kind}/${namespace}/${name}`,
       {
@@ -232,7 +232,7 @@ export class RBACBackendClient implements RBACAPI {
   async updateRole(oldRole: Role, newRole: Role) {
     const { token: idToken } = await this.identityApi.getCredentials();
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const { kind, namespace, name } = getKindNamespaceName(oldRole.name);
+    const { kind, namespace, name } = parseEntityRef(oldRole.name);
     const body = {
       oldRole,
       newRole,
@@ -266,7 +266,7 @@ export class RBACBackendClient implements RBACAPI {
   ) {
     const { token: idToken } = await this.identityApi.getCredentials();
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const { kind, namespace, name } = getKindNamespaceName(entityReference);
+    const { kind, namespace, name } = parseEntityRef(entityReference);
     const body = {
       oldPolicy: oldPolicies,
       newPolicy: newPolicies,
@@ -292,7 +292,7 @@ export class RBACBackendClient implements RBACAPI {
   async deletePolicies(entityReference: string, policies: RoleBasedPolicy[]) {
     const { token: idToken } = await this.identityApi.getCredentials();
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const { kind, namespace, name } = getKindNamespaceName(entityReference);
+    const { kind, namespace, name } = parseEntityRef(entityReference);
     const jsonResponse = await fetch(
       `${backendUrl}/api/permission/policies/${kind}/${namespace}/${name}`,
       {

--- a/plugins/rbac/src/components/CreateRole/AddedMembersTable.test.tsx
+++ b/plugins/rbac/src/components/CreateRole/AddedMembersTable.test.tsx
@@ -15,14 +15,14 @@ const selectedMembers: SelectedMember[] = [
     label: 'User 1',
     etag: 'etag-1',
     type: 'User',
-    ref: 'role/:user/:testns1/:testuser1',
+    ref: 'user:default/user-1',
   },
   {
     id: 'test-2',
     label: 'Group 1',
     etag: 'etag-2',
     type: 'Group',
-    ref: 'role/:group/testns1/testgroup1',
+    ref: 'group:default/test-2',
   },
 ];
 

--- a/plugins/rbac/src/components/CreateRole/AddedMembersTableColumn.tsx
+++ b/plugins/rbac/src/components/CreateRole/AddedMembersTableColumn.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
+import { parseEntityRef } from '@backstage/catalog-model';
 import { Link, TableColumn } from '@backstage/core-components';
 
 import { IconButton } from '@material-ui/core';
 import Delete from '@mui/icons-material/Delete';
 import { FormikErrors } from 'formik';
 
-import { getKindNamespaceName } from '../../utils/rbac-utils';
 import { RoleFormValues, SelectedMember } from './types';
 
 export const reviewStepMemebersTableColumns = () => [
@@ -53,7 +53,7 @@ export const selectedMembersColumns = (
       field: 'label',
       type: 'string',
       render: props => {
-        const { kind, namespace, name } = getKindNamespaceName(props.ref);
+        const { kind, namespace, name } = parseEntityRef(props.ref);
         return (
           <Link to={`/catalog/${namespace}/${kind}/${name}`} target="blank">
             {props.label}

--- a/plugins/rbac/src/components/CreateRole/RoleForm.tsx
+++ b/plugins/rbac/src/components/CreateRole/RoleForm.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { parseEntityRef } from '@backstage/catalog-model';
 import { SimpleStepper, SimpleStepperStep } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
@@ -27,11 +28,7 @@ import {
   getUpdatedConditionalPolicies,
   validationSchema,
 } from '../../utils/create-role-utils';
-import {
-  getKindNamespaceName,
-  isSamePermissionPolicy,
-  onlyInLeft,
-} from '../../utils/rbac-utils';
+import { isSamePermissionPolicy, onlyInLeft } from '../../utils/rbac-utils';
 import {
   createConditions,
   createPermissions,
@@ -77,7 +74,7 @@ export const RoleForm = ({
       ? { state: { toastMessage: `Role ${action} successfully` } }
       : { state: { toastMessage: '' } };
     if (step && roleName) {
-      const { kind, namespace, name } = getKindNamespaceName(roleName);
+      const { kind, namespace, name } = parseEntityRef(roleName);
       navigate(`../roles/${kind}/${namespace}/${name}`, stateProp);
     } else {
       navigate('..', stateProp);

--- a/plugins/rbac/src/components/EditRole.test.tsx
+++ b/plugins/rbac/src/components/EditRole.test.tsx
@@ -7,10 +7,13 @@ import '@testing-library/jest-dom';
 
 import EditRole from './EditRole';
 
-jest.mock('../utils/rbac-utils', () => ({
-  getKindNamespaceName: jest
-    .fn()
-    .mockReturnValue({ name: 'roleName', namespace: 'default', kind: 'Role' }),
+jest.mock('@backstage/catalog-model', () => ({
+  ...jest.requireActual('@backstage/catalog-model'),
+  parseEntityRef: jest.fn().mockReturnValue({
+    name: 'roleName',
+    namespace: 'default',
+    kind: 'Role',
+  }),
 }));
 
 describe('EditRole', () => {

--- a/plugins/rbac/src/components/EditRole.tsx
+++ b/plugins/rbac/src/components/EditRole.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 
+import { parseEntityRef } from '@backstage/catalog-model';
 import { Link } from '@backstage/core-components';
 
 import { IconButton, Tooltip } from '@material-ui/core';
 import EditIcon from '@material-ui/icons/Edit';
-
-import { getKindNamespaceName } from '../utils/rbac-utils';
 
 type EditRoleProps = {
   roleName: string;
@@ -22,7 +21,7 @@ const EditRole = ({
   dataTestId,
   to,
 }: EditRoleProps) => {
-  const { name, namespace, kind } = getKindNamespaceName(roleName);
+  const { name, namespace, kind } = parseEntityRef(roleName);
   return (
     <Tooltip title={tooltip || ''}>
       <span data-testid={dataTestId}>

--- a/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
+++ b/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { parseEntityRef } from '@backstage/catalog-model';
 import { Table, WarningPanel } from '@backstage/core-components';
 import { usePermission } from '@backstage/plugin-permission-react';
 
@@ -10,7 +11,7 @@ import { policyEntityUpdatePermission } from '@janus-idp/backstage-plugin-rbac-c
 
 import { MembersInfo } from '../../hooks/useMembers';
 import { MembersData } from '../../types';
-import { getKindNamespaceName, getMembers } from '../../utils/rbac-utils';
+import { getMembers } from '../../utils/rbac-utils';
 import EditRole from '../EditRole';
 import { columns } from './MembersListColumns';
 
@@ -29,7 +30,7 @@ const useStyles = makeStyles(theme => ({
 
 const getRefreshIcon = () => <CachedIcon />;
 const getEditIcon = (isAllowed: boolean, roleName: string) => {
-  const { kind, name, namespace } = getKindNamespaceName(roleName);
+  const { kind, name, namespace } = parseEntityRef(roleName);
 
   return (
     <EditRole

--- a/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
+++ b/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { parseEntityRef } from '@backstage/catalog-model';
 import { Table, WarningPanel } from '@backstage/core-components';
 import { usePermission } from '@backstage/plugin-permission-react';
 
@@ -10,7 +11,6 @@ import { policyEntityUpdatePermission } from '@janus-idp/backstage-plugin-rbac-c
 
 import { usePermissionPolicies } from '../../hooks/usePermissionPolicies';
 import { PermissionsData } from '../../types';
-import { getKindNamespaceName } from '../../utils/rbac-utils';
 import EditRole from '../EditRole';
 import { columns } from './PermissionsListColumns';
 
@@ -29,7 +29,7 @@ type PermissionsCardProps = {
 
 const getRefreshIcon = () => <CachedIcon />;
 const getEditIcon = (isAllowed: boolean, roleName: string) => {
-  const { kind, name, namespace } = getKindNamespaceName(roleName);
+  const { kind, name, namespace } = parseEntityRef(roleName);
 
   return (
     <EditRole

--- a/plugins/rbac/src/components/RolesList/RolesListColumns.tsx
+++ b/plugins/rbac/src/components/RolesList/RolesListColumns.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
+import { parseEntityRef } from '@backstage/catalog-model';
 import { Link, TableColumn } from '@backstage/core-components';
 
 import { Tooltip, Typography } from '@material-ui/core';
 
 import { RolesData } from '../../types';
-import { getKindNamespaceName, getMembers } from '../../utils/rbac-utils';
+import { getMembers } from '../../utils/rbac-utils';
 import EditRole from '../EditRole';
 import DeleteRole from './DeleteRole';
 
@@ -15,7 +16,7 @@ export const columns: TableColumn<RolesData>[] = [
     field: 'name',
     type: 'string',
     render: (props: RolesData) => {
-      const { kind, namespace, name } = getKindNamespaceName(props.name);
+      const { kind, namespace, name } = parseEntityRef(props.name);
       return (
         <Link to={`roles/${kind}/${namespace}/${name}`}>{props.name}</Link>
       );

--- a/plugins/rbac/src/hooks/useMembers.ts
+++ b/plugins/rbac/src/hooks/useMembers.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useAsyncRetry, useInterval } from 'react-use';
 
-import { stringifyEntityRef } from '@backstage/catalog-model';
+import { parseEntityRef, stringifyEntityRef } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 
 import { rbacApiRef } from '../api/RBACBackendClient';
 import { MemberEntity, MembersData } from '../types';
-import { getKindNamespaceName, getMembersFromGroup } from '../utils/rbac-utils';
+import { getMembersFromGroup } from '../utils/rbac-utils';
 
 export type MembersInfo = {
   loading: boolean;
@@ -53,7 +53,7 @@ const getMemberData = (
           : 0,
     };
   }
-  const { kind, namespace, name } = getKindNamespaceName(ref);
+  const { kind, namespace, name } = parseEntityRef(ref);
   return {
     name,
     type: kind === 'user' ? 'User' : ('Group' as 'User' | 'Group'),

--- a/plugins/rbac/src/utils/rbac-utils.test.ts
+++ b/plugins/rbac/src/utils/rbac-utils.test.ts
@@ -16,7 +16,6 @@ import {
   getConditionalPermissionsData,
   getConditionsData,
   getConditionUpperCriteria,
-  getKindNamespaceName,
   getMembers,
   getMembersFromGroup,
   getPermissions,
@@ -183,19 +182,6 @@ describe('rbac utils', () => {
     expect(
       getPluginInfo(mockPermissionPolicies, 'scaffolder-template').isResourced,
     ).toBe(true);
-  });
-
-  it('should return kind, namespace and name from the reference', () => {
-    expect(getKindNamespaceName('role:default/xyz')).toEqual({
-      kind: 'role',
-      namespace: 'default',
-      name: 'xyz',
-    });
-    expect(getKindNamespaceName('role:abc/test')).toEqual({
-      kind: 'role',
-      namespace: 'abc',
-      name: 'test',
-    });
   });
 
   it('should return the permissions data', () => {

--- a/plugins/rbac/src/utils/rbac-utils.ts
+++ b/plugins/rbac/src/utils/rbac-utils.ts
@@ -333,11 +333,7 @@ export const getConditionalPermissionsData = (
 };
 
 export const getKindNamespaceName = (roleRef: string) => {
-  const refs: string[] = roleRef.split(':');
-  const kind = refs[0];
-  const namespace = refs[1].split('/')[0];
-  const name = refs[1].split('/')[1];
-  return { kind, namespace, name };
+  return parseEntityRef(roleRef);
 };
 
 export const getSelectedMember = (

--- a/plugins/rbac/src/utils/rbac-utils.ts
+++ b/plugins/rbac/src/utils/rbac-utils.ts
@@ -332,10 +332,6 @@ export const getConditionalPermissionsData = (
   }, []);
 };
 
-export const getKindNamespaceName = (roleRef: string) => {
-  return parseEntityRef(roleRef);
-};
-
 export const getSelectedMember = (
   memberResource: MemberEntity | undefined,
   ref: string,
@@ -353,7 +349,7 @@ export const getSelectedMember = (
       members: getMembersCount(memberResource),
     };
   } else if (ref) {
-    const { kind, namespace, name } = getKindNamespaceName(ref);
+    const { kind, namespace, name } = parseEntityRef(ref);
     return {
       id: `${kind}-${namespace}-${name}`,
       ref,


### PR DESCRIPTION
## Description
Creating role with name that contains ':' or '/' creates role that can't be used.

Invalidate names that does not conform with format:
- Strings of length at least 1, and at most 63
- Must consist of sequences of [a-z0-9A-Z] possibly separated by one of [-_.]

Invalidate namespaces that does not conform with format:
- must be sequences of [a-zA-Z0-9], possibly separated by -, at most 63 characters in total.  

Deletes function `getKindNamespaceName` and uses instead more robust `parseEntityRef`. This change was originally introduced to support `:`, can be reverted.

Reference:
https://backstage.io/docs/features/software-catalog/descriptor-format/#name-required

## Fixes
https://issues.redhat.com/browse/RHIDP-3580
