### PR TITLE
chore: update catalog-info.yamls

### DIFF
--- a/catalog-info-teams.yaml
+++ b/catalog-info-teams.yaml
@@ -60,3 +60,21 @@ metadata:
 spec:
   type: team
   children: []
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: kiali-team
+spec:
+  type: team
+  children: []
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: orchestrator-team
+spec:
+  type: team
+  children: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -18,7 +18,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main

--- a/packages/cli/catalog-info.yaml
+++ b/packages/cli/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/packages/cli/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/packages/cli/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes

--- a/plugins/3scale-backend/catalog-info.yaml
+++ b/plugins/3scale-backend/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/3scale-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/3scale-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/3scale-backend
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/3scale-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/3scale-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/3scale-backend

--- a/plugins/aap-backend/catalog-info.yaml
+++ b/plugins/aap-backend/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/aap-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/aap-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/aap-backend
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/aap-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/aap-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/aap-backend

--- a/plugins/acr/catalog-info.yaml
+++ b/plugins/acr/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/acr/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/acr/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/acr
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/acr/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/acr/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/acr

--- a/plugins/analytics-module-matomo/catalog-info.yaml
+++ b/plugins/analytics-module-matomo/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/analytics-module-matomo/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/analytics-module-matomo/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-module-matomo
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/analytics-module-matomo/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/analytics-module-matomo/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-module-matomo

--- a/plugins/analytics-provider-segment/catalog-info.yaml
+++ b/plugins/analytics-provider-segment/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/analytics-provider-segment/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/analytics-provider-segment/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-provider-segment
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/analytics-provider-segment/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/analytics-provider-segment/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/analytics-provider-segment

--- a/plugins/argocd-common/catalog-info.yaml
+++ b/plugins/argocd-common/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/argocd-common/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/argocd-common/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/rhtap
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes

--- a/plugins/argocd/catalog-info.yaml
+++ b/plugins/argocd/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/argocd/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/argocd/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/rhtap
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/argocd/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/argocd/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/rhtap
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes

--- a/plugins/audit-log-node/catalog-info.yaml
+++ b/plugins/audit-log-node/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/audit-log-node/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/audit-log-node/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/audit-log-node
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/audit-log-node/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/audit-log-node/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/audit-log-node

--- a/plugins/bulk-import-backend/catalog-info.yaml
+++ b/plugins/bulk-import-backend/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/bulk-import-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import-backend

--- a/plugins/bulk-import-common/catalog-info.yaml
+++ b/plugins/bulk-import-common/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import-common/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/bulk-import-common/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import-common

--- a/plugins/bulk-import/catalog-info.yaml
+++ b/plugins/bulk-import/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/bulk-import/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import
@@ -35,7 +35,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/bulk-import/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/bulk-import

--- a/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - scaffolder
@@ -38,7 +38,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/catalog-backend-module-scaffolder-relation-processor/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - scaffolder

--- a/plugins/dynamic-plugins-info/catalog-info.yaml
+++ b/plugins/dynamic-plugins-info/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/dynamic-plugins-info/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/dynamic-plugins-info/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/dynamic-plugins-info
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/dynamic-plugins-info/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/dynamic-plugins-info/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/dynamic-plugins-info

--- a/plugins/feedback-backend/catalog-info.yaml
+++ b/plugins/feedback-backend/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/feedback-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/feedback-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/feedback-backend

--- a/plugins/feedback/catalog-info.yaml
+++ b/plugins/feedback/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/feedback/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/feedback/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/feedback
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/feedback/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/feedback/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/feedback

--- a/plugins/jfrog-artifactory/catalog-info.yaml
+++ b/plugins/jfrog-artifactory/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/jfrog-artifactory/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/jfrog-artifactory/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/jfrog-artifactory
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/jfrog-artifactory/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/jfrog-artifactory/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/jfrog-artifactory

--- a/plugins/keycloak-backend/catalog-info.yaml
+++ b/plugins/keycloak-backend/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/keycloak-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/keycloak-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/keycloak-backend
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/keycloak-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/keycloak-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/keycloak-backend

--- a/plugins/kiali-backend/catalog-info.yaml
+++ b/plugins/kiali-backend/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kiali-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/kiali-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kiali-backend
@@ -20,6 +20,6 @@ metadata:
 spec:
   type: backstage-backend-plugin
   lifecycle: production
-  owner: rhdh-team
+  owner: kiali-team
   system: rhdh
   subcomponentOf: janus-idp-kiali

--- a/plugins/kiali/catalog-info.yaml
+++ b/plugins/kiali/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kiali/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/kiali/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kiali
@@ -20,7 +20,7 @@ metadata:
 spec:
   type: backstage-plugin
   lifecycle: production
-  owner: rhdh-team
+  owner: kiali-team
   system: rhdh
   subcomponentOf: janus-idp-backstage-plugins
 ---
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kiali/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/kiali/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kiali
@@ -46,6 +46,6 @@ metadata:
 spec:
   type: backstage-frontend-plugin
   lifecycle: production
-  owner: rhdh-team
+  owner: kiali-team
   system: rhdh
   subcomponentOf: janus-idp-kiali

--- a/plugins/kubernetes-actions/catalog-info.yaml
+++ b/plugins/kubernetes-actions/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kubernetes-actions/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/kubernetes-actions/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes
@@ -41,7 +41,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kubernetes-actions/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/kubernetes-actions/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes

--- a/plugins/matomo-backend/catalog-info.yaml
+++ b/plugins/matomo-backend/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/matomo-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/matomo-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/matomo-backend

--- a/plugins/matomo/catalog-info.yaml
+++ b/plugins/matomo/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/matomo/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/matomo/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/matomo
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/matomo/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/matomo/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/matomo

--- a/plugins/nexus-repository-manager/catalog-info.yaml
+++ b/plugins/nexus-repository-manager/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/nexus-repository-manager/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/nexus-repository-manager/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/nexus-repository-manager
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/nexus-repository-manager/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/nexus-repository-manager/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/nexus-repository-manager

--- a/plugins/ocm-backend/catalog-info.yaml
+++ b/plugins/ocm-backend/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/ocm-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/ocm-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes

--- a/plugins/ocm-common/catalog-info.yaml
+++ b/plugins/ocm-common/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/ocm-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/ocm-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes

--- a/plugins/ocm/catalog-info.yaml
+++ b/plugins/ocm/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/ocm/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/ocm/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/ocm/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/ocm/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes

--- a/plugins/openshift-image-registry/catalog-info.yaml
+++ b/plugins/openshift-image-registry/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/openshift-image-registry/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/openshift-image-registry/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/openshift-image-registry/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/openshift-image-registry/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes

--- a/plugins/orchestrator-backend/catalog-info.yaml
+++ b/plugins/orchestrator-backend/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/orchestrator-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/orchestrator-codeowners
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator-backend
@@ -20,6 +20,6 @@ metadata:
 spec:
   type: backstage-backend-plugin
   lifecycle: production
-  owner: rhdh-team
+  owner: orchestrator-team
   system: rhdh
   subcomponentOf: janus-idp-orchestrator

--- a/plugins/orchestrator-common/catalog-info.yaml
+++ b/plugins/orchestrator-common/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator-common/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/orchestrator-common/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/orchestrator-codeowners
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator-common
@@ -20,6 +20,6 @@ metadata:
 spec:
   type: backstage-common-library
   lifecycle: production
-  owner: rhdh-team
+  owner: orchestrator-team
   system: rhdh
   subcomponentOf: janus-idp-orchestrator

--- a/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
+++ b/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/orchestrator-codeowners
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator-swf-editor-envelope
@@ -20,6 +20,6 @@ metadata:
 spec:
   type: backstage-frontend-plugin
   lifecycle: production
-  owner: rhdh-team
+  owner: orchestrator-team
   system: rhdh
   subcomponentOf: janus-idp-backstage-plugins

--- a/plugins/orchestrator/catalog-info.yaml
+++ b/plugins/orchestrator/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/orchestrator/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/orchestrator-codeowners
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator
@@ -20,7 +20,7 @@ metadata:
 spec:
   type: backstage-plugin
   lifecycle: production
-  owner: rhdh-team
+  owner: orchestrator-team
   system: rhdh
   subcomponentOf: janus-idp-backstage-plugins
 ---
@@ -36,7 +36,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/orchestrator/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/orchestrator-codeowners
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator
@@ -46,6 +46,6 @@ metadata:
 spec:
   type: backstage-frontend-plugin
   lifecycle: production
-  owner: rhdh-team
+  owner: orchestrator-team
   system: rhdh
   subcomponentOf: janus-idp-orchestrator

--- a/plugins/quay-actions/catalog-info.yaml
+++ b/plugins/quay-actions/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/quay-actions/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/quay-actions/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - quay
@@ -40,7 +40,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/quay-actions/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/quay-actions/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - quay

--- a/plugins/quay-common/catalog-info.yaml
+++ b/plugins/quay-common/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/quay-common/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/quay-common/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/rhtap
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - quay
@@ -22,6 +22,6 @@ metadata:
 spec:
   type: backstage-common-library
   lifecycle: production
-  owner: rhdh-team
+  owner: rhtap-team
   system: rhdh
   subcomponentOf: janus-idp-quay

--- a/plugins/quay/catalog-info.yaml
+++ b/plugins/quay/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/quay/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/quay/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/rhtap
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - quay
@@ -22,7 +22,7 @@ metadata:
 spec:
   type: backstage-plugin
   lifecycle: production
-  owner: rhdh-team
+  owner: rhtap-team
   system: rhdh
   subcomponentOf: janus-idp-backstage-plugins
 ---
@@ -38,7 +38,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/quay/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/quay/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/rhtap
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - quay
@@ -50,6 +50,6 @@ metadata:
 spec:
   type: backstage-frontend-plugin
   lifecycle: production
-  owner: rhdh-team
+  owner: rhtap-team
   system: rhdh
   subcomponentOf: janus-idp-quay

--- a/plugins/rbac-backend/catalog-info.yaml
+++ b/plugins/rbac-backend/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/rbac-backend/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - security

--- a/plugins/rbac-common/catalog-info.yaml
+++ b/plugins/rbac-common/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac-common/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/rbac-common/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - security

--- a/plugins/rbac-node/catalog-info.yaml
+++ b/plugins/rbac-node/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac-node/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/rbac-node/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - security

--- a/plugins/rbac/catalog-info.yaml
+++ b/plugins/rbac/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/rbac/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - security
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/rbac/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - security

--- a/plugins/regex-actions/catalog-info.yaml
+++ b/plugins/regex-actions/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/regex-actions/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/regex-actions/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - scaffolder
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/regex-actions/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/regex-actions/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - scaffolder

--- a/plugins/scaffolder-annotator-action/catalog-info.yaml
+++ b/plugins/scaffolder-annotator-action/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/scaffolder-annotator-action/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/scaffolder-annotator-action/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - scaffolder
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/scaffolder-annotator-action/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/scaffolder-annotator-action/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - scaffolder

--- a/plugins/servicenow-actions/catalog-info.yaml
+++ b/plugins/servicenow-actions/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/servicenow-actions/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/servicenow-actions/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - scaffolder
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/servicenow-actions/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/servicenow-actions/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - scaffolder

--- a/plugins/shared-react/catalog-info.yaml
+++ b/plugins/shared-react/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/shared-react/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/shared-react/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   links:
     - url: https://github.com/janus-idp/backstage-plugins/tree/main/plugins/shared-react

--- a/plugins/sonarqube-actions/catalog-info.yaml
+++ b/plugins/sonarqube-actions/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/sonarqube-actions/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/sonarqube-actions/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - scaffolder
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/sonarqube-actions/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/sonarqube-actions/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - scaffolder

--- a/plugins/tekton-common/catalog-info.yaml
+++ b/plugins/tekton-common/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/tekton-common/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/tekton-common/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/rhtap
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes
@@ -23,6 +23,6 @@ metadata:
 spec:
   type: backstage-common-library
   lifecycle: production
-  owner: rhdh-ui-team
+  owner: rhtap-team
   system: rhdh
   subcomponentOf: janus-idp-tekton

--- a/plugins/tekton/catalog-info.yaml
+++ b/plugins/tekton/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/tekton/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/tekton/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/rhtap
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes
@@ -23,7 +23,7 @@ metadata:
 spec:
   type: backstage-plugin
   lifecycle: production
-  owner: rhdh-ui-team
+  owner: rhtap-team
   system: rhdh
   subcomponentOf: janus-idp-backstage-plugins
 ---
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/tekton/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/tekton/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/rhtap
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes
@@ -52,6 +52,6 @@ metadata:
 spec:
   type: backstage-frontend-plugin
   lifecycle: production
-  owner: rhdh-ui-team
+  owner: rhtap-team
   system: rhdh
   subcomponentOf: janus-idp-tekton

--- a/plugins/topology-common/catalog-info.yaml
+++ b/plugins/topology-common/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/topology-common/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/topology-common/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes

--- a/plugins/topology/catalog-info.yaml
+++ b/plugins/topology/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/topology/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/topology/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/topology/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/topology/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes

--- a/plugins/web-terminal/catalog-info.yaml
+++ b/plugins/web-terminal/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/web-terminal/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/web-terminal/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes
@@ -39,7 +39,7 @@ metadata:
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/web-terminal/catalog-info.yaml
     backstage.io/edit-url: https://github.com/janus-idp/backstage-plugins/edit/main/plugins/web-terminal/catalog-info.yaml
     github.com/project-slug: janus-idp/backstage-plugins
-    #github.com/team-slug: janus-idp/maintainers
+    github.com/team-slug: janus-idp/maintainers-plugins
     sonarqube.org/project-key: janus-idp_backstage-plugins
   tags:
     - kubernetes


### PR DESCRIPTION
* add new `kiali-team` group and assign all kiali plugins to it
* add new `orchestrator-team` group and assign all orchestrator plugins to it
* assign tekton and quay plugins to `rhtap-team`
* set github.com/team-slug for all plugins

/cc @karthikjeeyar @divyanshiGupta @debsmita1 