### PR TITLE
chore(release): revert downgrade of bulk import common

### DIFF
--- a/plugins/bulk-import-common/package.json
+++ b/plugins/bulk-import-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-bulk-import-common",
   "description": "Common functionalities for the bulk-import plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

Again with the downgrade of a plugin by MSR. Here is a PR to revert and fix the release.

@AndrienkoAleksandr this downgrade caused your fix to fail to release.