### PR TITLE
feat(bulk-import): implement server-side search [RHIDP-3884]

### DIFF
--- a/plugins/bulk-import-backend/api-docs/Apis/ImportApi.md
+++ b/plugins/bulk-import-backend/api-docs/Apis/ImportApi.md
@@ -64,7 +64,7 @@ null (empty response body)
 
 <a name="findAllImports"></a>
 # **findAllImports**
-> List findAllImports(pagePerIntegration, sizePerIntegration)
+> List findAllImports(pagePerIntegration, sizePerIntegration, search)
 
 Fetch Import Jobs
 
@@ -74,6 +74,7 @@ Fetch Import Jobs
 |------------- | ------------- | ------------- | -------------|
 | **pagePerIntegration** | **Integer**| the page number for each Integration | [optional] [default to 1] |
 | **sizePerIntegration** | **Integer**| the number of items per Integration to return per page | [optional] [default to 20] |
+| **search** | **String**| returns only Imports that contain the search string, by repository name | [optional] [default to null] |
 
 ### Return type
 

--- a/plugins/bulk-import-backend/api-docs/Apis/OrganizationApi.md
+++ b/plugins/bulk-import-backend/api-docs/Apis/OrganizationApi.md
@@ -10,7 +10,7 @@ All URIs are relative to *http://localhost:7007/api/bulk-import*
 
 <a name="findAllOrganizations"></a>
 # **findAllOrganizations**
-> OrganizationList findAllOrganizations(pagePerIntegration, sizePerIntegration)
+> OrganizationList findAllOrganizations(pagePerIntegration, sizePerIntegration, search)
 
 Fetch Organizations accessible by Backstage Github Integrations
 
@@ -20,6 +20,7 @@ Fetch Organizations accessible by Backstage Github Integrations
 |------------- | ------------- | ------------- | -------------|
 | **pagePerIntegration** | **Integer**| the page number for each Integration | [optional] [default to 1] |
 | **sizePerIntegration** | **Integer**| the number of items per Integration to return per page | [optional] [default to 20] |
+| **search** | **String**| returns only organizations that match the search string, by name | [optional] [default to null] |
 
 ### Return type
 
@@ -36,7 +37,7 @@ Fetch Organizations accessible by Backstage Github Integrations
 
 <a name="findRepositoriesByOrganization"></a>
 # **findRepositoriesByOrganization**
-> RepositoryList findRepositoriesByOrganization(organizationName, checkImportStatus, pagePerIntegration, sizePerIntegration)
+> RepositoryList findRepositoriesByOrganization(organizationName, checkImportStatus, pagePerIntegration, sizePerIntegration, search)
 
 Fetch Repositories in the specified GitHub organization, provided it is accessible by any of the configured GitHub Integrations.
 
@@ -48,6 +49,7 @@ Fetch Repositories in the specified GitHub organization, provided it is accessib
 | **checkImportStatus** | **Boolean**| whether to return import status. Note that this might incur a performance penalty because the import status is computed for each repository. | [optional] [default to false] |
 | **pagePerIntegration** | **Integer**| the page number for each Integration | [optional] [default to 1] |
 | **sizePerIntegration** | **Integer**| the number of items per Integration to return per page | [optional] [default to 20] |
+| **search** | **String**| returns only organization repositories that contain the search string, by repository name | [optional] [default to null] |
 
 ### Return type
 

--- a/plugins/bulk-import-backend/api-docs/Apis/RepositoryApi.md
+++ b/plugins/bulk-import-backend/api-docs/Apis/RepositoryApi.md
@@ -9,7 +9,7 @@ All URIs are relative to *http://localhost:7007/api/bulk-import*
 
 <a name="findAllRepositories"></a>
 # **findAllRepositories**
-> RepositoryList findAllRepositories(checkImportStatus, pagePerIntegration, sizePerIntegration)
+> RepositoryList findAllRepositories(checkImportStatus, pagePerIntegration, sizePerIntegration, search)
 
 Fetch Organization Repositories accessible by Backstage Github Integrations
 
@@ -20,6 +20,7 @@ Fetch Organization Repositories accessible by Backstage Github Integrations
 | **checkImportStatus** | **Boolean**| whether to return import status. Note that this might incur a performance penalty because the import status is computed for each repository. | [optional] [default to false] |
 | **pagePerIntegration** | **Integer**| the page number for each Integration | [optional] [default to 1] |
 | **sizePerIntegration** | **Integer**| the number of items per Integration to return per page | [optional] [default to 20] |
+| **search** | **String**| returns only repositories that contain the search string, by name | [optional] [default to null] |
 
 ### Return type
 

--- a/plugins/bulk-import-backend/src/openapi.d.ts
+++ b/plugins/bulk-import-backend/src/openapi.d.ts
@@ -221,11 +221,13 @@ declare namespace Paths {
     namespace FindAllImports {
         namespace Parameters {
             export type PagePerIntegration = number;
+            export type Search = string;
             export type SizePerIntegration = number;
         }
         export interface QueryParameters {
             pagePerIntegration?: Parameters.PagePerIntegration;
             sizePerIntegration?: Parameters.SizePerIntegration;
+            search?: Parameters.Search;
         }
         namespace Responses {
             export type $200 = /* Import Job */ Components.Schemas.Import[];
@@ -236,11 +238,13 @@ declare namespace Paths {
     namespace FindAllOrganizations {
         namespace Parameters {
             export type PagePerIntegration = number;
+            export type Search = string;
             export type SizePerIntegration = number;
         }
         export interface QueryParameters {
             pagePerIntegration?: Parameters.PagePerIntegration;
             sizePerIntegration?: Parameters.SizePerIntegration;
+            search?: Parameters.Search;
         }
         namespace Responses {
             export type $200 = /* Organization List */ Components.Schemas.OrganizationList;
@@ -251,12 +255,14 @@ declare namespace Paths {
         namespace Parameters {
             export type CheckImportStatus = boolean;
             export type PagePerIntegration = number;
+            export type Search = string;
             export type SizePerIntegration = number;
         }
         export interface QueryParameters {
             checkImportStatus?: Parameters.CheckImportStatus;
             pagePerIntegration?: Parameters.PagePerIntegration;
             sizePerIntegration?: Parameters.SizePerIntegration;
+            search?: Parameters.Search;
         }
         namespace Responses {
             export type $200 = /* Repository List */ Components.Schemas.RepositoryList;
@@ -283,6 +289,7 @@ declare namespace Paths {
             export type CheckImportStatus = boolean;
             export type OrganizationName = string;
             export type PagePerIntegration = number;
+            export type Search = string;
             export type SizePerIntegration = number;
         }
         export interface PathParameters {
@@ -292,6 +299,7 @@ declare namespace Paths {
             checkImportStatus?: Parameters.CheckImportStatus;
             pagePerIntegration?: Parameters.PagePerIntegration;
             sizePerIntegration?: Parameters.SizePerIntegration;
+            search?: Parameters.Search;
         }
         namespace Responses {
             export type $200 = /* Repository List */ Components.Schemas.RepositoryList;

--- a/plugins/bulk-import-backend/src/openapidocument.ts
+++ b/plugins/bulk-import-backend/src/openapidocument.ts
@@ -8,7 +8,7 @@ const OPENAPI = `
   "info": {
     "version": "1.0",
     "title": "Bulk Import Backend",
-    "description": "The Bulk Import Backend APIs allow users to bulk import Backstage entities into the backstage catalog from remote sources such as Git."
+    "description": "The Bulk Import Backend APIs allow users to bulk import repositories into the Backstage catalog from remote sources such as Git."
   },
   "servers": [
     {
@@ -95,6 +95,14 @@ const OPENAPI = `
               "type": "integer",
               "default": 20
             }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "description": "returns only organizations that match the search string, by name",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -179,6 +187,14 @@ const OPENAPI = `
               "type": "integer",
               "default": 20
             }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "description": "returns only organization repositories that contain the search string, by repository name",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -254,6 +270,14 @@ const OPENAPI = `
               "type": "integer",
               "default": 20
             }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "description": "returns only repositories that contain the search string, by name",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -319,6 +343,14 @@ const OPENAPI = `
             "schema": {
               "type": "integer",
               "default": 20
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "description": "returns only Imports that contain the search string, by repository name",
+            "schema": {
+              "type": "string"
             }
           }
         ],

--- a/plugins/bulk-import-backend/src/schema/openapi.yaml
+++ b/plugins/bulk-import-backend/src/schema/openapi.yaml
@@ -17,7 +17,7 @@ openapi: '3.1.0'
 info:
   version: '1.0'
   title: 'Bulk Import Backend'
-  description: The Bulk Import Backend APIs allow users to bulk import Backstage entities into the backstage catalog from remote sources such as Git.
+  description: The Bulk Import Backend APIs allow users to bulk import repositories into the Backstage catalog from remote sources such as Git.
 servers:
   - url: '{protocol}://{host}:{port}/{basePath}'
     variables:
@@ -69,6 +69,11 @@ paths:
           schema:
             type: integer
             default: 20
+        - in: query
+          name: search
+          description: returns only organizations that match the search string, by name
+          schema:
+            type: string
       responses:
         200:
           description: Organization list was fetched successfully with no errors
@@ -121,6 +126,11 @@ paths:
           schema:
             type: integer
             default: 20
+        - in: query
+          name: search
+          description: returns only organization repositories that contain the search string, by repository name
+          schema:
+            type: string
       responses:
         200:
           description: Org Repository list was fetched successfully with no errors
@@ -167,6 +177,11 @@ paths:
           schema:
             type: integer
             default: 20
+        - in: query
+          name: search
+          description: returns only repositories that contain the search string, by name
+          schema:
+            type: string
       responses:
         200:
           description: Repository list was fetched successfully with no errors
@@ -207,6 +222,11 @@ paths:
           schema:
             type: integer
             default: 20
+        - in: query
+          name: search
+          description: returns only Imports that contain the search string, by repository name
+          schema:
+            type: string
       responses:
         200:
           description: Import Jobs list was fetched successfully with no errors

--- a/plugins/bulk-import-backend/src/service/githubApiService.ts
+++ b/plugins/bulk-import-backend/src/service/githubApiService.ts
@@ -30,6 +30,7 @@ import {
   CustomGithubCredentialsProvider,
   getBranchName,
   getCatalogFilename,
+  paginateArray,
 } from '../helpers';
 import {
   ExtendedGithubCredentials,
@@ -160,46 +161,66 @@ export class GithubApiService {
     });
   }
 
+  private async getAllAppOrgs(
+    ghConfig: GithubIntegrationConfig,
+    credentialAccountLogin?: string,
+  ) {
+    const result = new Map<string, GithubOrganization>();
+    const resp =
+      await this.githubCredentialsProvider.getAllAppInstallations(ghConfig);
+    for (const installation of resp ?? []) {
+      if (
+        !(
+          installation.account &&
+          installation.target_type?.toLowerCase() === 'organization'
+        )
+      ) {
+        continue;
+      }
+      const acc = installation.account!;
+      if (credentialAccountLogin !== acc.login) {
+        continue;
+      }
+      result.set(acc.url, {
+        id: acc.id,
+        description: acc.description ?? undefined,
+        name: acc.login,
+        url: acc.html_url,
+        html_url: acc.html_url,
+        repos_url: acc.repos_url,
+        events_url: acc.events_url,
+      });
+    }
+    return result;
+  }
+
   private async addGithubAppOrgs(
     octokit: Octokit,
     credentialAccountLogin: string | undefined,
     ghConfig: GithubIntegrationConfig,
+    search: string | undefined,
     orgs: Map<string, GithubOrganization>,
     errors: Map<number, GithubFetchError>,
   ): Promise<{ totalCount?: number }> {
     let totalCount = 0;
     try {
-      const resp =
-        await this.githubCredentialsProvider.getAllAppInstallations(ghConfig);
-      for (const installation of resp ?? []) {
+      const resp = await this.getAllAppOrgs(ghConfig, credentialAccountLogin);
+      for (const [orgUrl, ghOrg] of resp) {
         if (
-          !(
-            installation.account &&
-            installation.target_type?.toLowerCase() === 'organization'
-          )
+          search &&
+          !ghOrg.name.toLowerCase().includes(search.toLowerCase())
         ) {
           continue;
         }
-        const acc = installation.account!;
-        if (credentialAccountLogin !== acc.login) {
-          continue;
-        }
         const orgData = await octokit.request(
-          acc.url.replace('/users/', '/orgs/'),
+          orgUrl.replace('/users/', '/orgs/'),
         );
-        const ghOrg: GithubOrganization = {
-          id: acc.id,
-          description: acc.description ?? undefined,
-          name: acc.login,
-          url: acc.url,
-          html_url: acc.html_url,
-          repos_url: acc.repos_url,
-          events_url: acc.events_url,
+        orgs.set(ghOrg.name, {
+          ...ghOrg,
           public_repos: orgData?.data?.public_repos,
           total_private_repos: orgData?.data?.total_private_repos,
           owned_private_repos: orgData?.data?.owned_private_repos,
-        };
-        orgs.set(ghOrg.name, ghOrg);
+        });
         totalCount++;
       }
     } catch (err: any) {
@@ -214,31 +235,73 @@ export class GithubApiService {
   private async addGithubTokenOrgs(
     octokit: Octokit,
     credential: GithubCredentials,
+    search: string | undefined,
     orgs: Map<string, GithubOrganization>,
     errors: Map<number, GithubFetchError>,
     pageNumber: number = DefaultPageNumber,
     pageSize: number = DefaultPageSize,
   ): Promise<{ totalCount?: number }> {
     let totalCount: number | undefined;
+
     try {
-      /**
-       * The listForAuthenticatedUser endpoint will grab all the repositories the github token has explicit access to.
-       * These would include repositories they own, repositories where they are a collaborator,
-       * and repositories that they can access through an organization membership.
-       */
-      const resp = await octokit.rest.orgs.listForAuthenticatedUser({
-        page: pageNumber,
-        per_page: pageSize,
-        sort: 'full_name',
-        direction: 'asc',
-      });
-      for (const org of resp?.data ?? []) {
+      let matchingOrgs;
+      if (search) {
+        // Initial idea was to leverage octokit.rest.search.users({q: `${search} type:org`}),
+        // but this searches across all of GitHub, not only the orgs accessible by the current creds.
+        // That's why we are searching in everything, hoping the list of organizations to not be that big in size
+        const resp = await octokit.paginate(
+          octokit.rest.orgs.listForAuthenticatedUser,
+          {
+            sort: 'full_name',
+            direction: 'asc',
+          },
+        );
+        const allMatchingOrgs =
+          resp?.filter(org =>
+            org.login.toLowerCase().includes(search.toLowerCase()),
+          ) ?? [];
+        const matchingOrgsPage = paginateArray(
+          allMatchingOrgs,
+          pageNumber,
+          pageSize,
+        );
+        matchingOrgs = matchingOrgsPage.result;
+        totalCount = matchingOrgsPage.totalCount;
+      } else {
+        /**
+         * The listForAuthenticatedUser endpoint will grab all the repositories the github token has explicit access to.
+         * These would include repositories they own, repositories where they are a collaborator,
+         * and repositories that they can access through an organization membership.
+         */
+        const resp = await octokit.rest.orgs.listForAuthenticatedUser({
+          page: pageNumber,
+          per_page: pageSize,
+          sort: 'full_name',
+          direction: 'asc',
+        });
+        matchingOrgs = resp?.data ?? [];
+
+        totalCount = await this.computeTotalCountFromGitHubToken(
+          async (lastPageNumber: number) =>
+            octokit.orgs
+              .listForAuthenticatedUser({
+                page: lastPageNumber,
+                per_page: 100,
+              })
+              .then(lastPageResp => lastPageResp.data.length),
+          'orgs.listForAuthenticatedUser',
+          resp?.data?.length,
+          resp?.headers?.link,
+        );
+      }
+
+      for (const org of matchingOrgs) {
         const orgData = await octokit.request(org.url);
         const ghOrg: GithubOrganization = {
           id: org.id,
           name: org.login,
           description: org.description ?? undefined,
-          url: org.url,
+          url: orgData?.data?.html_url ?? org.url,
           repos_url: org.repos_url,
           hooks_url: org.hooks_url,
           issues_url: org.issues_url,
@@ -251,19 +314,6 @@ export class GithubApiService {
         };
         orgs.set(org.login, ghOrg);
       }
-
-      totalCount = await this.computeTotalCountFromGitHubToken(
-        async (lastPageNumber: number) =>
-          octokit.orgs
-            .listForAuthenticatedUser({
-              page: lastPageNumber,
-              per_page: 100,
-            })
-            .then(lastPageResp => lastPageResp.data.length),
-        'orgs.listForAuthenticatedUser',
-        resp?.data?.length,
-        resp?.headers?.link,
-      );
     } catch (err) {
       this.handleError(
         'Fetching orgs with token from token',
@@ -275,6 +325,34 @@ export class GithubApiService {
     return { totalCount };
   }
 
+  private async searchRepos(
+    octokit: Octokit,
+    ghSearchQuery: string,
+    pageNumber: number = DefaultPageNumber,
+    pageSize: number = DefaultPageSize,
+  ): Promise<{ totalCount?: number; repositories: GithubRepository[] }> {
+    const repoSearchResp = await octokit.rest.search.repos({
+      q: ghSearchQuery,
+      order: 'asc',
+      page: pageNumber,
+      per_page: pageSize,
+    });
+    return {
+      totalCount: repoSearchResp?.data?.total_count,
+      repositories:
+        repoSearchResp?.data?.items?.map(repo => {
+          return {
+            name: repo.name,
+            full_name: repo.full_name,
+            url: repo.url,
+            html_url: repo.html_url,
+            default_branch: repo.default_branch,
+            updated_at: repo.updated_at,
+          };
+        }) ?? [],
+    };
+  }
+
   /**
    * Adds the repositories accessible by the provided github app to the provided repositories Map<string, GithubRepository>
    * If any errors occurs, adds them to the provided errors Map<number, GithubFetchError>
@@ -282,29 +360,58 @@ export class GithubApiService {
   private async addGithubAppRepositories(
     octokit: Octokit,
     credential: GithubAppCredentials,
+    ghConfig: GithubIntegrationConfig,
     repositories: Map<string, GithubRepository>,
     errors: Map<number, GithubFetchError>,
-    pageNumber: number = DefaultPageNumber,
-    pageSize: number = DefaultPageSize,
+    reqParams?: {
+      search?: string;
+      pageNumber?: number;
+      pageSize?: number;
+    },
   ): Promise<{ totalCount?: number }> {
+    const search = reqParams?.search;
+    const pageNumber = reqParams?.pageNumber ?? DefaultPageNumber;
+    const pageSize = reqParams?.pageSize ?? DefaultPageSize;
     let totalCount: number | undefined;
     try {
-      const resp = await octokit.apps.listReposAccessibleToInstallation({
-        page: pageNumber,
-        per_page: pageSize,
-      });
-      const repos = resp?.data?.repositories ?? resp?.data;
-      repos?.forEach(repo => {
-        repositories.set(repo.full_name, {
-          name: repo.name,
-          full_name: repo.full_name,
-          url: repo.url,
-          html_url: repo.html_url,
-          default_branch: repo.default_branch,
-          updated_at: repo.updated_at,
+      if (search) {
+        const allOrgsMap = await this.getAllAppOrgs(
+          ghConfig,
+          credential.accountLogin,
+        );
+        const orgSearch: string[] = [];
+        for (const [_orgUrl, ghOrg] of allOrgsMap) {
+          orgSearch.push(`org:${ghOrg.name}`);
+        }
+        const query = `${search} in:name ${orgSearch.join(' ')}`;
+        const searchResp = await this.searchRepos(
+          octokit,
+          query,
+          pageNumber,
+          pageSize,
+        );
+        totalCount = searchResp.totalCount;
+        searchResp.repositories.forEach(repo =>
+          repositories.set(repo.full_name, repo),
+        );
+      } else {
+        const resp = await octokit.apps.listReposAccessibleToInstallation({
+          page: pageNumber,
+          per_page: pageSize,
         });
-      });
-      totalCount = resp?.data?.total_count;
+        const repos = resp?.data?.repositories ?? resp?.data;
+        repos?.forEach(repo => {
+          repositories.set(repo.full_name, {
+            name: repo.name,
+            full_name: repo.full_name,
+            url: repo.url,
+            html_url: repo.html_url,
+            default_branch: repo.default_branch,
+            updated_at: repo.updated_at,
+          });
+        });
+        totalCount = resp?.data?.total_count;
+      }
     } catch (err) {
       this.logger.error(
         `Fetching repositories with access token for github app ${credential.appId}, failed with ${err}`,
@@ -329,45 +436,82 @@ export class GithubApiService {
     credential: GithubCredentials,
     repositories: Map<string, GithubRepository>,
     errors: Map<number, GithubFetchError>,
-    pageNumber: number = DefaultPageNumber,
-    pageSize: number = DefaultPageSize,
+    reqParams?: {
+      search?: string;
+      pageNumber?: number;
+      pageSize?: number;
+    },
   ): Promise<{ totalCount?: number }> {
+    const search = reqParams?.search;
+    const pageNumber = reqParams?.pageNumber ?? DefaultPageNumber;
+    const pageSize = reqParams?.pageSize ?? DefaultPageSize;
     let totalCount: number | undefined;
     try {
-      /**
-       * The listForAuthenticatedUser endpoint will grab all the repositories the github token has explicit access to.
-       * These would include repositories they own, repositories where they are a collaborator,
-       * and repositories that they can access through an organization membership.
-       */
-      const resp = await octokit.rest.repos.listForAuthenticatedUser({
-        page: pageNumber,
-        per_page: pageSize,
-        sort: 'full_name',
-        direction: 'asc',
-      });
-      resp?.data?.forEach(repo => {
-        repositories.set(repo.full_name, {
-          name: repo.name,
-          full_name: repo.full_name,
-          url: repo.url,
-          html_url: repo.html_url,
-          default_branch: repo.default_branch,
-          updated_at: repo.updated_at,
-        });
-      });
+      if (search) {
+        // Get currently authenticated user
+        const username = (await octokit.rest.users.getAuthenticated())?.data
+          ?.login;
+        let query = `${search} in:name user:${username}`;
 
-      totalCount = await this.computeTotalCountFromGitHubToken(
-        async (lastPageNumber: number) =>
-          octokit.repos
-            .listForAuthenticatedUser({
-              page: lastPageNumber,
-              per_page: 100,
-            })
-            .then(lastPageResp => lastPageResp.data.length),
-        'repos.listForAuthenticatedUser',
-        resp?.data?.length,
-        resp?.headers?.link,
-      );
+        const allOrgsResp = await octokit.paginate(
+          octokit.rest.orgs.listForAuthenticatedUser,
+          {
+            sort: 'full_name',
+            direction: 'asc',
+          },
+        );
+        const orgSearch: string[] = [];
+        allOrgsResp?.forEach(org => orgSearch.push(`org:${org.login}`));
+        if (orgSearch.length > 0) {
+          query += ` ${orgSearch.join(' ')}`;
+        }
+
+        const searchResp = await this.searchRepos(
+          octokit,
+          query,
+          pageNumber,
+          pageSize,
+        );
+        totalCount = searchResp.totalCount;
+        searchResp.repositories.forEach(repo =>
+          repositories.set(repo.full_name, repo),
+        );
+      } else {
+        /**
+         * The listForAuthenticatedUser endpoint will grab all the repositories the github token has explicit access to.
+         * These would include repositories they own, repositories where they are a collaborator,
+         * and repositories that they can access through an organization membership.
+         */
+        const resp = await octokit.rest.repos.listForAuthenticatedUser({
+          page: pageNumber,
+          per_page: pageSize,
+          sort: 'full_name',
+          direction: 'asc',
+        });
+        resp?.data?.forEach(repo => {
+          repositories.set(repo.full_name, {
+            name: repo.name,
+            full_name: repo.full_name,
+            url: repo.url,
+            html_url: repo.html_url,
+            default_branch: repo.default_branch,
+            updated_at: repo.updated_at,
+          });
+        });
+
+        totalCount = await this.computeTotalCountFromGitHubToken(
+          async (lastPageNumber: number) =>
+            octokit.repos
+              .listForAuthenticatedUser({
+                page: lastPageNumber,
+                per_page: 100,
+              })
+              .then(lastPageResp => lastPageResp.data.length),
+          'repos.listForAuthenticatedUser',
+          resp?.data?.length,
+          resp?.headers?.link,
+        );
+      }
     } catch (err) {
       this.handleError(
         'Fetching repositories with token from token',
@@ -401,48 +545,68 @@ export class GithubApiService {
     org: string,
     repositories: Map<string, GithubRepository>,
     errors: Map<number, GithubFetchError>,
-    pageNumber: number = DefaultPageNumber,
-    pageSize: number = DefaultPageSize,
+    reqParams?: {
+      search?: string;
+      pageNumber?: number;
+      pageSize?: number;
+    },
   ): Promise<{ totalCount?: number }> {
+    const search = reqParams?.search;
+    const pageNumber = reqParams?.pageNumber ?? DefaultPageNumber;
+    const pageSize = reqParams?.pageSize ?? DefaultPageSize;
     let totalCount: number | undefined;
     try {
-      /**
-       * The listForAuthenticatedUser endpoint will grab all the repositories the github token has explicit access to.
-       * These would include repositories they own, repositories where they are a collaborator,
-       * and repositories that they can access through an organization membership.
-       */
-      const resp = await octokit.rest.repos.listForOrg({
-        org,
-        page: pageNumber,
-        per_page: pageSize,
-        sort: 'full_name',
-        direction: 'asc',
-      });
-      resp?.data?.forEach(repo => {
-        const githubRepo: GithubRepository = {
-          name: repo.name,
-          full_name: repo.full_name,
-          url: repo.url,
-          html_url: repo.html_url,
-          default_branch: repo.default_branch ?? 'main',
-          updated_at: repo.updated_at,
-        };
-        repositories.set(githubRepo.full_name, githubRepo);
-      });
+      if (search) {
+        const query = `${search} in:name org:${org}`;
+        const searchResp = await this.searchRepos(
+          octokit,
+          query,
+          pageNumber,
+          pageSize,
+        );
+        totalCount = searchResp.totalCount;
+        searchResp.repositories.forEach(repo =>
+          repositories.set(repo.full_name, repo),
+        );
+      } else {
+        /**
+         * The listForAuthenticatedUser endpoint will grab all the repositories the github token has explicit access to.
+         * These would include repositories they own, repositories where they are a collaborator,
+         * and repositories that they can access through an organization membership.
+         */
+        const resp = await octokit.rest.repos.listForOrg({
+          org,
+          page: pageNumber,
+          per_page: pageSize,
+          sort: 'full_name',
+          direction: 'asc',
+        });
+        resp?.data?.forEach(repo => {
+          const githubRepo: GithubRepository = {
+            name: repo.name,
+            full_name: repo.full_name,
+            url: repo.url,
+            html_url: repo.html_url,
+            default_branch: repo.default_branch ?? 'main',
+            updated_at: repo.updated_at,
+          };
+          repositories.set(githubRepo.full_name, githubRepo);
+        });
 
-      totalCount = await this.computeTotalCountFromGitHubToken(
-        async (lastPageNumber: number) =>
-          octokit.repos
-            .listForOrg({
-              org,
-              page: lastPageNumber,
-              per_page: 100,
-            })
-            .then(lastPageResp => lastPageResp.data.length),
-        'repos.listForOrg',
-        resp?.data?.length,
-        resp?.headers?.link,
-      );
+        totalCount = await this.computeTotalCountFromGitHubToken(
+          async (lastPageNumber: number) =>
+            octokit.repos
+              .listForOrg({
+                org,
+                page: lastPageNumber,
+                per_page: 100,
+              })
+              .then(lastPageResp => lastPageResp.data.length),
+          'repos.listForOrg',
+          resp?.data?.length,
+          resp?.headers?.link,
+        );
+      }
     } catch (err) {
       this.handleError(
         'Fetching org repositories with token from token',
@@ -545,6 +709,7 @@ export class GithubApiService {
   }
 
   async getOrganizationsFromIntegrations(
+    search?: string,
     pageNumber: number = DefaultPageNumber,
     pageSize: number = DefaultPageSize,
   ): Promise<GithubOrganizationResponse> {
@@ -573,6 +738,7 @@ export class GithubApiService {
             octokit,
             credential.accountLogin,
             ghConfig,
+            search,
             orgs,
             errors,
           );
@@ -580,6 +746,7 @@ export class GithubApiService {
           resp = await this.addGithubTokenOrgs(
             octokit,
             credential,
+            search,
             orgs,
             errors,
             pageNumber,
@@ -604,6 +771,7 @@ export class GithubApiService {
 
   async getOrgRepositoriesFromIntegrations(
     orgName: string,
+    search?: string,
     pageNumber: number = DefaultPageNumber,
     pageSize: number = DefaultPageSize,
   ): Promise<GithubRepositoryResponse> {
@@ -613,7 +781,11 @@ export class GithubApiService {
     const repositories = new Map<string, GithubRepository>();
     const errors = new Map<number, GithubFetchError>();
     let totalCount = 0;
+    let orgFetched = false;
     for (const [ghConfig, credentials] of credentialsByConfig) {
+      if (orgFetched) {
+        break;
+      }
       this.logger.debug(
         `Got ${credentials.length} credential(s) for ${ghConfig.host}`,
       );
@@ -633,10 +805,14 @@ export class GithubApiService {
           resp = await this.addGithubAppRepositories(
             octokit,
             credential,
+            ghConfig,
             repositories,
             errors,
-            pageNumber,
-            pageSize,
+            {
+              search,
+              pageNumber,
+              pageSize,
+            },
           );
         } else {
           resp = await this.addGithubTokenOrgRepositories(
@@ -645,10 +821,14 @@ export class GithubApiService {
             orgName,
             repositories,
             errors,
-            pageNumber,
-            pageSize,
+            {
+              search,
+              pageNumber,
+              pageSize,
+            },
           );
         }
+        orgFetched = true;
         this.logger.debug(
           `Got ${resp.totalCount} org repo(s) for ${ghConfig.host}`,
         );
@@ -670,6 +850,7 @@ export class GithubApiService {
    *   - a list of errors encountered by each app and/or token (if any exist)
    */
   async getRepositoriesFromIntegrations(
+    search?: string,
     pageNumber: number = DefaultPageNumber,
     pageSize: number = DefaultPageSize,
   ): Promise<GithubRepositoryResponse> {
@@ -697,10 +878,14 @@ export class GithubApiService {
           resp = await this.addGithubAppRepositories(
             octokit,
             credential,
+            ghConfig,
             repositories,
             errors,
-            pageNumber,
-            pageSize,
+            {
+              search,
+              pageNumber,
+              pageSize,
+            },
           );
         } else {
           resp = await this.addGithubTokenRepositories(
@@ -708,8 +893,11 @@ export class GithubApiService {
             credential,
             repositories,
             errors,
-            pageNumber,
-            pageSize,
+            {
+              search,
+              pageNumber,
+              pageSize,
+            },
           );
         }
         this.logger.debug(

--- a/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
@@ -47,6 +47,7 @@ export async function findAllImports(
   config: Config,
   githubApiService: GithubApiService,
   catalogInfoGenerator: CatalogInfoGenerator,
+  search?: string,
   pageNumber: number = DefaultPageNumber,
   pageSize: number = DefaultPageSize,
 ): Promise<HandlerResponse<Components.Schemas.Import[]>> {
@@ -56,6 +57,7 @@ export async function findAllImports(
 
   const allLocations = await catalogInfoGenerator.listCatalogUrlLocations(
     config,
+    search,
     pageNumber,
     pageSize,
   );

--- a/plugins/bulk-import-backend/src/service/handlers/organizations.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/organizations.ts
@@ -27,14 +27,16 @@ import {
 export async function findAllOrganizations(
   logger: Logger,
   githubApiService: GithubApiService,
+  search?: string,
   pageNumber: number = DefaultPageNumber,
   pageSize: number = DefaultPageSize,
 ): Promise<HandlerResponse<Components.Schemas.OrganizationList>> {
   logger.debug(
-    `Getting all organizations (page,size)=(${pageNumber},${pageSize})..`,
+    `Getting all organizations (search,page,size)=('${search ?? ''}',${pageNumber},${pageSize})..`,
   );
   const allOrgsAccessible =
     await githubApiService.getOrganizationsFromIntegrations(
+      search,
       pageNumber,
       pageSize,
     );

--- a/plugins/bulk-import-backend/src/service/handlers/repositories.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/repositories.ts
@@ -35,15 +35,22 @@ export async function findAllRepositories(
   config: Config,
   githubApiService: GithubApiService,
   catalogInfoGenerator: CatalogInfoGenerator,
-  checkStatus: boolean = false,
-  pageNumber: number = DefaultPageNumber,
-  pageSize: number = DefaultPageSize,
+  reqParams?: {
+    search?: string;
+    checkStatus?: boolean;
+    pageNumber?: number;
+    pageSize?: number;
+  },
 ): Promise<HandlerResponse<Components.Schemas.RepositoryList>> {
+  const search = reqParams?.search;
+  const checkStatus = reqParams?.checkStatus ?? false;
+  const pageNumber = reqParams?.pageNumber ?? DefaultPageNumber;
+  const pageSize = reqParams?.pageSize ?? DefaultPageSize;
   logger.debug(
-    `Getting all repositories - (page,size)=(${pageNumber},${pageSize})..`,
+    `Getting all repositories - (search,page,size)=('${search ?? ''}',${pageNumber},${pageSize})..`,
   );
   return githubApiService
-    .getRepositoriesFromIntegrations(pageNumber, pageSize)
+    .getRepositoriesFromIntegrations(search, pageNumber, pageSize)
     .then(response =>
       formatResponse(
         response,
@@ -64,15 +71,16 @@ export async function findRepositoriesByOrganization(
     catalogInfoGenerator: CatalogInfoGenerator;
   },
   orgName: string,
+  search?: string,
   checkStatus: boolean = false,
   pageNumber: number = DefaultPageNumber,
   pageSize: number = DefaultPageSize,
 ): Promise<HandlerResponse<Components.Schemas.RepositoryList>> {
   deps.logger.debug(
-    `Getting all repositories for org "${orgName}" - (page,size)=(${pageNumber},${pageSize})..`,
+    `Getting all repositories for org "${orgName}" - (search,page,size)=(${search},${pageNumber},${pageSize})..`,
   );
   return deps.githubApiService
-    .getOrgRepositoriesFromIntegrations(orgName, pageNumber, pageSize)
+    .getOrgRepositoriesFromIntegrations(orgName, search, pageNumber, pageSize)
     .then(response =>
       formatResponse(
         response,

--- a/plugins/bulk-import-backend/src/service/router.ts
+++ b/plugins/bulk-import-backend/src/service/router.ts
@@ -148,6 +148,7 @@ export async function createRouter(
       const response = await findAllOrganizations(
         logger,
         githubApiService,
+        q.search,
         q.pagePerIntegration,
         q.sizePerIntegration,
       );
@@ -176,9 +177,12 @@ export async function createRouter(
         config,
         githubApiService,
         catalogInfoGenerator,
-        q.checkImportStatus,
-        q.pagePerIntegration,
-        q.sizePerIntegration,
+        {
+          search: q.search,
+          checkStatus: q.checkImportStatus,
+          pageNumber: q.pagePerIntegration,
+          pageSize: q.sizePerIntegration,
+        },
       );
       const repos = response.responseBody?.repositories;
       return res.status(response.statusCode).json({
@@ -209,6 +213,7 @@ export async function createRouter(
           catalogInfoGenerator,
         },
         c.request.params.organizationName?.toString(),
+        q.search,
         q.checkImportStatus,
         q.pagePerIntegration,
         q.sizePerIntegration,
@@ -238,6 +243,7 @@ export async function createRouter(
         config,
         githubApiService,
         catalogInfoGenerator,
+        q.search,
         q.pagePerIntegration,
         q.sizePerIntegration,
       );


### PR DESCRIPTION
**What does this PR do / why we need it:**

As reported in https://issues.redhat.com/browse/RHIDP-3859, searching in the bulk import pages is currently done client-side and only works on the visible rows (due to how data is returned by the backend in paginated chunks).
To address this issue, this PR implements search in the backend. This is done by introducing a new optional `search` query parameter to the endpoints below:

- `GET /organizations[?search=<orgName>]`: searches in the organization names (from the organizations accessible from the configured Github integrations)
- `GET /repositories[?search=<repoName>]`: searches in the repository names (from the repositories accessible from the configured Github integrations)
- `GET /organizations/:orgName/repositories[?search=<repoName>]`: search the organization repositories names (from the organization repositories accessible from the configured Github integrations)
- `GET /imports[?search=<repoName>]`: searches in the repository names (each Import being tied to a specified repository)

Once this PR is merged, a subsequent PR will follow up for the frontend to handle that new `search` parameter.

**Which issue(s) this PR fixes:**
https://issues.redhat.com/browse/RHIDP-3884

**PR acceptance criteria:**

- [x] Unit tests

- [ ] Integration tests

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**

Examples of requests/responses:

<details>
<summary>Searching organizations</summary>

```
$ http -A bearer -a "${ADMIN_CURL_TOKEN}" GET http://localhost:7007/api/bulk-import/organizations search=='dev' 

{
    "errors": [],
    "organizations": [
        {
            "description": "File specification and tools for software defined cloud development environments",
            "errors": [],
            "id": "REDACTED",
            "name": "devfile",
            "totalRepoCount": 22,
            "url": "https://github.com/devfile"
        },
        {
            "description": "odo - Fast, Iterative and Simplified container-based application development. The main repo for odo is at https://github.com/redhat-developer/odo",
            "errors": [],
            "id": "REDACTED",
            "name": "ododev",
            "totalRepoCount": 1,
            "url": "https://github.com/ododev"
        },
        {
            "description": "Github home of the Red Hat Developer program.",
            "errors": [],
            "id": "REDACTED",
            "name": "redhat-developer",
            "totalRepoCount": 251,
            "url": "https://github.com/redhat-developer"
        }
    ],
    "pagePerIntegration": 1,
    "sizePerIntegration": 20,
    "totalCount": 3
}

```

</details>

<details>
<summary>Searching repositories</summary>

```
$ http -A bearer -a "${ADMIN_CURL_TOKEN}" GET http://localhost:7007/api/bulk-import/repositories search=='hello'

{
    "errors": [],
    "repositories": [
        {
            "defaultBranch": "master",
            "errors": [],
            "id": "openshift/ruby-hello-world",
            "lastUpdate": "2024-05-21T13:48:43Z",
            "name": "ruby-hello-world",
            "organization": "openshift",
            "url": "https://github.com/openshift/ruby-hello-world"
        }
    ],
    "totalCount": 1
}

```

</details>


<details>
<summary>Searching organization repositories</summary>

```
$ http -A bearer -a "${ADMIN_CURL_TOKEN}" GET http://localhost:7007/api/bulk-import/organizations/janus-idp/repositories search=='operator'

{
    "errors": [],
    "repositories": [
        {
            "defaultBranch": "main",
            "errors": [],
            "id": "janus-idp/backstage-operator",
            "lastUpdate": "2023-12-19T12:17:52Z",
            "name": "backstage-operator",
            "organization": "janus-idp",
            "url": "https://github.com/janus-idp/backstage-operator"
        },
        {
            "defaultBranch": "main",
            "errors": [],
            "id": "janus-idp/operator",
            "lastUpdate": "2024-08-19T09:28:01Z",
            "name": "operator",
            "organization": "janus-idp",
            "url": "https://github.com/janus-idp/operator"
        }
    ],
    "totalCount": 2
}

```

</details>


<details>
<summary>Searching Imports (on repository names)</summary>

```
$ http -A bearer -a "${ADMIN_CURL_TOKEN}" GET http://localhost:7007/api/bulk-import/imports search=='happiness'

[
    {
        "approvalTool": "GIT",
        "id": "https://github.com/lemra-org-ent-2/animated-happiness",
        "lastUpdate": "2024-09-12T11:52:58Z",
        "repository": {
            "defaultBranch": "main",
            "id": "lemra-org-ent-2/animated-happiness",
            "name": "animated-happiness",
            "organization": "lemra-org-ent-2",
            "url": "https://github.com/lemra-org-ent-2/animated-happiness"
        },
        "status": "ADDED"
    }
]


```

</details>
