### PR TITLE
fix(shared-react): include css files in shared react folder

### DIFF
--- a/plugins/shared-react/package.json
+++ b/plugins/shared-react/package.json
@@ -19,7 +19,9 @@
       "@janus-idp/shared-react"
     ]
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./**/*.css"
+  ],
   "scripts": {
     "build": "backstage-cli package build",
     "tsc": "tsc",


### PR DESCRIPTION
Fixes:

https://issues.redhat.com/browse/RHTAPBUGS-1310

Description:

with sideEffects property to set to false, CSS files are not ignored by webpack tree-shaking.  This PR adds css to the webpack builds.

custom css are supported loaders for backstage https://backstage.io/docs/tooling/cli/build-system/#loaders
https://webpack.js.org/guides/tree-shaking/ 


Screenshots:

**Tekton Plugin:** 

**Before:**
 
![Screenshot 2024-09-03 at 2 54 57 PM](https://github.com/user-attachments/assets/fb929c5f-db84-49f9-affd-254828ce30e8)

  
**After:**

![Screenshot 2024-09-03 at 3 03 03 PM](https://github.com/user-attachments/assets/eb7d23f7-ae77-454a-a563-2a5420741059)


---

**Topology Plugin:** 

**Before:**

![Screenshot 2024-09-03 at 3 17 07 PM](https://github.com/user-attachments/assets/e7b3f78a-c7db-4928-8d9f-093d44a7aac2)

**After:**
![Screenshot 2024-09-03 at 3 12 35 PM](https://github.com/user-attachments/assets/037d13d1-a3f2-4435-99e5-93ee9036ee77)


cc: @invincibleJai 