### PR TITLE
feat(bulk-import): improve performance of the `GET /imports` endpoint [RHIDP-3680]

### DIFF
--- a/plugins/bulk-import-backend/src/helpers/catalogInfoGenerator.ts
+++ b/plugins/bulk-import-backend/src/helpers/catalogInfoGenerator.ts
@@ -92,8 +92,12 @@ ${jsYaml.dump(generatedEntity.entity)}`,
       .join('\n');
   }
 
-  getCatalogUrl(repoUrl: string, defaultBranch: string = 'main'): string {
-    return `${repoUrl}/blob/${defaultBranch}/catalog-info.yaml`;
+  getCatalogUrl(
+    config: Config,
+    repoUrl: string,
+    defaultBranch: string = 'main',
+  ): string {
+    return `${repoUrl}/blob/${defaultBranch}/${getCatalogFilename(config)}`;
   }
 
   async listCatalogUrlLocations(): Promise<string[]> {

--- a/plugins/bulk-import-backend/src/helpers/catalogInfoGenerator.ts
+++ b/plugins/bulk-import-backend/src/helpers/catalogInfoGenerator.ts
@@ -121,7 +121,9 @@ ${jsYaml.dump(generatedEntity.entity)}`,
     if (Array.isArray(locations)) {
       return new Map(
         locations
-          .filter(location => location.data.type === 'url')
+          .filter(
+            location => location.data?.target && location.data?.type === 'url',
+          )
           .map(location => [location.data.id, location.data.target]),
       );
     }

--- a/plugins/bulk-import-backend/src/helpers/pagination.ts
+++ b/plugins/bulk-import-backend/src/helpers/pagination.ts
@@ -14,7 +14,22 @@
  * limitations under the License.
  */
 
-export * from './auth';
-export * from './catalogInfoGenerator';
-export * from './GithubAppManager';
-export * from './pagination';
+/**
+ * Returns a paginated chunk of the specified array
+ * @param array the array to paginate
+ * @param page the page number
+ * @param size the maximum number of elements in each page
+ */
+export function paginateArray<T>(
+  array: T[],
+  page: number,
+  size: number,
+): { result: T[]; totalCount: number } {
+  const startIndex = (page - 1) * size;
+  const endIndex = startIndex + size;
+
+  return {
+    result: array.slice(startIndex, endIndex),
+    totalCount: array.length,
+  };
+}

--- a/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
@@ -249,6 +249,7 @@ export async function createImportJobs(
 
     // Check if repo is already imported
     const repoCatalogUrl = catalogInfoGenerator.getCatalogUrl(
+      config,
       req.repository.url,
       req.repository.defaultBranch,
     );
@@ -464,6 +465,7 @@ async function performDryRunChecks(
 
 export async function findImportStatusByRepo(
   logger: Logger,
+  config: Config,
   githubApiService: GithubApiService,
   catalogInfoGenerator: CatalogInfoGenerator,
   repoUrl: string,
@@ -493,6 +495,7 @@ export async function findImportStatusByRepo(
       const catalogLocations =
         await catalogInfoGenerator.listCatalogUrlLocations();
       const catalogUrl = catalogInfoGenerator.getCatalogUrl(
+        config,
         repoUrl,
         defaultBranch,
       );
@@ -549,6 +552,7 @@ export async function findImportStatusByRepo(
 
 export async function deleteImportByRepo(
   logger: Logger,
+  config: Config,
   githubApiService: GithubApiService,
   catalogInfoGenerator: CatalogInfoGenerator,
   repoUrl: string,
@@ -571,7 +575,11 @@ export async function deleteImportByRepo(
   // Remove Location from catalog
   const catalogLocations =
     await catalogInfoGenerator.listCatalogUrlLocationsById();
-  const catalogUrl = catalogInfoGenerator.getCatalogUrl(repoUrl, defaultBranch);
+  const catalogUrl = catalogInfoGenerator.getCatalogUrl(
+    config,
+    repoUrl,
+    defaultBranch,
+  );
   let locationId: string | undefined;
   for (const [id, loc] of catalogLocations) {
     if (loc === catalogUrl) {

--- a/plugins/bulk-import-backend/src/service/handlers/importStatus.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/importStatus.ts
@@ -16,6 +16,7 @@
 
 import { AuthService } from '@backstage/backend-plugin-api';
 import { CatalogApi } from '@backstage/catalog-client';
+import { Config } from '@backstage/config';
 
 import { Logger } from 'winston';
 
@@ -25,6 +26,7 @@ import { GithubApiService } from '../githubApiService';
 
 export async function getImportStatus(
   logger: Logger,
+  config: Config,
   githubApiService: GithubApiService,
   auth: AuthService,
   catalogApi: CatalogApi,
@@ -37,6 +39,7 @@ export async function getImportStatus(
 } | null> {
   return getImportStatusWithCheckerFn(
     logger,
+    config,
     githubApiService,
     catalogInfoGenerator,
     repoUrl,
@@ -48,6 +51,7 @@ export async function getImportStatus(
 
 export async function getImportStatusFromLocations(
   logger: Logger,
+  config: Config,
   githubApiService: GithubApiService,
   catalogInfoGenerator: CatalogInfoGenerator,
   repoUrl: string,
@@ -59,6 +63,7 @@ export async function getImportStatusFromLocations(
 } | null> {
   return getImportStatusWithCheckerFn(
     logger,
+    config,
     githubApiService,
     catalogInfoGenerator,
     repoUrl,
@@ -76,6 +81,7 @@ export async function getImportStatusFromLocations(
 
 async function getImportStatusWithCheckerFn(
   logger: Logger,
+  config: Config,
   githubApiService: GithubApiService,
   catalogInfoGenerator: CatalogInfoGenerator,
   repoUrl: string,
@@ -91,7 +97,7 @@ async function getImportStatusWithCheckerFn(
   });
   if (!openImportPr.prUrl) {
     const existsInCatalog = await catalogExistenceCheckFn(
-      catalogInfoGenerator.getCatalogUrl(repoUrl, defaultBranch),
+      catalogInfoGenerator.getCatalogUrl(config, repoUrl, defaultBranch),
     );
     const existsInRepo =
       await githubApiService.doesCatalogInfoAlreadyExistInRepo(logger, {

--- a/plugins/bulk-import-backend/src/service/handlers/importStatus.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/importStatus.ts
@@ -24,31 +24,6 @@ import { CatalogInfoGenerator, getTokenForPlugin } from '../../helpers';
 import { Components } from '../../openapi';
 import { GithubApiService } from '../githubApiService';
 
-export async function getImportStatus(
-  logger: Logger,
-  config: Config,
-  githubApiService: GithubApiService,
-  auth: AuthService,
-  catalogApi: CatalogApi,
-  catalogInfoGenerator: CatalogInfoGenerator,
-  repoUrl: string,
-  defaultBranch?: string,
-): Promise<{
-  status: Components.Schemas.ImportStatus;
-  lastUpdate?: string;
-} | null> {
-  return getImportStatusWithCheckerFn(
-    logger,
-    config,
-    githubApiService,
-    catalogInfoGenerator,
-    repoUrl,
-    async (catalogUrl: string) =>
-      await verifyLocationExistence(auth, catalogApi, catalogUrl),
-    defaultBranch,
-  );
-}
-
 export async function getImportStatusFromLocations(
   logger: Logger,
   config: Config,

--- a/plugins/bulk-import-backend/src/service/handlers/repositories.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/repositories.ts
@@ -57,28 +57,30 @@ export async function findAllRepositories(
 }
 
 export async function findRepositoriesByOrganization(
-  logger: Logger,
-  config: Config,
-  githubApiService: GithubApiService,
-  catalogInfoGenerator: CatalogInfoGenerator,
+  deps: {
+    logger: Logger;
+    config: Config;
+    githubApiService: GithubApiService;
+    catalogInfoGenerator: CatalogInfoGenerator;
+  },
   orgName: string,
   checkStatus: boolean = false,
   pageNumber: number = DefaultPageNumber,
   pageSize: number = DefaultPageSize,
 ): Promise<HandlerResponse<Components.Schemas.RepositoryList>> {
-  logger.debug(
+  deps.logger.debug(
     `Getting all repositories for org "${orgName}" - (page,size)=(${pageNumber},${pageSize})..`,
   );
-  return githubApiService
+  return deps.githubApiService
     .getOrgRepositoriesFromIntegrations(orgName, pageNumber, pageSize)
     .then(response =>
       formatResponse(
         response,
-        catalogInfoGenerator,
+        deps.catalogInfoGenerator,
         checkStatus,
-        logger,
-        config,
-        githubApiService,
+        deps.logger,
+        deps.config,
+        deps.githubApiService,
       ),
     );
 }

--- a/plugins/bulk-import-backend/src/service/handlers/repositories.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/repositories.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { Config } from '@backstage/config';
+
 import gitUrlParse from 'git-url-parse';
 import { Logger } from 'winston';
 
@@ -30,6 +32,7 @@ import { getImportStatusFromLocations } from './importStatus';
 
 export async function findAllRepositories(
   logger: Logger,
+  config: Config,
   githubApiService: GithubApiService,
   catalogInfoGenerator: CatalogInfoGenerator,
   checkStatus: boolean = false,
@@ -47,6 +50,7 @@ export async function findAllRepositories(
         catalogInfoGenerator,
         checkStatus,
         logger,
+        config,
         githubApiService,
       ),
     );
@@ -54,6 +58,7 @@ export async function findAllRepositories(
 
 export async function findRepositoriesByOrganization(
   logger: Logger,
+  config: Config,
   githubApiService: GithubApiService,
   catalogInfoGenerator: CatalogInfoGenerator,
   orgName: string,
@@ -72,6 +77,7 @@ export async function findRepositoriesByOrganization(
         catalogInfoGenerator,
         checkStatus,
         logger,
+        config,
         githubApiService,
       ),
     );
@@ -82,6 +88,7 @@ async function formatResponse(
   catalogInfoGenerator: CatalogInfoGenerator,
   checkStatus: boolean,
   logger: Logger,
+  config: Config,
   githubApiService: GithubApiService,
 ) {
   const errorList: string[] = [];
@@ -115,6 +122,7 @@ async function formatResponse(
         importStatus = checkStatus
           ? await getImportStatusFromLocations(
               logger,
+              config,
               githubApiService,
               catalogInfoGenerator,
               repo.html_url,

--- a/plugins/bulk-import-backend/src/service/router.test.ts
+++ b/plugins/bulk-import-backend/src/service/router.test.ts
@@ -741,33 +741,12 @@ describe('createRouter', () => {
       mockedAuthorize.mockImplementation(allowAll);
 
       jest
-        .spyOn(GithubApiService.prototype, 'getRepositoriesFromIntegrations')
-        .mockResolvedValue({
-          repositories: [
-            {
-              name: 'A',
-              full_name: 'my-ent-org-1/A',
-              url: 'https://api.github.com/repos/my-ent-org-1/A',
-              html_url: 'https://github.com/my-ent-org-1/A',
-              default_branch: 'dev',
-            },
-            {
-              name: 'B',
-              full_name: 'my-ent-org-1/B',
-              url: 'https://api.github.com/repos/my-ent-org-1/B',
-              html_url: 'https://github.com/my-ent-org-1/B',
-              default_branch: 'main',
-            },
-            {
-              name: 'A',
-              full_name: 'my-ent-org-2/A',
-              url: 'https://api.github.com/repos/my-ent-org-2/A',
-              html_url: 'https://github.com/my-ent-org-2/A',
-              default_branch: 'dev',
-            },
-          ],
-          errors: [],
-        });
+        .spyOn(CatalogInfoGenerator.prototype, 'listCatalogUrlLocations')
+        .mockResolvedValue([
+          'https://github.com/my-ent-org-1/A/blob/dev/catalog-info.yaml',
+          'https://github.com/my-ent-org-1/B/blob/main/catalog-info.yaml',
+          'https://github.com/my-ent-org-2/A/blob/dev/catalog-info.yaml',
+        ]);
       jest
         .spyOn(GithubApiService.prototype, 'findImportOpenPr')
         .mockImplementation((_logger, input) => {
@@ -798,22 +777,14 @@ describe('createRouter', () => {
             input.repoUrl === 'https://github.com/my-ent-org-1/A',
           );
         });
-      jest
-        .spyOn(CatalogInfoGenerator.prototype, 'listCatalogUrlLocations')
-        .mockResolvedValue([
-          'https://github.com/my-ent-org-1/A/blob/dev/catalog-info.yaml',
-        ]);
 
       const response = await request(app).get('/imports');
       expect(response.status).toEqual(200);
       expect(response.body).toEqual([
         {
           approvalTool: 'GIT',
-          id: 'my-ent-org-1/A',
+          id: 'https://github.com/my-ent-org-1/A',
           repository: {
-            defaultBranch: 'dev',
-            errors: [],
-            id: 'my-ent-org-1/A',
             name: 'A',
             organization: 'my-ent-org-1',
             url: 'https://github.com/my-ent-org-1/A',
@@ -825,11 +796,8 @@ describe('createRouter', () => {
           errors: [
             'could not find out if there is an import PR open on this repo',
           ],
-          id: 'my-ent-org-1/B',
+          id: 'https://github.com/my-ent-org-1/B',
           repository: {
-            defaultBranch: 'main',
-            errors: [],
-            id: 'my-ent-org-1/B',
             name: 'B',
             organization: 'my-ent-org-1',
             url: 'https://github.com/my-ent-org-1/B',
@@ -838,7 +806,7 @@ describe('createRouter', () => {
         },
         {
           approvalTool: 'GIT',
-          id: 'my-ent-org-2/A',
+          id: 'https://github.com/my-ent-org-2/A',
           github: {
             pullRequest: {
               number: 987,
@@ -846,9 +814,6 @@ describe('createRouter', () => {
             },
           },
           repository: {
-            defaultBranch: 'dev',
-            errors: [],
-            id: 'my-ent-org-2/A',
             name: 'A',
             organization: 'my-ent-org-2',
             url: 'https://github.com/my-ent-org-2/A',

--- a/plugins/bulk-import-backend/src/service/router.ts
+++ b/plugins/bulk-import-backend/src/service/router.ts
@@ -135,6 +135,7 @@ export async function createRouter(
       q.checkImportStatus = stringToBoolean(q.checkImportStatus);
       const response = await findAllRepositories(
         logger,
+        config,
         githubApiService,
         catalogInfoGenerator,
         q.checkImportStatus,
@@ -165,6 +166,7 @@ export async function createRouter(
       q.checkImportStatus = stringToBoolean(q.checkImportStatus);
       const response = await findRepositoriesByOrganization(
         logger,
+        config,
         githubApiService,
         catalogInfoGenerator,
         c.request.params.organizationName?.toString(),
@@ -195,6 +197,7 @@ export async function createRouter(
       q.sizePerIntegration = stringToNumber(q.sizePerIntegration);
       const response = await findAllImports(
         logger,
+        config,
         githubApiService,
         catalogInfoGenerator,
         q.pagePerIntegration,
@@ -242,6 +245,7 @@ export async function createRouter(
       }
       const response = await findImportStatusByRepo(
         logger,
+        config,
         githubApiService,
         catalogInfoGenerator,
         q.repo,
@@ -263,6 +267,7 @@ export async function createRouter(
       }
       const response = await deleteImportByRepo(
         logger,
+        config,
         githubApiService,
         catalogInfoGenerator,
         q.repo,

--- a/plugins/bulk-import-backend/src/service/router.ts
+++ b/plugins/bulk-import-backend/src/service/router.ts
@@ -165,10 +165,12 @@ export async function createRouter(
       q.sizePerIntegration = stringToNumber(q.sizePerIntegration);
       q.checkImportStatus = stringToBoolean(q.checkImportStatus);
       const response = await findRepositoriesByOrganization(
-        logger,
-        config,
-        githubApiService,
-        catalogInfoGenerator,
+        {
+          logger,
+          config,
+          githubApiService,
+          catalogInfoGenerator,
+        },
         c.request.params.organizationName?.toString(),
         q.checkImportStatus,
         q.pagePerIntegration,


### PR DESCRIPTION
**What does this PR do / why we need it:**

This PR improves the overall bulk-import user experience by improving the performance of the `GET /imports` endpoint.

It should also fix the issue where the list of imports returned would sometimes not be accurate (some repositories just imported would not show up in this list depending on the page and size requested).

Before this PR, listing imports would take several seconds (and even more depending on the number of repositories accessible from the GH integrations). Example below where it took **~35 seconds** to return a response:

```
$ time http -A bearer -a "${ADMIN_CURL_TOKEN}" GET http://localhost:7007/api/bulk-import/imports pagePerIntegration==1 sizePerIntegration==10000

[
    {
        "approvalTool": "GIT",
        "id": "https://github.com/lemra-org-ent-1/java-quarkus-starter",
        "lastUpdate": "2024-08-19T19:45:11Z",
        "repository": {
            "name": "java-quarkus-starter",
            "organization": "lemra-org-ent-1",
            "url": "https://github.com/lemra-org-ent-1/java-quarkus-starter"
        },
        "status": "ADDED"
    },
    {
        "approvalTool": "GIT",
        "github": {
            "pullRequest": {
                "number": 36,
                "url": "https://github.com/lemra-org-ent-2/animated-happiness/pull/36"
            }
        },
        "id": "https://github.com/lemra-org-ent-2/animated-happiness",
        "lastUpdate": "2024-08-21T07:38:28Z",
        "repository": {
            "name": "animated-happiness",
            "organization": "lemra-org-ent-2",
            "url": "https://github.com/lemra-org-ent-2/animated-happiness"
        },
        "status": "WAIT_PR_APPROVAL"
    }
]

http -A bearer -a "${ADMIN_CURL_TOKEN}" GET  pagePerIntegration==1   0.25s user 0.03s system 0% cpu 35.426 total
```

This PR improves this by no longer iterating from the repository list. As we can see in the output below, the same call above now takes **less than 2 seconds** to return a response.
Now the response time depends on the number of Location entities (treated as Import jobs), and not on the number of repositories accessible from the GH integrations configured.
```
$ time http -A bearer -a "${ADMIN_CURL_TOKEN}" GET http://localhost:7007/api/bulk-import/imports pagePerIntegration==1 sizePerIntegration==10000

[
    {
        "approvalTool": "GIT",
        "id": "https://github.com/lemra-org-ent-1/java-quarkus-starter",
        "lastUpdate": "2024-08-19T19:45:11Z",
        "repository": {
            "name": "java-quarkus-starter",
            "organization": "lemra-org-ent-1",
            "url": "https://github.com/lemra-org-ent-1/java-quarkus-starter"
        },
        "status": "ADDED"
    },
    {
        "approvalTool": "GIT",
        "github": {
            "pullRequest": {
                "number": 36,
                "url": "https://github.com/lemra-org-ent-2/animated-happiness/pull/36"
            }
        },
        "id": "https://github.com/lemra-org-ent-2/animated-happiness",
        "lastUpdate": "2024-08-21T07:38:28Z",
        "repository": {
            "name": "animated-happiness",
            "organization": "lemra-org-ent-2",
            "url": "https://github.com/lemra-org-ent-2/animated-happiness"
        },
        "status": "WAIT_PR_APPROVAL"
    }
]

http -A bearer -a "${ADMIN_CURL_TOKEN}" GET  pagePerIntegration==1   0.26s user 0.03s system 24% cpu 1.193 total
```

**Which issue(s) this PR fixes:**

Fixes https://issues.redhat.com/browse/RHIDP-3680

**PR acceptance criteria:**

- [ ] Unit tests

- [ ] Integration tests

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

/cc @debsmita1 @ciiay @jerolimov 