### PR TITLE
chore: start frontend and backend with yarn dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -455,7 +455,7 @@ Backstage's support for standalone plugin development is minimal (especially for
        packages/app/package.json \
        packages/app/src/components/catalog/EntityPage.tsx
    ```
-4. Run `yarn start:backstage`
+4. Run `yarn dev`
 
 ### Standalone standalone plugin development
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "preinstall": "npx only-allow yarn",
+    "dev": "turbo run start --filter=...app --filter=...backend",
     "start:backend": "turbo run start --filter=...backend",
     "start:backstage": "turbo run start --filter=...app --filter=...backend",
     "start:plugins": "turbo run start --filter=@janus-idp/*",

--- a/plugins/kiali/DEVELOPMENT.md
+++ b/plugins/kiali/DEVELOPMENT.md
@@ -93,7 +93,7 @@
        dangerouslyDisableDefaultAuthPolicy: true
    ```
 
-7. Run `yarn start:backstage` from the project root.
+7. Run `yarn dev` from the project root.
 8. After create a new component, the Kiali tab should be enabled:
 
 ![catalog-list](./images/kiali-tab-backstage.png)


### PR DESCRIPTION
One extra run script that makes it easier to switch between backstage/rhdh projects.

Adds `yarn dev` to start frontend and backend together.

`yarn start:backstage` still work, of course.