### PR TITLE
chore(release): revert version downgrade of `@janus-idp/backstage-plugin-audit-log-node` from 1.4.0 to 1.0.0

### DIFF
--- a/plugins/audit-log-node/package.json
+++ b/plugins/audit-log-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-audit-log-node",
   "description": "Node.js library for the audit-log plugin",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
This reverts commit dddb1021c6ad1131ff7ba33b4d2f0762e54df4f0.

For some reason, the MSR process downgraded `@janus-idp/backstage-plugin-audit-log-node` from 1.4.0 to 1.0.0, causing dirty `yarn.lock` issues in PRs.

Fixes https://issues.redhat.com/browse/RHIDP-3824

/cc @nickboldt @schultzp2020 @PatAKnight @AndrienkoAleksandr 
