### PR TITLE
feat(bulk-import): allow skipping the CODEOWNERS dry-run check [RHIDP-3339]

### DIFF
--- a/plugins/bulk-import-backend/api-docs/Models/ImportRequest.md
+++ b/plugins/bulk-import-backend/api-docs/Models/ImportRequest.md
@@ -5,6 +5,7 @@
 |------------ | ------------- | ------------- | -------------|
 | **approvalTool** | [**ApprovalTool**](ApprovalTool.md) |  | [optional] [default to null] |
 | **catalogEntityName** | **String** | Expected Entity name in the catalog. Relevant only if the &#39;dryRun&#39; query parameter is set to &#39;true&#39;. | [optional] [default to null] |
+| **codeOwnersFileAsEntityOwner** | **Boolean** | Whether the CODEOWNERS file will be used as entity owner. Only relevant for dry-run requests. If set to &#39;false&#39;, the corresponding dry-run check will be skipped. | [optional] [default to null] |
 | **repository** | [**ImportRequest_repository**](ImportRequest_repository.md) |  | [default to null] |
 | **catalogInfoContent** | **String** | content of the catalog-info.yaml to include in the import Pull Request. | [optional] [default to null] |
 | **github** | [**ImportRequest_github**](ImportRequest_github.md) |  | [optional] [default to null] |

--- a/plugins/bulk-import-backend/src/openapi.d.ts
+++ b/plugins/bulk-import-backend/src/openapi.d.ts
@@ -65,6 +65,10 @@ declare namespace Components {
              * Expected Entity name in the catalog. Relevant only if the 'dryRun' query parameter is set to 'true'.
              */
             catalogEntityName?: string;
+            /**
+             * Whether the CODEOWNERS file will be used as entity owner. Only relevant for dry-run requests. If set to 'false', the corresponding dry-run check will be skipped.
+             */
+            codeOwnersFileAsEntityOwner?: boolean;
             repository: {
                 /**
                  * repository name

--- a/plugins/bulk-import-backend/src/openapidocument.ts
+++ b/plugins/bulk-import-backend/src/openapidocument.ts
@@ -726,6 +726,10 @@ const OPENAPI = `
             "type": "string",
             "description": "Expected Entity name in the catalog. Relevant only if the 'dryRun' query parameter is set to 'true'."
           },
+          "codeOwnersFileAsEntityOwner": {
+            "type": "boolean",
+            "description": "Whether the CODEOWNERS file will be used as entity owner. Only relevant for dry-run requests. If set to 'false', the corresponding dry-run check will be skipped."
+          },
           "repository": {
             "type": "object",
             "required": [

--- a/plugins/bulk-import-backend/src/schema/openapi.yaml
+++ b/plugins/bulk-import-backend/src/schema/openapi.yaml
@@ -491,6 +491,9 @@ components:
         catalogEntityName:
           type: string
           description: Expected Entity name in the catalog. Relevant only if the 'dryRun' query parameter is set to 'true'.
+        codeOwnersFileAsEntityOwner:
+          type: boolean
+          description: Whether the CODEOWNERS file will be used as entity owner. Only relevant for dry-run requests. If set to 'false', the corresponding dry-run check will be skipped.
         repository:
           type: object
           required:

--- a/plugins/bulk-import-backend/src/service/router.test.ts
+++ b/plugins/bulk-import-backend/src/service/router.test.ts
@@ -1055,7 +1055,7 @@ spec:
             input: {
               repoUrl: string;
             },
-          ) => input.repoUrl !== 'https://github.com/my-org-ent-2/my-repo-c',
+          ) => input.repoUrl !== 'https://github.com/my-org-ent-2/my-repo-d',
         );
 
       const response = await request(app)
@@ -1083,6 +1083,14 @@ spec:
               defaultBranch: 'trunk',
             },
           },
+          {
+            catalogEntityName: 'my-entity-d',
+            codeOwnersFileAsEntityOwner: true,
+            repository: {
+              url: 'https://github.com/my-org-ent-2/my-repo-d',
+              defaultBranch: 'devBranch',
+            },
+          },
         ]);
       expect(response.status).toEqual(202);
       expect(response.body).toEqual([
@@ -1107,11 +1115,20 @@ spec:
           },
         },
         {
-          errors: ['CODEOWNERS_FILE_NOT_FOUND_IN_REPO', 'REPO_EMPTY'],
+          errors: ['REPO_EMPTY'],
           catalogEntityName: 'my-entity-c',
           repository: {
             url: 'https://github.com/my-org-ent-2/my-repo-c',
             name: 'my-repo-c',
+            organization: 'my-org-ent-2',
+          },
+        },
+        {
+          errors: ['CODEOWNERS_FILE_NOT_FOUND_IN_REPO'],
+          catalogEntityName: 'my-entity-d',
+          repository: {
+            url: 'https://github.com/my-org-ent-2/my-repo-d',
+            name: 'my-repo-d',
             organization: 'my-org-ent-2',
           },
         },


### PR DESCRIPTION
**What does this PR do / why we need it:**

This PR is an addendum to https://github.com/janus-idp/backstage-plugins/pull/1979
Currently, the dry-run operation always checks for the presence of a CODEOWNERS file. We want to skip this check if the client does not request it explicitly.
This is needed in the UI. Otherwise, the UI will not allow creating a bulk import PR even if the user did not select the checkbox to use the CODEOWNERS file as entity owner.

To support this, a new `codeOwnersFileAsEntityOwner` field has been added to each item in the ImportRequest object.

**Which issue(s) this PR fixes:**

ref https://issues.redhat.com/browse/RHIDP-3339

**PR acceptance criteria:**

- [x] Unit tests

- [ ] Integration tests

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**

/cc @debsmita1 @ciiay 