### PR TITLE
fix(annotator-action): fix generation annotation backstage.io/createdAt

### DIFF
--- a/plugins/scaffolder-annotator-action/src/actions/annotator/annotator.test.ts
+++ b/plugins/scaffolder-annotator-action/src/actions/annotator/annotator.test.ts
@@ -20,7 +20,11 @@ describe('catalog annotator', () => {
       'catalog:timestamping',
       'Creates a new `catalog:timestamping` Scaffolder action to annotate scaffolded entities with creation timestamp.',
       'some logger info msg',
-      { annotations: { 'backstage.io/createdAt': getCurrentTimestamp() } },
+      () => {
+        return {
+          annotations: { 'backstage.io/createdAt': getCurrentTimestamp() },
+        };
+      },
     );
 
     const logger = getVoidLogger();
@@ -67,7 +71,9 @@ describe('catalog annotator', () => {
       'catalog:test-annotate',
       'Creates a new `catalog:test-annotate` Scaffolder action to annotate catalog-info.yaml with labels and annotations.',
       '',
-      {},
+      () => {
+        return {};
+      },
     );
 
     const logger = getVoidLogger();
@@ -126,7 +132,9 @@ describe('catalog annotator', () => {
       'catalog:test-annotate-obj',
       'Creates a new `catalog:test-annotate-obj` Scaffolder action to annotate any object yaml with labels and annotations.',
       'some logger info message',
-      {},
+      () => {
+        return {};
+      },
     );
 
     const logger = getVoidLogger();
@@ -199,8 +207,8 @@ describe('catalog annotator', () => {
       'catalog:entityRef',
       'Some description',
       'some logger info msg',
-      {
-        spec: { scaffoldedFrom: 'testt-ref' },
+      () => {
+        return { spec: { scaffoldedFrom: 'testt-ref' } };
       },
     );
 
@@ -245,8 +253,12 @@ describe('catalog annotator', () => {
       'catalog:entityRef',
       'Some description',
       'some logger info msg',
-      {
-        spec: { scaffoldedFrom: { readFromContext: 'templateInfo.entityRef' } },
+      () => {
+        return {
+          spec: {
+            scaffoldedFrom: { readFromContext: 'templateInfo.entityRef' },
+          },
+        };
       },
     );
 

--- a/plugins/scaffolder-annotator-action/src/actions/annotator/annotator.ts
+++ b/plugins/scaffolder-annotator-action/src/actions/annotator/annotator.ts
@@ -16,7 +16,7 @@ export const createAnnotatorAction = (
   actionId: string = 'catalog:annotate',
   actionDescription?: string,
   loggerInfoMsg?: string,
-  annotateEntityObject?: {
+  annotateEntityObjectProvider?: () => {
     annotations?: { [key: string]: string };
     labels?: { [key: string]: string };
     spec?: { [key: string]: Value };
@@ -86,6 +86,7 @@ export const createAnnotatorAction = (
       },
     },
     async handler(ctx) {
+      const annotateEntityObject = annotateEntityObjectProvider?.();
       let objToAnnotate: { [key: string]: any };
 
       if (ctx.input?.objectYaml) {

--- a/plugins/scaffolder-annotator-action/src/actions/customActions/createScaffoldedFromAction.ts
+++ b/plugins/scaffolder-annotator-action/src/actions/customActions/createScaffoldedFromAction.ts
@@ -5,10 +5,12 @@ export const createScaffoldedFromAction = () => {
     'catalog:scaffolded-from',
     'Creates a new `catalog:scaffolded-from` scaffolder action to update a catalog-info.yaml with the entityRef of the template that created it.',
     'Annotating catalog-info.yaml with template entityRef',
-    {
-      spec: {
-        scaffoldedFrom: { readFromContext: 'templateInfo.entityRef' },
-      },
+    () => {
+      return {
+        spec: {
+          scaffoldedFrom: { readFromContext: 'templateInfo.entityRef' },
+        },
+      };
     },
   );
 };

--- a/plugins/scaffolder-annotator-action/src/actions/customActions/createTimestampAction.ts
+++ b/plugins/scaffolder-annotator-action/src/actions/customActions/createTimestampAction.ts
@@ -6,6 +6,10 @@ export const createTimestampAction = () => {
     'catalog:timestamping',
     'Creates a new `catalog:timestamping` Scaffolder action to annotate scaffolded entities with creation timestamp.',
     'Annotating catalog-info.yaml with current timestamp',
-    { annotations: { 'backstage.io/createdAt': getCurrentTimestamp() } },
+    () => {
+      return {
+        annotations: { 'backstage.io/createdAt': getCurrentTimestamp() },
+      };
+    },
   );
 };


### PR DESCRIPTION
### What does this pull request do:

Fix generation annotation backstage.io/createdAt by changing createAnnotatorAction argument from object to arrow function, to re-execute annotation value in the handler.

### What does this pull request fix

Fixes: https://issues.redhat.com/browse/RHIDP-3612

### Demo

https://youtu.be/StirzwMxDbg

### How to test it

1. Disable RBAC plugin to simplify testing, or you can enanble plugin and provide permissions from my demo video.

2. Install anotator module:

```bash
yarn workspace backend add @janus-idp/backstage-scaffolder-backend-module-annotator
yarn workspace backend add @backstage/plugin-scaffolder-backend-module-github
```

3. Add modules to the backend in the packages/backend/index.ts:

```index.ts
backend.add(
  import('@janus-idp/backstage-scaffolder-backend-module-annotator/alpha'),
);
backend.add(import('@backstage/plugin-scaffolder-backend-module-github'));
```

4. Generate github personal access token(classic) in the https://github.com/settings/tokens, but with enougth permission to create and read github repositories. Apply token to the app configuration integrations:

```
...
integrations:
  github:
    - host: github.com       
      token: your-token
...
```

5. Add template to catalog in the app config:

```
...
catalog:
....
  locations:
    - type: url
    target: https://github.com/debsmita1/nodejs-ex-1/blob/master/local-template.yaml
    rules:
      - allow: [Template]
 ...
```

6. Execute instance
7. Go to /create
8. Execute template 2 times. Each time timestamp should be new and actual.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>