### PR TITLE
fix(bulk-import): make sure import branch is up-to-date to prevent potential conflicts or unchanged files in GH [RHIDP-3901]

### DIFF
--- a/plugins/bulk-import-backend/src/service/githubApiService.ts
+++ b/plugins/bulk-import-backend/src/service/githubApiService.ts
@@ -897,22 +897,8 @@ export class GithubApiService {
     lastUpdate?: string;
     errors?: string[];
   }> {
-    const ghConfig = this.integrations.github.byUrl(input.repoUrl)?.config;
-    if (!ghConfig) {
-      throw new Error(`Could not find GH integration from ${input.repoUrl}`);
-    }
-
-    const owner = input.gitUrl.organization;
-    const repo = input.gitUrl.name;
-
-    const credentials = await this.githubCredentialsProvider.getAllCredentials({
-      host: ghConfig.host,
-    });
-    if (credentials.length === 0) {
-      throw new Error(`No credentials for GH integration`);
-    }
-
-    const branchName = getBranchName(this.config);
+    const { ghConfig, owner, repo, credentials, branchName } =
+      await this.validateAndBuildRepoData(input);
     const fileName = getCatalogFilename(this.config);
     const errors: any[] = [];
     for (const credential of credentials) {
@@ -1054,6 +1040,29 @@ export class GithubApiService {
     };
   }
 
+  private async validateAndBuildRepoData(input: {
+    repoUrl: string;
+    gitUrl: gitUrlParse.GitUrl;
+  }) {
+    const ghConfig = this.integrations.github.byUrl(input.repoUrl)?.config;
+    if (!ghConfig) {
+      throw new Error(`Could not find GH integration from ${input.repoUrl}`);
+    }
+
+    const owner = input.gitUrl.organization;
+    const repo = input.gitUrl.name;
+
+    const credentials = await this.githubCredentialsProvider.getAllCredentials({
+      host: ghConfig.host,
+    });
+    if (credentials.length === 0) {
+      throw new Error(`No credentials for GH integration`);
+    }
+
+    const branchName = getBranchName(this.config);
+    return { ghConfig, owner, repo, credentials, branchName };
+  }
+
   private async fileExistsInDefaultBranch(
     logger: Logger,
     octo: Octokit,
@@ -1172,22 +1181,8 @@ export class GithubApiService {
       comment: string;
     },
   ) {
-    const ghConfig = this.integrations.github.byUrl(input.repoUrl)?.config;
-    if (!ghConfig) {
-      throw new Error(`Could not find GH integration from ${input.repoUrl}`);
-    }
-
-    const owner = input.gitUrl.organization;
-    const repo = input.gitUrl.name;
-
-    const credentials = await this.githubCredentialsProvider.getAllCredentials({
-      host: ghConfig.host,
-    });
-    if (credentials.length === 0) {
-      throw new Error(`No credentials for GH integration`);
-    }
-
-    const branchName = getBranchName(this.config);
+    const { ghConfig, owner, repo, credentials, branchName } =
+      await this.validateAndBuildRepoData(input);
     for (const credential of credentials) {
       const octo = this.buildOcto({ credential, owner }, ghConfig.apiBaseUrl);
       if (!octo) {
@@ -1281,22 +1276,8 @@ export class GithubApiService {
       gitUrl: gitUrlParse.GitUrl;
     },
   ) {
-    const ghConfig = this.integrations.github.byUrl(input.repoUrl)?.config;
-    if (!ghConfig) {
-      throw new Error(`Could not find GH integration from ${input.repoUrl}`);
-    }
-
-    const owner = input.gitUrl.organization;
-    const repo = input.gitUrl.name;
-
-    const credentials = await this.githubCredentialsProvider.getAllCredentials({
-      host: ghConfig.host,
-    });
-    if (credentials.length === 0) {
-      throw new Error(`No credentials for GH integration`);
-    }
-
-    const branchName = getBranchName(this.config);
+    const { ghConfig, owner, repo, credentials, branchName } =
+      await this.validateAndBuildRepoData(input);
     for (const credential of credentials) {
       const octo = this.buildOcto({ credential, owner }, ghConfig.apiBaseUrl);
       if (!octo) {

--- a/plugins/bulk-import-backend/src/service/handlers/bulkImports.test.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/bulkImports.test.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2024 The Janus IDP Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getVoidLogger } from '@backstage/backend-common';
+import {
+  AuthService,
+  BackstageCredentials,
+  BackstagePrincipalTypes,
+} from '@backstage/backend-plugin-api';
+import { ConfigReader } from '@backstage/config';
+
+import { Logger } from 'winston';
+
+import { CatalogInfoGenerator } from '../../helpers';
+import { GithubApiService } from '../githubApiService';
+import { deleteImportByRepo } from './bulkImports';
+
+const mockDiscovery = {
+  getBaseUrl: jest.fn().mockResolvedValue('https://api.example.com'),
+  getExternalBaseUrl: jest.fn().mockResolvedValue('https://api.example.com'),
+};
+
+const config = new ConfigReader({
+  app: {
+    baseUrl: 'https://my-backstage-app.example.com',
+  },
+  integrations: {
+    github: [
+      {
+        host: 'github.com',
+        apps: [
+          {
+            appId: 1,
+            privateKey: 'privateKey',
+            webhookSecret: '123',
+            clientId: 'CLIENT_ID',
+            clientSecret: 'CLIENT_SECRET',
+          },
+        ],
+        token: 'hardcoded_token',
+      },
+    ],
+  },
+});
+
+describe('bulkimports.ts tests', () => {
+  let logger: Logger;
+  let mockAuth: AuthService;
+  let mockCatalogInfoGenerator: CatalogInfoGenerator;
+  let mockGithubApiService: GithubApiService;
+
+  beforeAll(() => {
+    logger = getVoidLogger();
+    mockAuth = {
+      isPrincipal<TType extends keyof BackstagePrincipalTypes>(
+        _credentials: BackstageCredentials,
+        _type: TType,
+      ): _credentials is BackstageCredentials<BackstagePrincipalTypes[TType]> {
+        return false;
+      },
+      getPluginRequestToken: () =>
+        Promise.resolve({ token: 'ey123.abc.xyzzz' }),
+      authenticate: jest.fn(),
+      getNoneCredentials: jest.fn(),
+      getOwnServiceCredentials: jest.fn().mockResolvedValue({
+        principal: {
+          subject: 'my-sub',
+        },
+      }),
+      getLimitedUserToken: jest.fn(),
+      listPublicServiceKeys: jest.fn(),
+    };
+    mockCatalogInfoGenerator = new CatalogInfoGenerator(
+      logger,
+      mockDiscovery,
+      mockAuth,
+    );
+    mockGithubApiService = new GithubApiService(logger, config);
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('deleteImportByRepo', () => {
+    it('should not try to delete PR is there is no open import PR, but still try to delete import branch if any', async () => {
+      const repoUrl = 'https://github.com/my-org-1/my-repo-11';
+      const defaultBranch = 'main';
+      jest
+        .spyOn(mockGithubApiService, 'findImportOpenPr')
+        .mockResolvedValue({});
+      jest.spyOn(mockGithubApiService, 'closePR').mockResolvedValue();
+      jest
+        .spyOn(mockGithubApiService, 'deleteImportBranch')
+        .mockResolvedValue();
+      jest
+        .spyOn(mockCatalogInfoGenerator, 'listCatalogUrlLocationsById')
+        .mockResolvedValue(
+          new Map([
+            [
+              'location-id-11',
+              `${repoUrl}/blob/${defaultBranch}/catalog-info.yaml`,
+            ],
+          ]),
+        );
+      jest
+        .spyOn(mockCatalogInfoGenerator, 'deleteCatalogLocationById')
+        .mockResolvedValue();
+      await deleteImportByRepo(
+        logger,
+        config,
+        mockGithubApiService,
+        mockCatalogInfoGenerator,
+        repoUrl,
+        defaultBranch,
+      );
+
+      expect(mockGithubApiService.closePR).not.toHaveBeenCalled();
+      expect(mockGithubApiService.deleteImportBranch).toHaveBeenCalledTimes(1);
+      expect(mockGithubApiService.deleteImportBranch).toHaveBeenNthCalledWith(
+        1,
+        logger,
+        expect.objectContaining({
+          repoUrl,
+        }),
+      );
+      expect(
+        mockCatalogInfoGenerator.deleteCatalogLocationById,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockCatalogInfoGenerator.deleteCatalogLocationById,
+      ).toHaveBeenNthCalledWith(1, 'location-id-11');
+    });
+
+    it('should try to delete both PR and branch is there is an open import PR', async () => {
+      const repoUrl = 'https://github.com/my-org-1/my-repo-12';
+      const defaultBranch = 'dev';
+      const prNum = 123456789;
+      jest.spyOn(mockGithubApiService, 'findImportOpenPr').mockResolvedValue({
+        prNum,
+        prUrl: `${repoUrl}/pull/${prNum}`,
+      });
+      jest.spyOn(mockGithubApiService, 'closePR').mockResolvedValue();
+      jest
+        .spyOn(mockGithubApiService, 'deleteImportBranch')
+        .mockResolvedValue();
+      jest
+        .spyOn(mockCatalogInfoGenerator, 'listCatalogUrlLocationsById')
+        .mockResolvedValue(
+          new Map([
+            [
+              'location-id-12',
+              `${repoUrl}/blob/${defaultBranch}/catalog-info.yaml`,
+            ],
+          ]),
+        );
+      jest
+        .spyOn(mockCatalogInfoGenerator, 'deleteCatalogLocationById')
+        .mockResolvedValue();
+      await deleteImportByRepo(
+        logger,
+        config,
+        mockGithubApiService,
+        mockCatalogInfoGenerator,
+        repoUrl,
+        defaultBranch,
+      );
+
+      expect(mockGithubApiService.closePR).toHaveBeenCalledTimes(1);
+      expect(mockGithubApiService.closePR).toHaveBeenCalledWith(
+        logger,
+        expect.objectContaining({
+          repoUrl,
+          comment: 'Closing PR upon request for bulk import deletion',
+        }),
+      );
+      expect(mockGithubApiService.deleteImportBranch).toHaveBeenCalledTimes(1);
+      expect(mockGithubApiService.deleteImportBranch).toHaveBeenCalledWith(
+        logger,
+        expect.objectContaining({
+          repoUrl,
+        }),
+      );
+      expect(
+        mockCatalogInfoGenerator.deleteCatalogLocationById,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockCatalogInfoGenerator.deleteCatalogLocationById,
+      ).toHaveBeenCalledWith('location-id-12');
+    });
+  });
+});

--- a/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
@@ -543,14 +543,20 @@ export async function deleteImportByRepo(
   const openImportPr = await githubApiService.findImportOpenPr(logger, {
     repoUrl: repoUrl,
   });
+  const gitUrl = gitUrlParse(repoUrl);
   if (openImportPr.prUrl) {
     // Close PR
     await githubApiService.closePR(logger, {
       repoUrl,
-      gitUrl: gitUrlParse(repoUrl),
+      gitUrl,
       comment: `Closing PR upon request for bulk import deletion`,
     });
   }
+  // Also delete the import branch, so that it is not outdated if we try later to import the repo again
+  await githubApiService.deleteImportBranch(logger, {
+    repoUrl,
+    gitUrl,
+  });
   // Remove Location from catalog
   const catalogLocations =
     await catalogInfoGenerator.listCatalogUrlLocationsById();


### PR DESCRIPTION
**What does this PR do / why we need it:**

The branch linked to an import PR could be outdated compared to the default branch.
To fix the issue reported in https://issues.redhat.com/browse/RHIDP-3901, the backend now ensures:
- that the import branch is up-to-date (best effort) prior to creating the import PR in case the branch already exists
- that the import branch is also deleted when the import PR is closed (when deleting an import job)

**Which issue(s) this PR fixes:**

https://issues.redhat.com/browse/RHIDP-3901

**PR acceptance criteria:**

- [x] Unit tests

- [ ] Integration tests

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

See https://issues.redhat.com/browse/RHIDP-3901 for the repro steps.

Before the changes here, import PR could end up in Conflict on GH:

![Screenshot from 2024-09-10 13-12-19](https://github.com/user-attachments/assets/986510c5-c7c5-48ce-ada8-ddcff636c518)

Now with the changes here, the backend attempts to keep the import branch up-to-date, so that the import PR is merge-able:

![Screenshot from 2024-09-10 13-20-13](https://github.com/user-attachments/assets/baca04f6-7106-44fa-902c-e193a147f3bb)


/cc @invincibleJai @PatAKnight 