### PR TITLE
chore: add deprecate note to the 3scale plugin

### DIFF
--- a/plugins/3scale-backend/README.md
+++ b/plugins/3scale-backend/README.md
@@ -1,3 +1,9 @@
+# ❗DEPRECATED❗
+
+This package has been deprecated.
+
+Please use the **[@backstage-community/plugin-3scale-backend](https://www.npmjs.com/package/@backstage-community/plugin-3scale-backend)** package instead.
+
 # 3scale Backstage provider
 
 The 3scale Backstage provider plugin synchronizes the 3scale content into the [Backstage](https://backstage.io/) catalog.

--- a/plugins/3scale-backend/package.json
+++ b/plugins/3scale-backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-3scale-backend",
   "version": "1.8.1",
+  "private": true,
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/RHIDP-3544

The `3scale-backend` plugin has been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins/tree/main/workspaces/redhat-argocd/plugins) repository in support of our [sunsetting](https://issues.redhat.com/browse/RHIDP-3227) efforts.

This Pull Request is adding a note within the [backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins) repository about the `3scale-backend` plugin being deprecated. It is also setting the package.json files to private "private": true, to prevent accidental publishing of deprecated plugin.