### PR TITLE
fix(topology): fixes custom styles loading

### DIFF
--- a/plugins/tekton/package.json
+++ b/plugins/tekton/package.json
@@ -19,7 +19,9 @@
       "@janus-idp/backstage-plugin-tekton-common"
     ]
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./**/*.css"
+  ],
   "scripts": {
     "build": "backstage-cli package build",
     "clean": "backstage-cli package clean",

--- a/plugins/topology/package.json
+++ b/plugins/topology/package.json
@@ -18,7 +18,9 @@
       "@janus-idp/backstage-plugin-topology-common"
     ]
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./**/*.css"
+  ],
   "scripts": {
     "build": "backstage-cli package build",
     "clean": "backstage-cli package clean",


### PR DESCRIPTION
Fixes:

https://issues.redhat.com/browse/RHIDP-3710, https://issues.redhat.com/browse/RHIDP-3466

**Description:** 

The sideEffects key in a package.json file is used to inform bundlers like Webpack about the presence of side effects in your code. This key plays a crucial role in optimizing the bundle size during the build process by enabling tree shaking, which is the process of eliminating unused code from the final bundle.

In the context of JavaScript, a side effect refers to any operation or code that affects something outside its scope, such as modifying a global variable, performing I/O operations, or altering the DOM. Pure functions, on the other hand, have no side effects—they return the same output given the same input and do not alter external states.

With sideEffects false, custom styles were being removed as part of optimization by webpack. 

custom css are supported loaders for backstage https://backstage.io/docs/tooling/cli/build-system/#loaders 

https://webpack.js.org/guides/tree-shaking/

**Before:**

Topology:

<img width="1900" alt="image" src="https://github.com/user-attachments/assets/997230da-1d73-4fe2-854a-d3786e138329">


Tekton:

<img width="1904" alt="image" src="https://github.com/user-attachments/assets/b264f188-86a4-4243-8d1c-01f645e2a697">


**After:**

Topology:

<img width="1643" alt="image" src="https://github.com/user-attachments/assets/dc537489-5924-433d-a4b2-a2bdfcc12675">


Tekton:

<img width="1659" alt="image" src="https://github.com/user-attachments/assets/39f9fd1a-0ca5-4b73-947a-08a02cd4bcb1">




