### PR TITLE
fix(orchestrator): revert "chore(release): 1.0.0 [skip ci]"

### DIFF
--- a/plugins/orchestrator-form-react/CHANGELOG.md
+++ b/plugins/orchestrator-form-react/CHANGELOG.md
@@ -1,10 +1,5 @@
 ### Dependencies
 
-* **@janus-idp/backstage-plugin-orchestrator-common:** upgraded to 1.0.0
-* **@janus-idp/backstage-plugin-orchestrator-form-api:** upgraded to 1.0.0
-
-### Dependencies
-
 * **@janus-idp/backstage-plugin-orchestrator-common:** upgraded to 1.15.1
 
 ### Dependencies

--- a/plugins/orchestrator-form-react/package.json
+++ b/plugins/orchestrator-form-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-orchestrator-form-react",
   "description": "Web library for the orchestrator-form plugin",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,8 +28,8 @@
     "@backstage/core-components": "^0.14.9",
     "@backstage/core-plugin-api": "^1.9.3",
     "@backstage/types": "^1.1.1",
-    "@janus-idp/backstage-plugin-orchestrator-common": "1.0.0",
-    "@janus-idp/backstage-plugin-orchestrator-form-api": "1.0.0",
+    "@janus-idp/backstage-plugin-orchestrator-common": "1.15.1",
+    "@janus-idp/backstage-plugin-orchestrator-form-api": "1.0.1",
     "json-schema": "^0.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This reverts commit 5698cc55368bc966bbb3408fe80c498755dae800.

Erroneous downgrade of `@janus-idp/backstage-plugin-orchestrator-common` and `@janus-idp/backstage-plugin-orchestrator-form-api`