### PR TITLE
chore(release): revert downgrade of bulk-import-backend plugin

### DIFF
--- a/plugins/bulk-import-backend/CHANGELOG.md
+++ b/plugins/bulk-import-backend/CHANGELOG.md
@@ -1,10 +1,5 @@
 ### Dependencies
 
-* **@janus-idp/backstage-plugin-bulk-import-common:** upgraded to 1.0.0
-* **@janus-idp/cli:** upgraded to 1.0.0
-
-### Dependencies
-
 * **@janus-idp/backstage-plugin-bulk-import-common:** upgraded to 1.0.1
 
 ### Dependencies

--- a/plugins/bulk-import-backend/dist-dynamic/package.json
+++ b/plugins/bulk-import-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-bulk-import-backend-dynamic",
-  "version": "1.0.0",
+  "version": "1.4.1",
   "main": "./dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/bulk-import-backend/package.json
+++ b/plugins/bulk-import-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-bulk-import-backend",
-  "version": "1.0.0",
+  "version": "1.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -57,7 +57,7 @@
     "@backstage/plugin-catalog-node": "^1.12.4",
     "@backstage/plugin-permission-common": "^0.8.0",
     "@backstage/plugin-permission-node": "^0.8.0",
-    "@janus-idp/backstage-plugin-bulk-import-common": "1.0.0",
+    "@janus-idp/backstage-plugin-bulk-import-common": "1.0.1",
     "@octokit/auth-app": "^6.0.3",
     "@octokit/core": "^5.1.0",
     "@octokit/rest": "^20.0.2",
@@ -78,7 +78,7 @@
     "@backstage/backend-test-utils": "0.4.4",
     "@backstage/cli": "0.26.11",
     "@backstage/plugin-catalog-backend": "1.24.0",
-    "@janus-idp/cli": "1.0.0",
+    "@janus-idp/cli": "1.13.1",
     "@types/supertest": "2.0.16",
     "supertest": "6.3.4"
   },


### PR DESCRIPTION
This reverts commit a8ae32706e001eadd7a667e3a1f5e356792951d1.

Looks like another MSR issue after https://github.com/janus-idp/backstage-plugins/pull/2131 was merged ([release job logs](https://github.com/janus-idp/backstage-plugins/actions/runs/10793064428/job/29934131723)), causing dirty `yarn.lock` files in PRs like https://github.com/janus-idp/backstage-plugins/pull/2146

/cc @PatAKnight @AndrienkoAleksandr 
