### PR TITLE
fix(quay): fix the security scan sorting in quay plugin

### DIFF
--- a/plugins/quay/dev/__data__/security_vulnerabilities.ts
+++ b/plugins/quay/dev/__data__/security_vulnerabilities.ts
@@ -359,6 +359,16 @@ export const v3securityDetails: SecurityDetailsResponse = {
     ...securityDetails.data,
     Layer: {
       ...(securityDetails?.data?.Layer ?? {}),
+      Features: [],
+    } as Layer,
+  },
+};
+export const v4securityDetails: SecurityDetailsResponse = {
+  ...securityDetails,
+  data: {
+    ...securityDetails.data,
+    Layer: {
+      ...(securityDetails?.data?.Layer ?? {}),
       Features: securityDetails.data?.Layer?.Features?.slice(0, 5) ?? [],
     } as Layer,
   },

--- a/plugins/quay/dev/__data__/security_vulnerabilities.ts
+++ b/plugins/quay/dev/__data__/security_vulnerabilities.ts
@@ -1,4 +1,5 @@
 import {
+  Layer,
   SecurityDetailsResponse,
   VulnerabilitySeverity,
 } from '../../src/types';
@@ -325,5 +326,40 @@ export const securityDetails: SecurityDetailsResponse = {
         },
       ],
     },
+  },
+};
+
+export const v1securityDetails: SecurityDetailsResponse = {
+  ...securityDetails,
+  status: 'unsupported',
+  data: {
+    ...securityDetails.data,
+    Layer: {
+      ...(securityDetails?.data?.Layer ?? {}),
+      Features: [],
+    } as Layer,
+  },
+};
+
+export const v2securityDetails: SecurityDetailsResponse = {
+  ...securityDetails,
+  status: 'queued',
+  data: {
+    ...securityDetails.data,
+    Layer: {
+      ...(securityDetails?.data?.Layer ?? {}),
+      Features: securityDetails.data?.Layer?.Features?.slice(0, 5) ?? [],
+    } as Layer,
+  },
+};
+
+export const v3securityDetails: SecurityDetailsResponse = {
+  ...securityDetails,
+  data: {
+    ...securityDetails.data,
+    Layer: {
+      ...(securityDetails?.data?.Layer ?? {}),
+      Features: securityDetails.data?.Layer?.Features?.slice(0, 5) ?? [],
+    } as Layer,
   },
 };

--- a/plugins/quay/dev/__data__/tags.ts
+++ b/plugins/quay/dev/__data__/tags.ts
@@ -10,6 +10,36 @@ export const tags = {
       size: 275862608,
       last_modified: 'Tue, 06 Feb 2024 09:39:24 -0000',
     },
+    {
+      name: 'v3',
+      reversion: false,
+      start_ts: 1707212364,
+      manifest_digest:
+        'sha256:79c96c750aa532d92d9cb56cad59159b7cc26b10e39ff4a895c28345d2cd775d',
+      is_manifest_list: false,
+      size: 265862608,
+      last_modified: 'Tue, 06 Feb 2024 09:39:24 -0000',
+    },
+    {
+      name: 'v2',
+      reversion: false,
+      start_ts: 1707212364,
+      manifest_digest:
+        'sha256:89c96c750aa532d92d9cb56cad59159b7cc26b10e39ff4a895c28345d2cd775e',
+      is_manifest_list: false,
+      size: 235862608,
+      last_modified: 'Tue, 06 Feb 2024 09:39:24 -0000',
+    },
+    {
+      name: 'v1',
+      reversion: false,
+      start_ts: 1707212364,
+      manifest_digest:
+        'sha256:99c96c750aa532d92d9cb56cad59159b7cc26b10e39ff4a895c28345d2cd775f',
+      is_manifest_list: false,
+      size: 225862608,
+      last_modified: 'Tue, 06 Feb 2024 09:39:24 -0000',
+    },
   ],
   page: 1,
   has_additional: false,

--- a/plugins/quay/dev/__data__/tags.ts
+++ b/plugins/quay/dev/__data__/tags.ts
@@ -11,6 +11,16 @@ export const tags = {
       last_modified: 'Tue, 06 Feb 2024 09:39:24 -0000',
     },
     {
+      name: 'v4',
+      reversion: false,
+      start_ts: 1707212364,
+      manifest_digest:
+        'sha256:29c96c750aa532d92d9cb56cad59159b7cc26b10e39ff4a895c28345d2cd775d',
+      is_manifest_list: false,
+      size: 265862608,
+      last_modified: 'Tue, 06 Feb 2024 09:39:24 -0000',
+    },
+    {
       name: 'v3',
       reversion: false,
       start_ts: 1707212364,

--- a/plugins/quay/dev/index.tsx
+++ b/plugins/quay/dev/index.tsx
@@ -12,7 +12,12 @@ import { quayApiRef, QuayApiV1 } from '../src/api';
 import { QuayPage, quayPlugin } from '../src/plugin';
 import { labels } from './__data__/labels';
 import { manifestDigest } from './__data__/manifest_digest';
-import { securityDetails } from './__data__/security_vulnerabilities';
+import {
+  securityDetails,
+  v1securityDetails,
+  v2securityDetails,
+  v3securityDetails,
+} from './__data__/security_vulnerabilities';
 import { tags } from './__data__/tags';
 
 const mockEntity: Entity = {
@@ -45,7 +50,27 @@ export class MockQuayApiClient implements QuayApiV1 {
     return manifestDigest;
   }
 
-  async getSecurityDetails() {
+  async getSecurityDetails(_: string, __: string, digest: string) {
+    if (
+      digest ===
+      'sha256:79c96c750aa532d92d9cb56cad59159b7cc26b10e39ff4a895c28345d2cd775d'
+    ) {
+      return v3securityDetails;
+    }
+
+    if (
+      digest ===
+      'sha256:89c96c750aa532d92d9cb56cad59159b7cc26b10e39ff4a895c28345d2cd775e'
+    ) {
+      return v2securityDetails;
+    }
+    if (
+      digest ===
+      'sha256:99c96c750aa532d92d9cb56cad59159b7cc26b10e39ff4a895c28345d2cd775f'
+    ) {
+      return v1securityDetails;
+    }
+
     return securityDetails;
   }
 }

--- a/plugins/quay/dev/index.tsx
+++ b/plugins/quay/dev/index.tsx
@@ -17,6 +17,7 @@ import {
   v1securityDetails,
   v2securityDetails,
   v3securityDetails,
+  v4securityDetails,
 } from './__data__/security_vulnerabilities';
 import { tags } from './__data__/tags';
 
@@ -69,6 +70,13 @@ export class MockQuayApiClient implements QuayApiV1 {
       'sha256:99c96c750aa532d92d9cb56cad59159b7cc26b10e39ff4a895c28345d2cd775f'
     ) {
       return v1securityDetails;
+    }
+
+    if (
+      digest ===
+      'sha256:29c96c750aa532d92d9cb56cad59159b7cc26b10e39ff4a895c28345d2cd775d'
+    ) {
+      return v4securityDetails;
     }
 
     return securityDetails;

--- a/plugins/quay/src/components/QuayRepository/tableHeading.tsx
+++ b/plugins/quay/src/components/QuayRepository/tableHeading.tsx
@@ -52,7 +52,14 @@ export const columns: TableColumn<QuayTagData>[] = [
 
       const tagManifest = rowData.manifest_digest_raw;
       const retStr = vulnerabilitySummary(rowData.securityDetails);
-      return <Link to={`tag/${tagManifest}`}>{retStr}</Link>;
+      return (
+        <Link
+          data-testid={`${rowData.name}-security-scan`}
+          to={`tag/${tagManifest}`}
+        >
+          {retStr}
+        </Link>
+      );
     },
     id: 'securityScan',
     customSort: (a: QuayTagData, b: QuayTagData) =>

--- a/plugins/quay/src/components/QuayRepository/tableHeading.tsx
+++ b/plugins/quay/src/components/QuayRepository/tableHeading.tsx
@@ -5,7 +5,7 @@ import { Link, Progress, TableColumn } from '@backstage/core-components';
 import { Tooltip } from '@material-ui/core';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 
-import { vulnerabilitySummary } from '../../lib/utils';
+import { securityScanComparator, vulnerabilitySummary } from '../../lib/utils';
 import type { QuayTagData } from '../../types';
 
 export const columns: TableColumn<QuayTagData>[] = [
@@ -55,7 +55,8 @@ export const columns: TableColumn<QuayTagData>[] = [
       return <Link to={`tag/${tagManifest}`}>{retStr}</Link>;
     },
     id: 'securityScan',
-    sorting: false,
+    customSort: (a: QuayTagData, b: QuayTagData) =>
+      securityScanComparator(a, b),
   },
   {
     title: 'Size',

--- a/plugins/quay/src/lib/utils.test.ts
+++ b/plugins/quay/src/lib/utils.test.ts
@@ -79,11 +79,19 @@ describe('compareSecurityScans', () => {
     },
     {
       ...tagArray[2],
+      securityStatus: 'scanned',
+      securityDetails: {
+        ...securityDetails?.data?.Layer,
+        Features: [],
+      },
+    },
+    {
+      ...tagArray[3],
       securityStatus: 'queued',
       securityDetails: v2securityDetails?.data?.Layer,
     },
     {
-      ...tagArray[3],
+      ...tagArray[4],
       securityStatus: 'unsupported',
       securityDetails: v1securityDetails?.data?.Layer,
     },
@@ -93,7 +101,8 @@ describe('compareSecurityScans', () => {
     const expected = [
       'latest-linux-arm64', // High: 3, Medium: 2, Low: 1 ; High value
       'stable', // High: 2, Medium: 2, Low: 1 ; High value
-      'v3', // Medium: 1;  No High, but has Medium and Low
+      'v4', // Medium: 1;  No High, but has Medium and Low
+      'v3', // Passed
       'v2', // Queued;
       'v1', // Unsupported
     ];
@@ -107,6 +116,7 @@ describe('compareSecurityScans', () => {
     const expected = [
       'v1', // Unsupported
       'v2', // Queued;
+      'v4', // Passed
       'v3', // Medium: 1;  No High, but has Medium and Low
       'stable', // High: 2, Medium: 2, Low: 1 ; High value
       'latest-linux-arm64', // High: 3, Medium: 2, Low: 1 ; High value
@@ -131,6 +141,7 @@ describe('compareSecurityScans', () => {
       'v1beta', // Scanning; Show loading indicator in UI.
       'v1', // Unsupported
       'v2', // Queued;
+      'v4', // Passed
       'v3', // Medium: 1;  No High, but has Medium and Low
       'stable', // High: 2, Medium: 2, Low: 1 ; High value
       'latest-linux-arm64', // High: 3, Medium: 2, Low: 1 ; High value

--- a/plugins/quay/src/lib/utils.ts
+++ b/plugins/quay/src/lib/utils.ts
@@ -48,11 +48,11 @@ const securityScanOrder = [
   'High',
   'Medium',
   'Low',
+  'Passed',
   'Scanning',
   'Queued',
   'Unscanned',
   'Unsupported',
-  'Passed',
 ];
 
 export const capitalizeFirstLetter = (s: string): string => {

--- a/plugins/quay/src/types.ts
+++ b/plugins/quay/src/types.ts
@@ -64,7 +64,7 @@ export interface Platform {
 }
 
 export interface SecurityDetailsResponse {
-  status: 'unsupported' | 'unscanned' | 'scanning' | 'scanned';
+  status: 'unsupported' | 'unscanned' | 'scanning' | 'scanned' | 'queued';
   data: Data | null;
 }
 export interface Data {

--- a/plugins/quay/tests/quay.spec.ts
+++ b/plugins/quay/tests/quay.spec.ts
@@ -40,7 +40,10 @@ test.describe('Quay plugin', () => {
   test('Vulnerabilities are listed', async () => {
     const severity = ['High:', 'Medium:', 'Low:'];
     for (const lvl of severity) {
-      await expect(page.getByRole('link', { name: lvl })).toBeVisible();
+      const tagWithAllVulnerabilities = await page.getByTestId(
+        'latest-linux-arm64-security-scan',
+      );
+      await expect(tagWithAllVulnerabilities).toContainText(lvl);
     }
   });
 


### PR DESCRIPTION
**Fixes:** 

https://issues.redhat.com/browse/RHTAPBUGS-1309

**Description:**

Enable Security scan column by adding sort comparator in quay plugin. 

This PR adds following changes:
- sort comparator for security scan
- additional mock data for dev mode
- unit tests.



**Screenshots**:
![quay_security_scan_sorting](https://github.com/user-attachments/assets/1dadf90b-a40d-4f03-b5b9-10b481567409)

**How to test?:**

1. run yarn start in plugins/quay folder to run the application in dev mode.


cc: @jrichter1 