### PR TITLE
fix(rbac): support RejectUnauthorized ssl option for postgres

### DIFF
--- a/plugins/rbac-backend/package.json
+++ b/plugins/rbac-backend/package.json
@@ -40,6 +40,7 @@
     "@backstage/errors": "^1.2.4",
     "@backstage/plugin-auth-node": "^0.4.17",
     "@backstage/plugin-permission-backend": "^0.5.46",
+    "@backstage/backend-defaults": "^0.4.1",
     "@backstage/plugin-permission-common": "^0.8.0",
     "@backstage/plugin-permission-node": "^0.8.0",
     "@backstage/types": "^1.1.1",

--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
@@ -198,13 +198,14 @@ describe('CasbinAdapterFactory', () => {
           },
         },
       });
-      const factory = new CasbinDBAdapterFactory(config, mockDatabaseManager);
+      const factory = new CasbinDBAdapterFactory(config, db);
       const adapter = await factory.createAdapter();
       expect(adapter).not.toBeNull();
       expect(newAdapterMock).toHaveBeenCalledWith({
         type: 'postgres',
         host: 'localhost',
         port: 5432,
+        schema: 'public',
         username: 'postgresUser',
         password: process.env.TEST,
         database: 'test-database',
@@ -232,13 +233,14 @@ describe('CasbinAdapterFactory', () => {
           },
         },
       });
-      const factory = new CasbinDBAdapterFactory(config, mockDatabaseManager);
+      const factory = new CasbinDBAdapterFactory(config, db);
       const adapter = await factory.createAdapter();
       expect(adapter).not.toBeNull();
       expect(newAdapterMock).toHaveBeenCalledWith({
         type: 'postgres',
         host: 'localhost',
         port: 5432,
+        schema: 'public',
         username: 'postgresUser',
         password: process.env.TEST,
         database: 'test-database',

--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
@@ -214,6 +214,39 @@ describe('CasbinAdapterFactory', () => {
         },
       });
     });
+
+    it('test building an adapter using a PostgreSQL configuration with intentionally ssl without CA.', async () => {
+      const config = new ConfigReader({
+        backend: {
+          database: {
+            client: 'pg',
+            connection: {
+              host: 'localhost',
+              port: '5432',
+              user: 'postgresUser',
+              password: process.env.TEST,
+              ssl: {
+                rejectUnauthorized: false,
+              },
+            },
+          },
+        },
+      });
+      const factory = new CasbinDBAdapterFactory(config, mockDatabaseManager);
+      const adapter = await factory.createAdapter();
+      expect(adapter).not.toBeNull();
+      expect(newAdapterMock).toHaveBeenCalledWith({
+        type: 'postgres',
+        host: 'localhost',
+        port: 5432,
+        username: 'postgresUser',
+        password: process.env.TEST,
+        database: 'test-database',
+        ssl: {
+          rejectUnauthorized: false,
+        },
+      });
+    });
   });
 
   it('ensure that building an adapter with an unknown configuration fails.', async () => {

--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
@@ -179,6 +179,41 @@ describe('CasbinAdapterFactory', () => {
         },
       });
     });
+
+    it('test building an adapter using a PostgreSQL configuration with intentionally ssl and TLS options.', async () => {
+      const config = new ConfigReader({
+        backend: {
+          database: {
+            client: 'pg',
+            connection: {
+              host: 'localhost',
+              port: '5432',
+              user: 'postgresUser',
+              password: process.env.TEST,
+              ssl: {
+                ca: 'abc',
+                rejectUnauthorized: false,
+              },
+            },
+          },
+        },
+      });
+      const factory = new CasbinDBAdapterFactory(config, mockDatabaseManager);
+      const adapter = await factory.createAdapter();
+      expect(adapter).not.toBeNull();
+      expect(newAdapterMock).toHaveBeenCalledWith({
+        type: 'postgres',
+        host: 'localhost',
+        port: 5432,
+        username: 'postgresUser',
+        password: process.env.TEST,
+        database: 'test-database',
+        ssl: {
+          ca: 'abc',
+          rejectUnauthorized: false,
+        },
+      });
+    });
   });
 
   it('ensure that building an adapter with an unknown configuration fails.', async () => {

--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
@@ -10,7 +10,7 @@ import { TlsOptions } from 'tls';
 const DEFAULT_SQLITE3_STORAGE_FILE_NAME = 'rbac.sqlite';
 
 type DbSSLOptions = {
-  ca: string;
+  ca?: string;
   rejectUnauthorized?: boolean;
 };
 
@@ -88,7 +88,7 @@ export class CasbinDBAdapterFactory {
       const sslOpts = ssl as DbSSLOptions;
       const tlsOpts = {
         ca: sslOpts.ca,
-        rejectUnauthorized: sslOpts.rejectUnauthorized ?? undefined,
+        rejectUnauthorized: sslOpts.rejectUnauthorized,
       };
 
       if (Object.values(tlsOpts).every(el => el === undefined)) {

--- a/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
+++ b/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
@@ -9,6 +9,11 @@ import { TlsOptions } from 'tls';
 
 const DEFAULT_SQLITE3_STORAGE_FILE_NAME = 'rbac.sqlite';
 
+type DbSSLOptions = {
+  ca: string;
+  rejectUnauthorized?: boolean;
+};
+
 export class CasbinDBAdapterFactory {
   public constructor(
     private readonly config: ConfigApi,
@@ -68,6 +73,7 @@ export class CasbinDBAdapterFactory {
     if (!connection) {
       return undefined;
     }
+
     const ssl = (connection as { ssl: Object | boolean | undefined }).ssl;
 
     if (ssl === undefined) {
@@ -79,12 +85,17 @@ export class CasbinDBAdapterFactory {
     }
 
     if (typeof ssl.valueOf() === 'object') {
-      const ca = (ssl as { ca: string }).ca;
-      if (ca) {
-        return { ca };
+      const sslOpts = ssl as DbSSLOptions;
+      const tlsOpts = {
+        ca: sslOpts.ca,
+        rejectUnauthorized: sslOpts.rejectUnauthorized ?? undefined,
+      };
+
+      if (Object.values(tlsOpts).every(el => el === undefined)) {
+        return true;
       }
-      // SSL object was defined with some options that we don't support yet.
-      return true;
+
+      return tlsOpts;
     }
 
     return undefined;

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -1,8 +1,8 @@
 import {
   createLegacyAuthAdapters,
-  DatabaseManager,
   PluginEndpointDiscovery,
 } from '@backstage/backend-common';
+import { DatabaseManager } from '@backstage/backend-defaults/database';
 import {
   AuthService,
   HttpAuthService,


### PR DESCRIPTION
### What does this pull request:

Support RejectUnauthorized ssl option for postgres db. 
Pr is rebased and improved work https://github.com/janus-idp/backstage-plugins/pull/1613

### What does this pull request fix:

Fixes: https://issues.redhat.com/browse/RHIDP-2409

### How to test this pull request

You can test this pr with localhost. 

1. Create folder docker-postgres-ssl in the your directory:

```bash
mkdir -p ~/docker-postgres-ssl
```

2. Generate ca certificate:

```bash
cd ~/docker-postgres-ssl
openssl req -new -x509 -days 365 -nodes -out server.crt -keyout server.key -subj "/CN=localhost"
```

3. Execute docker postgres container with access to server.key and server.crt files from container:

```bash
docker run --hostname=48c66dd5ec67 \
--env=GOSU_VERSION=1.17 \
--env=PGDATA=/var/lib/postgresql/data \
--env=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/16/bin \
--env=LANG=en_US.utf8 \
--env=PG_MAJOR=16 \
--env=PG_VERSION=16.3-1.pgdg120+1 \
--env=POSTGRES_PASSWORD=postgres \
--env=POSTGRES_USER=postgres \
--volume=/var/lib/postgresql/data \
--volume="${HOME}"/docker-postgres-ssl/server.crt:/var/lib/postgresql/server.crt:ro \
--volume="${HOME}"/docker-postgres-ssl/server.key:/var/lib/postgresql/server.key:ro \
--network=bridge -p 5432:5432 \
--restart=no \
--runtime=runc \
-d postgres \
-c ssl=on \
-c ssl_cert_file=/var/lib/postgresql/server.crt \
-c ssl_key_file=/var/lib/postgresql/server.key
```

4. Use postgres configuration:

```
  database:
    client: pg
    connection:
      host: localhost
      port: 5432
      user: postgres
      password: postgres
      ssl: true
  ```

5. Execute backstage-plugins instance: it should fail with error:

```
backend:start: Error: Failed to connect to the database to make sure that 'backstage_plugin_app' exists, Error: self-signed certificate
backend:start:     at PgConnector.getClient (/Users/oandriie/projects/backstage-plugins/node_modules/@backstage/backend-defaults/src/entrypoints/database/connectors/postgres.ts:276:15)
backend:start: 
```

6. Change configuration:

```
  database:
    client: pg
    connection:
      host: localhost
      port: 5432
      user: postgres
      password: postgres
      ssl:
        rejectUnauthorized: false
  ```
  
  7. Restart backstage-plugins. Instance should be fine.
  8.  Check one more configuration with ca certificate content, but use your generated servert.cert:
  
```
  database:
    client: pg
    connection:
      host: localhost
      port: 5432
      user: postgres
      password: postgres
      ssl:
        ca: |
          -----BEGIN CERTIFICATE-----
          MIIDCTCCAfGgAwIBAgIUBgcc99EWGx7XfmwbXyEZQIlvqKkwDQYJKoZIhvcNAQEL
          BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI0MDkwMjEwMjY0NloXDTI1MDkw
          bla-bla
          C87pvvmv7UwwOhqFiQ==
          -----END CERTIFICATE-----
  ```

  9. Restart backstage-plugins. Instance should be fine.

P.S.: Thanks @PatAKnight for docker run command.
