### PR TITLE
fix(bulk-import): bulk import fixes

### DIFF
--- a/plugins/bulk-import/README.md
+++ b/plugins/bulk-import/README.md
@@ -10,37 +10,14 @@ This plugin allows bulk import of multiple catalog entities into the catalog.
 
 The sections below are relevant for static plugins. If the plugin is expected to be installed as a dynamic one:
 
-- follow https://github.com/janus-idp/backstage-showcase/blob/main/showcase-docs/dynamic-plugins.md#installing-a-dynamic-plugin-package-in-the-showcase
-- add content of `app-config.janus-idp.yaml` into `app-config.local.yaml`.
+- Follow https://github.com/janus-idp/backstage-showcase/blob/main/showcase-docs/dynamic-plugins.md#installing-a-dynamic-plugin-package-in-the-showcase
+- Add content of `app-config.janus-idp.yaml` into `app-config.local.yaml`.
 
 #### Prerequisites
 
 - Follow the Bulk import backend plugin [README](https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import-backend/README.md) to integrate bulk import in your Backstage instance.
 
 - Follow the [GitHub Locations](https://backstage.io/docs/integrations/github/locations) to integrate GitHub integrations in your Backstage instance. For now, the plugin only supports loading catalog entities from github.com or GitHub Enterprise.
-
----
-
-**NOTE**
-
-- When RBAC permission framework is enabled, for non-admin users wanting to access bulk import UI, the role associated with your user should have the following permission policies associated with it. Add the following in your permission policies configuration file:
-
-```CSV
-p, role:default/team_a, catalog-entity.read, read, allow
-p, role:default/team_a, catalog-entity.create, create, allow
-g, user:default/<login-id/user-name>, role:default/team_a
-```
-
-#### Installing as a dynamic plugin?
-
-The sections below are relevant for static plugins. If the plugin is expected to be installed as a dynamic one:
-
-- follow https://github.com/janus-idp/backstage-showcase/blob/main/showcase-docs/dynamic-plugins.md#installing-a-dynamic-plugin-package-in-the-showcase
-- add content of `app-config.janus-idp.yaml` into `app-config.local.yaml`.
-
-#### Prerequisites
-
-Follow the Bulk import backend plugin [README](https://github.com/janus-idp/backstage-plugins/blob/main/plugins/bulk-import-backend/README.md) to integrate bulk import in your Backstage instance.
 
 ---
 

--- a/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesFormFooter.tsx
+++ b/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesFormFooter.tsx
@@ -39,6 +39,7 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     borderTopStyle: 'groove',
     border: theme.palette.divider,
+    zIndex: 1,
   },
 }));
 

--- a/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesPage.tsx
+++ b/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesPage.tsx
@@ -47,6 +47,7 @@ const useStyles = makeStyles(() => ({
 export const AddRepositoriesPage = () => {
   const theme = useTheme();
   const classes = useStyles();
+  const bulkImportApi = useApi(bulkImportApiRef);
   const navigate = useNavigate();
   const [generalSubmitError, setGeneralSubmitError] = React.useState<{
     message: string;
@@ -59,7 +60,6 @@ export const AddRepositoriesPage = () => {
     approvalTool: ApprovalTool.Git,
   };
 
-  const bulkImportApi = useApi(bulkImportApiRef);
   const bulkImportViewPermissionResult = usePermission({
     permission: bulkImportPermission,
     resourceRef: bulkImportPermission.resourceType,
@@ -102,7 +102,7 @@ export const AddRepositoriesPage = () => {
             formikHelpers.setStatus(createJobErrors);
             formikHelpers.setSubmitting(false);
           } else {
-            navigate(`../bulk-import/repositories`);
+            navigate(`..`);
           }
         }
       }
@@ -115,25 +115,25 @@ export const AddRepositoriesPage = () => {
     }
   };
 
-  return (
-    <Page themeId="tool">
-      <Header title="Add repositories" type="Bulk import" typeLink=".." />
-      <Content noPadding>
-        {bulkImportViewPermissionResult.loading && <Progress />}
-        {bulkImportViewPermissionResult.allowed ? (
-          <>
-            <div style={{ padding: '24px' }}>
-              <Accordion defaultExpanded>
-                <AccordionSummary
-                  expandIcon={<ExpandMoreIcon />}
-                  id="add-repository-summary"
-                >
-                  <Typography variant="h5">
-                    Add repositories to Red Hat Developer Hub in 4 steps
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails className={classes.accordionDetails}>
-                  {/* <Illustrations
+  const showContent = () => {
+    if (bulkImportViewPermissionResult.loading) {
+      return <Progress />;
+    }
+    if (bulkImportViewPermissionResult.allowed) {
+      return (
+        <>
+          <div style={{ padding: '24px' }}>
+            <Accordion defaultExpanded>
+              <AccordionSummary
+                expandIcon={<ExpandMoreIcon />}
+                id="add-repository-summary"
+              >
+                <Typography variant="h5">
+                  Add repositories to Red Hat Developer Hub in 4 steps
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails className={classes.accordionDetails}>
+                {/* <Illustrations
                 iconClassname={
                   theme.palette.type === 'dark'
                     ? 'icon-approval-tool-white'
@@ -141,61 +141,68 @@ export const AddRepositoriesPage = () => {
                 }
                 iconText="Choose approval tool (git/ServiceNow) for PR/ticket creation"
               /> */}
-                  <Illustrations
-                    iconClassname={
-                      theme.palette.type === 'dark'
-                        ? 'icon-choose-repositories-white'
-                        : 'icon-choose-repositories-black'
-                    }
-                    iconText="Choose repositories you want to add"
-                  />
-                  <Illustrations
-                    iconClassname={
-                      theme.palette.type === 'dark'
-                        ? 'icon-generate-cataloginfo-white'
-                        : 'icon-generate-cataloginfo-black'
-                    }
-                    iconText="Generate a catalog-info.yaml file for each repository"
-                  />
-                  <Illustrations
-                    iconClassname={
-                      theme.palette.type === 'dark'
-                        ? 'icon-edit-pullrequest-white'
-                        : 'icon-edit-pullrequest-black'
-                    }
-                    iconText="Edit the pull request details if needed"
-                  />
-                  <Illustrations
-                    iconClassname={
-                      theme.palette.type === 'dark'
-                        ? 'icon-track-status-white'
-                        : 'icon-track-status-black'
-                    }
-                    iconText="Track the approval status"
-                  />
-                </AccordionDetails>
-              </Accordion>
-            </div>
-            <DrawerContextProvider>
-              <Formik
-                initialValues={initialValues}
-                enableReinitialize
-                onSubmit={handleSubmit}
-              >
-                <AddRepositoriesForm error={generalSubmitError} />
-              </Formik>
-            </DrawerContextProvider>
-          </>
-        ) : (
-          <div style={{ padding: '24px' }}>
-            <Alert severity="warning" data-testid="no-permission-alert">
-              <AlertTitle>Permission required</AlertTitle>
-              To add repositories, contact your administrator to give you the
-              `bulk.import` permission.
-            </Alert>
+                <Illustrations
+                  iconClassname={
+                    theme.palette.type === 'dark'
+                      ? 'icon-choose-repositories-white'
+                      : 'icon-choose-repositories-black'
+                  }
+                  iconText="Choose repositories you want to add"
+                />
+                <Illustrations
+                  iconClassname={
+                    theme.palette.type === 'dark'
+                      ? 'icon-generate-cataloginfo-white'
+                      : 'icon-generate-cataloginfo-black'
+                  }
+                  iconText="Generate a catalog-info.yaml file for each repository"
+                />
+                <Illustrations
+                  iconClassname={
+                    theme.palette.type === 'dark'
+                      ? 'icon-edit-pullrequest-white'
+                      : 'icon-edit-pullrequest-black'
+                  }
+                  iconText="Edit the pull request details if needed"
+                />
+                <Illustrations
+                  iconClassname={
+                    theme.palette.type === 'dark'
+                      ? 'icon-track-status-white'
+                      : 'icon-track-status-black'
+                  }
+                  iconText="Track the approval status"
+                />
+              </AccordionDetails>
+            </Accordion>
           </div>
-        )}
-      </Content>
+          <DrawerContextProvider>
+            <Formik
+              initialValues={initialValues}
+              enableReinitialize
+              onSubmit={handleSubmit}
+            >
+              <AddRepositoriesForm error={generalSubmitError} />
+            </Formik>
+          </DrawerContextProvider>
+        </>
+      );
+    }
+    return (
+      <div style={{ padding: '24px' }}>
+        <Alert severity="warning" data-testid="no-permission-alert">
+          <AlertTitle>Permission required</AlertTitle>
+          To add repositories, contact your administrator to give you the
+          `bulk.import` permission.
+        </Alert>
+      </div>
+    );
+  };
+
+  return (
+    <Page themeId="tool">
+      <Header title="Add repositories" type="Bulk import" typeLink=".." />
+      <Content noPadding>{showContent()}</Content>
     </Page>
   );
 };

--- a/plugins/bulk-import/src/components/BulkImportPage.tsx
+++ b/plugins/bulk-import/src/components/BulkImportPage.tsx
@@ -33,32 +33,39 @@ export const BulkImportPage = () => {
     resourceRef: bulkImportPermission.resourceType,
   });
 
+  const showContent = () => {
+    if (bulkImportViewPermissionResult.loading) {
+      return <Progress />;
+    }
+    if (bulkImportViewPermissionResult.allowed) {
+      return (
+        <Formik
+          initialValues={initialValues}
+          enableReinitialize
+          onSubmit={async (_values: AddRepositoriesFormValues) => {}}
+        >
+          <FormControl fullWidth>
+            <RepositoriesList />
+          </FormControl>
+        </Formik>
+      );
+    }
+    return (
+      <Alert severity="warning" data-testid="no-permission-alert">
+        <AlertTitle>Permission required</AlertTitle>
+        To view the added repositories, contact your administrator to give you
+        the `bulk.import` permission.
+      </Alert>
+    );
+  };
+
   return (
     <Page themeId="tool">
       <Header title="Bulk import" />
       <DrawerContextProvider>
         <DeleteDialogContextProvider>
           <Content noPadding>
-            <div style={{ padding: '24px' }}>
-              {bulkImportViewPermissionResult.loading && <Progress />}
-              {bulkImportViewPermissionResult.allowed ? (
-                <Formik
-                  initialValues={initialValues}
-                  enableReinitialize
-                  onSubmit={async (_values: AddRepositoriesFormValues) => {}}
-                >
-                  <FormControl fullWidth>
-                    <RepositoriesList />
-                  </FormControl>
-                </Formik>
-              ) : (
-                <Alert severity="warning" data-testid="no-permission-alert">
-                  <AlertTitle>Permission required</AlertTitle>
-                  To view the added repositories, contact your administrator to
-                  give you the `bulk.import` permission.
-                </Alert>
-              )}
-            </div>
+            <div style={{ padding: '24px' }}>{showContent()}</div>
           </Content>
         </DeleteDialogContextProvider>
       </DrawerContextProvider>

--- a/plugins/bulk-import/src/components/PreviewFile/KeyValueTextField.tsx
+++ b/plugins/bulk-import/src/components/PreviewFile/KeyValueTextField.tsx
@@ -55,7 +55,7 @@ const KeyValueTextField: React.FC<KeyValueTextFieldProps> = ({
     return {
       ...formErrors,
       [repoId]: {
-        ...formErrors[repoId],
+        ...(formErrors?.[repoId] || {}),
         [fieldName]: validationError,
       },
     };

--- a/plugins/bulk-import/src/components/PreviewFile/PreviewFile.tsx
+++ b/plugins/bulk-import/src/components/PreviewFile/PreviewFile.tsx
@@ -60,7 +60,7 @@ export const PreviewFile = ({ data }: { data: AddRepositoryData }) => {
           <Link
             to={errorMessage.showRepositoryLink ? data.repoUrl || '' : ''}
             onClick={() =>
-              errorMessage.showRepositoryLink ? null : setOpenDrawer(true)
+              errorMessage.showRepositoryLink ? null : openDrawer(data)
             }
             data-testid="edit-pull-request"
           >

--- a/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebar.tsx
+++ b/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebar.tsx
@@ -1,31 +1,29 @@
 import * as React from 'react';
 
-import { Link } from '@backstage/core-components';
-import { useApi } from '@backstage/core-plugin-api';
+import {
+  configApiRef,
+  identityApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
 
-import { Button, Drawer, makeStyles } from '@material-ui/core';
-import { Skeleton } from '@material-ui/lab';
-import CloseIcon from '@mui/icons-material/Close';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import Box from '@mui/material/Box';
-import CircularProgress from '@mui/material/CircularProgress';
-import IconButton from '@mui/material/IconButton';
-import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
+import { Drawer, makeStyles } from '@material-ui/core';
+import { useFormikContext } from 'formik';
 
 import { bulkImportApiRef } from '../../api/BulkImportBackendClient';
 import {
+  AddRepositoriesFormValues,
   AddRepositoryData,
   ImportJobStatus,
   PullRequestPreview,
   PullRequestPreviewData,
-  RepositorySelection,
   RepositoryStatus,
   RepositoryType,
 } from '../../types';
-import { evaluatePRTemplate, urlHelper } from '../../utils/repository-utils';
-import { PreviewPullRequest } from './PreviewPullRequest';
-import { PreviewPullRequests } from './PreviewPullRequests';
+import {
+  evaluatePRTemplate,
+  getPRTemplate,
+} from '../../utils/repository-utils';
+import { PreviewFileSidebarDrawerContent } from './PreviewFileSidebarDrawerContent';
 
 const useDrawerStyles = makeStyles(theme => ({
   paper: {
@@ -36,178 +34,6 @@ const useDrawerStyles = makeStyles(theme => ({
     padding: theme.spacing(2.5),
   },
 }));
-
-const useDrawerContentStyles = makeStyles(theme => ({
-  createButton: {
-    marginRight: theme.spacing(1),
-  },
-  header: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'baseline',
-    padding: theme.spacing(2.5),
-  },
-  body: {
-    padding: theme.spacing(2.5),
-    paddingTop: theme.spacing(1),
-    paddingBottom: theme.spacing(1),
-    marginBottom: '100px',
-    flexGrow: 1,
-  },
-  footer: {
-    flexDirection: 'row',
-    gap: '14px',
-    paddingTop: theme.spacing(2.5),
-    display: 'flex',
-    justifyContent: 'left',
-    position: 'fixed',
-    bottom: 0,
-    paddingLeft: '24px',
-    paddingBottom: '24px',
-    backgroundColor: theme.palette.background.paper,
-    width: '100%',
-    borderTopStyle: 'groove',
-    border: theme.palette.divider,
-    zIndex: 1,
-  },
-}));
-
-const DrawerContent = ({
-  repositoryType,
-  onCancel,
-  isLoading,
-  isSubmitting,
-  data,
-  pullRequest,
-  onSave,
-  setPullRequest,
-}: {
-  repositoryType: string;
-  onCancel: () => void;
-  isLoading: boolean;
-  isSubmitting: boolean | undefined;
-  data: AddRepositoryData;
-  pullRequest: PullRequestPreviewData;
-  onSave: (pullRequest: PullRequestPreviewData, _event: any) => void;
-
-  setPullRequest: (pullRequest: PullRequestPreviewData) => void;
-}) => {
-  const [formErrors, setFormErrors] = React.useState<PullRequestPreviewData>();
-  const classes = useDrawerStyles();
-  const contentClasses = useDrawerContentStyles();
-
-  if (isLoading) {
-    return (
-      <Stack spacing={5} className={classes.body}>
-        <span style={{ display: 'flex', height: '10%' }}>
-          <Skeleton variant="rect" width="100%" height="100%" />
-          <IconButton
-            key="dismiss"
-            title="Close the drawer"
-            onClick={onCancel}
-            color="inherit"
-          >
-            <CloseIcon fontSize="small" />
-          </IconButton>
-        </span>
-        <Skeleton variant="rect" width="100%" height={750} />
-        <Skeleton variant="rect" width="100%" height="10%" />
-      </Stack>
-    );
-  }
-  return (
-    <>
-      <Box>
-        <Box className={contentClasses.header}>
-          <div>
-            {repositoryType === RepositorySelection.Repository ? (
-              <>
-                <Typography variant="h5">
-                  {`${data.orgName ?? data.organizationUrl}/${data.repoName}`}
-                </Typography>
-                <Link to={data.repoUrl ?? ''}>
-                  {urlHelper(data.repoUrl || '')}
-                  <OpenInNewIcon
-                    style={{ verticalAlign: 'sub', paddingTop: '7px' }}
-                  />
-                </Link>
-              </>
-            ) : (
-              <>
-                <Typography variant="h5">{`${data.orgName}`}</Typography>
-                <Link to={data.organizationUrl ?? ''}>
-                  {urlHelper(data.organizationUrl || '')}
-                  <OpenInNewIcon
-                    style={{ verticalAlign: 'sub', paddingTop: '7px' }}
-                  />
-                </Link>
-              </>
-            )}
-          </div>
-
-          <IconButton
-            key="dismiss"
-            title="Close the drawer"
-            onClick={onCancel}
-            color="inherit"
-          >
-            <CloseIcon fontSize="small" />
-          </IconButton>
-        </Box>
-
-        <Box className={contentClasses.body}>
-          {repositoryType === RepositorySelection.Repository && (
-            <PreviewPullRequest
-              repoId={data.id}
-              repoUrl={data.repoUrl || ''}
-              repoBranch={data.defaultBranch || 'main'}
-              pullRequest={pullRequest}
-              setPullRequest={setPullRequest}
-              formErrors={formErrors as PullRequestPreviewData}
-              setFormErrors={setFormErrors}
-            />
-          )}
-          {repositoryType === RepositorySelection.Organization && (
-            <PreviewPullRequests
-              repositories={
-                Object.values(data?.selectedRepositories || []) || []
-              }
-              pullRequest={pullRequest}
-              formErrors={formErrors as PullRequestPreviewData}
-              setFormErrors={setFormErrors}
-              setPullRequest={setPullRequest}
-            />
-          )}
-        </Box>
-      </Box>
-      <div className={contentClasses.footer}>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={e => onSave(pullRequest, e)}
-          className={contentClasses.createButton}
-          disabled={
-            isSubmitting ||
-            (!!formErrors &&
-              Object.values(formErrors).length > 0 &&
-              Object.values(formErrors).every(
-                fe => !!fe && Object.values(fe).length > 0,
-              ))
-          }
-          startIcon={
-            isSubmitting && <CircularProgress size="20px" color="inherit" />
-          }
-        >
-          Save
-        </Button>
-        <Link to="" variant="button" onClick={onCancel}>
-          <Button variant="outlined">Cancel</Button>
-        </Link>
-      </div>
-    </>
-  );
-};
 
 export const PreviewFileSidebar = ({
   open,
@@ -224,52 +50,116 @@ export const PreviewFileSidebar = ({
   handleSave: (pullRequest: PullRequestPreviewData, _event: any) => void;
   isSubmitting?: boolean;
 }) => {
+  const { setStatus, status } = useFormikContext<AddRepositoriesFormValues>();
   const classes = useDrawerStyles();
   const bulkImportApi = useApi(bulkImportApiRef);
+  const identityApi = useApi(identityApiRef);
+  const configApi = useApi(configApiRef);
   const [pullRequest, setPullRequest] = React.useState<PullRequestPreviewData>(
     {},
   );
   const [isInitialized, setIsInitialized] = React.useState(false);
 
+  const fetchPullRequestData = async (
+    id: string,
+    repoName: string,
+    orgName: string,
+    url: string,
+    branch: string,
+    repoPrTemplate: PullRequestPreview,
+  ) => {
+    const result = await bulkImportApi.getImportAction(
+      url || '',
+      branch || 'main',
+    );
+    if ((result as Response)?.statusText) {
+      setStatus({
+        ...status,
+        errors: {
+          ...(status?.errors || {}),
+          [data.id]: {
+            error: {
+              title: (result as Response)?.statusText,
+              message: [
+                `Failed to fetch the pull request. A new YAML has been generated below.`,
+              ],
+            },
+          },
+        },
+      });
+      return repoPrTemplate;
+    } else if (
+      (result as ImportJobStatus)?.status === RepositoryStatus.WAIT_PR_APPROVAL
+    ) {
+      const importJobResult = result as ImportJobStatus;
+      const evaluatedPRTemplate = evaluatePRTemplate(importJobResult);
+      let pullReqPreview = { ...evaluatedPRTemplate.pullReqPreview };
+
+      if (evaluatedPRTemplate.isInvalidEntity) {
+        const identityRef = await identityApi.getBackstageIdentity();
+        const baseUrl = configApi.getString('app.baseUrl');
+        const prTemp = getPRTemplate(
+          repoName,
+          orgName,
+          identityRef.userEntityRef || 'user:default/guest',
+          baseUrl as string,
+          url,
+          branch,
+        );
+        delete prTemp.prDescription;
+        delete prTemp.prTitle;
+
+        setStatus({
+          ...status,
+          infos: {
+            ...(status?.infos || {}),
+            [id]: {
+              error: {
+                message: [
+                  `The entity YAML in your pull request is invalid (empty file or missing apiVersion, kind, or metadata.name). A new YAML has been generated below.`,
+                ],
+              },
+            },
+          },
+        });
+        pullReqPreview = {
+          ...prTemp,
+          prDescription: pullReqPreview.prDescription || '',
+          prTitle: pullReqPreview.prTitle || '',
+        };
+      }
+      return pullReqPreview;
+    }
+    return repoPrTemplate;
+  };
+
   const initializePullRequest = React.useCallback(async () => {
     const newPullRequestData: PullRequestPreviewData = {};
     if (Object.keys(data?.selectedRepositories || [])?.length > 0) {
       for (const repo of Object.values(data?.selectedRepositories || [])) {
-        const result = await bulkImportApi.getImportAction(
+        newPullRequestData[repo.id] = await fetchPullRequestData(
+          repo.id,
+          repo.repoName || '',
+          repo.orgName || '',
           repo.repoUrl || '',
           repo.defaultBranch || 'main',
+          repo.catalogInfoYaml?.prTemplate as PullRequestPreview,
         );
-        if (
-          (result as ImportJobStatus)?.status ===
-          RepositoryStatus.WAIT_PR_APPROVAL
-        ) {
-          const prTemplate = evaluatePRTemplate(result as ImportJobStatus);
-          newPullRequestData[repo.id] = prTemplate;
-        } else {
-          newPullRequestData[repo.id] = repo.catalogInfoYaml
-            ?.prTemplate as PullRequestPreview;
-        }
       }
     } else {
-      const result = await bulkImportApi.getImportAction(
+      newPullRequestData[data.id] = await fetchPullRequestData(
+        data.id,
+        data.repoName || '',
+        data.orgName || '',
         data.repoUrl || '',
         data.defaultBranch || 'main',
+        data.catalogInfoYaml?.prTemplate as PullRequestPreview,
       );
-      if (
-        (result as ImportJobStatus)?.status ===
-        RepositoryStatus.WAIT_PR_APPROVAL
-      ) {
-        const prTemplate = evaluatePRTemplate(result as ImportJobStatus);
-        newPullRequestData[data.id] = prTemplate;
-      } else {
-        newPullRequestData[data.id] = data.catalogInfoYaml
-          ?.prTemplate as PullRequestPreview;
-      }
     }
-
     setPullRequest(newPullRequestData);
     setIsInitialized(true);
-  }, [data, bulkImportApi]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, bulkImportApi, setStatus, status]);
 
   React.useEffect(() => {
     if (!isInitialized && data?.id) {
@@ -296,7 +186,7 @@ export const PreviewFileSidebar = ({
         paper: classes.paper,
       }}
     >
-      <DrawerContent
+      <PreviewFileSidebarDrawerContent
         repositoryType={repositoryType}
         onCancel={handleCancel}
         isLoading={!isInitialized}

--- a/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebarDrawerContent.tsx
+++ b/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebarDrawerContent.tsx
@@ -1,0 +1,204 @@
+import * as React from 'react';
+
+import { Link } from '@backstage/core-components';
+
+import { Button, makeStyles } from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
+import CloseIcon from '@mui/icons-material/Close';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import {
+  AddRepositoryData,
+  PullRequestPreviewData,
+  RepositorySelection,
+} from '../../types';
+import { urlHelper } from '../../utils/repository-utils';
+import { PreviewPullRequest } from './PreviewPullRequest';
+import { PreviewPullRequests } from './PreviewPullRequests';
+
+const useDrawerStyles = makeStyles(theme => ({
+  paper: {
+    width: '40%',
+    gap: '3%',
+  },
+  body: {
+    padding: theme.spacing(2.5),
+  },
+}));
+
+const useDrawerContentStyles = makeStyles(theme => ({
+  createButton: {
+    marginRight: theme.spacing(1),
+  },
+  header: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    padding: theme.spacing(2.5),
+  },
+  body: {
+    padding: theme.spacing(2.5),
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    marginBottom: '100px',
+    flexGrow: 1,
+  },
+  footer: {
+    flexDirection: 'row',
+    gap: '14px',
+    paddingTop: theme.spacing(2.5),
+    display: 'flex',
+    justifyContent: 'left',
+    position: 'fixed',
+    bottom: 0,
+    paddingLeft: '24px',
+    paddingBottom: '24px',
+    backgroundColor: theme.palette.background.paper,
+    width: '100%',
+    borderTopStyle: 'groove',
+    border: theme.palette.divider,
+    zIndex: 1,
+  },
+}));
+
+export const PreviewFileSidebarDrawerContent = ({
+  repositoryType,
+  onCancel,
+  isLoading,
+  isSubmitting,
+  data,
+  pullRequest,
+  onSave,
+  setPullRequest,
+}: {
+  repositoryType: string;
+  onCancel: () => void;
+  isLoading: boolean;
+  isSubmitting: boolean | undefined;
+  data: AddRepositoryData;
+  pullRequest: PullRequestPreviewData;
+  onSave: (pullRequest: PullRequestPreviewData, _event: any) => void;
+
+  setPullRequest: (pullRequest: PullRequestPreviewData) => void;
+}) => {
+  const [formErrors, setFormErrors] = React.useState<PullRequestPreviewData>();
+  const classes = useDrawerStyles();
+  const contentClasses = useDrawerContentStyles();
+
+  if (isLoading) {
+    return (
+      <Stack spacing={5} className={classes.body}>
+        <span style={{ display: 'flex', height: '10%' }}>
+          <Skeleton variant="rect" width="100%" height="100%" />
+          <IconButton
+            key="dismiss"
+            title="Close the drawer"
+            onClick={onCancel}
+            color="inherit"
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </span>
+        <Skeleton variant="rect" width="100%" height={750} />
+        <Skeleton variant="rect" width="100%" height="10%" />
+      </Stack>
+    );
+  }
+  return (
+    <>
+      <Box>
+        <Box className={contentClasses.header}>
+          <div>
+            {repositoryType === RepositorySelection.Repository ? (
+              <>
+                <Typography variant="h5">
+                  {`${data.orgName ?? data.organizationUrl}/${data.repoName}`}
+                </Typography>
+                <Link to={data.repoUrl ?? ''}>
+                  {urlHelper(data.repoUrl || '')}
+                  <OpenInNewIcon
+                    style={{ verticalAlign: 'sub', paddingTop: '7px' }}
+                  />
+                </Link>
+              </>
+            ) : (
+              <>
+                <Typography variant="h5">{`${data.orgName}`}</Typography>
+                <Link to={data.organizationUrl ?? ''}>
+                  {urlHelper(data.organizationUrl || '')}
+                  <OpenInNewIcon
+                    style={{ verticalAlign: 'sub', paddingTop: '7px' }}
+                  />
+                </Link>
+              </>
+            )}
+          </div>
+
+          <IconButton
+            key="dismiss"
+            title="Close the drawer"
+            onClick={onCancel}
+            color="inherit"
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+
+        <Box className={contentClasses.body}>
+          {repositoryType === RepositorySelection.Repository && (
+            <PreviewPullRequest
+              repoId={data.id}
+              repoUrl={data.repoUrl || ''}
+              repoBranch={data.defaultBranch || 'main'}
+              pullRequest={pullRequest}
+              setPullRequest={setPullRequest}
+              formErrors={formErrors as PullRequestPreviewData}
+              setFormErrors={setFormErrors}
+            />
+          )}
+          {repositoryType === RepositorySelection.Organization && (
+            <PreviewPullRequests
+              repositories={
+                Object.values(data?.selectedRepositories || []) || []
+              }
+              pullRequest={pullRequest}
+              formErrors={formErrors as PullRequestPreviewData}
+              setFormErrors={setFormErrors}
+              setPullRequest={setPullRequest}
+            />
+          )}
+        </Box>
+      </Box>
+      <div className={contentClasses.footer}>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={e => onSave(pullRequest, e)}
+          className={contentClasses.createButton}
+          disabled={
+            isSubmitting ||
+            (!!formErrors &&
+              Object.values(formErrors).length > 0 &&
+              Object.values(formErrors).every(
+                fe => !!fe && Object.values(fe).length > 0,
+              ))
+          }
+          startIcon={
+            isSubmitting && <CircularProgress size="20px" color="inherit" />
+          }
+        >
+          Save
+        </Button>
+        <Link to="" variant="button" onClick={onCancel}>
+          <Button variant="outlined">Cancel</Button>
+        </Link>
+      </div>
+    </>
+  );
+};

--- a/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequestForm.test.tsx
+++ b/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequestForm.test.tsx
@@ -105,6 +105,7 @@ describe('Preview Pull Request Form', () => {
               'user:default/guest',
               'https://localhost:3001',
               'https://github.com/org/dessert/cupcake',
+              'main',
             ),
           }}
           setFormErrors={() => jest.fn()}
@@ -159,6 +160,7 @@ describe('Preview Pull Request Form', () => {
               'user:default/guest',
               'https://localhost:3001',
               'https://github.com/org/dessert/cupcake',
+              'main',
             ),
           }}
           setFormErrors={() => jest.fn()}
@@ -215,6 +217,7 @@ describe('Preview Pull Request Form', () => {
               'user:default/guest',
               'https://localhost:3001',
               'https://github.com/org/dessert/cupcake',
+              'main',
             ),
           }}
           setFormErrors={setFormErrors}

--- a/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequests.test.tsx
+++ b/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequests.test.tsx
@@ -100,6 +100,7 @@ describe('Preview Pull Requests', () => {
               'user:default/guest',
               'https://localhost:3001',
               'https://github.com/org/dessert/cupcake',
+              'main',
             ),
           }}
           setFormErrors={() => jest.fn()}
@@ -156,6 +157,7 @@ describe('Preview Pull Requests', () => {
               'user:default/guest',
               'https://localhost:3001',
               'https://github.com/org/dessert/cupcake',
+              'main',
             ),
             'org/dessert/donut': getPRTemplate(
               'org/dessert/donut',
@@ -163,6 +165,7 @@ describe('Preview Pull Requests', () => {
               'user:default/guest',
               'https://localhost:3001',
               'https://github.com/org/dessert/donut',
+              'main',
             ),
           }}
           setFormErrors={() => jest.fn()}
@@ -247,6 +250,7 @@ describe('Preview Pull Requests', () => {
               'user:default/guest',
               'https://localhost:3001',
               'https://github.com/org/dessert/cupcake',
+              'main',
             ),
             'org/dessert/donut': getPRTemplate(
               'org/dessert/donut',
@@ -254,6 +258,7 @@ describe('Preview Pull Requests', () => {
               'user:default/guest',
               'https://localhost:3001',
               'https://github.com/org/dessert/donut',
+              'main',
             ),
           }}
           setFormErrors={() => jest.fn()}

--- a/plugins/bulk-import/src/components/Repositories/EditCatalogInfo.tsx
+++ b/plugins/bulk-import/src/components/Repositories/EditCatalogInfo.tsx
@@ -35,11 +35,11 @@ const EditCatalogInfo = ({
   const { setSubmitting, setStatus, isSubmitting } =
     useFormikContext<AddRepositoriesFormValues>();
 
-  const yamlContent = yaml.load(
+  const yamlContent = yaml.loadAll(
     importStatus?.github?.pullRequest?.catalogInfoContent,
-  ) as Entity;
-  const catalogEntityName = yamlContent.metadata?.name;
-  const entityOwner = yamlContent.spec?.owner as string;
+  )[0] as Entity;
+  const catalogEntityName = yamlContent?.metadata?.name;
+  const entityOwner = yamlContent?.spec?.owner as string;
 
   const previewData: AddRepositoryData = {
     id: importStatus?.repository?.id,

--- a/plugins/bulk-import/src/components/Repositories/RepositoriesList.test.tsx
+++ b/plugins/bulk-import/src/components/Repositories/RepositoriesList.test.tsx
@@ -5,6 +5,7 @@ import { identityApiRef } from '@backstage/core-plugin-api';
 import { TestApiProvider } from '@backstage/test-utils';
 
 import { render, screen } from '@testing-library/react';
+import { useFormikContext } from 'formik';
 
 import { useAddedRepositories } from '../../hooks';
 import { mockGetImportJobs } from '../../mocks/mockData';
@@ -101,6 +102,10 @@ describe('RepositoriesList', () => {
   });
 
   it('should have an add button and an Added repositories table', async () => {
+    (useFormikContext as jest.Mock).mockReturnValue({
+      status: null,
+      setFieldValue: jest.fn(),
+    });
     mockUseAddedRepositories.mockReturnValue(mockAsyncData);
     render(
       <Router>
@@ -123,6 +128,10 @@ describe('RepositoriesList', () => {
   });
 
   it('should render the component and display empty content when no data', async () => {
+    (useFormikContext as jest.Mock).mockReturnValue({
+      status: null,
+      setFieldValue: jest.fn(),
+    });
     mockUseAddedRepositories.mockReturnValue({ ...mockAsyncData, data: [] });
     render(
       <Router>
@@ -138,5 +147,27 @@ describe('RepositoriesList', () => {
     const emptyMessage = screen.getByTestId('added-repositories-table-empty');
     expect(emptyMessage).toBeInTheDocument();
     expect(emptyMessage).toHaveTextContent('No records found');
+  });
+
+  it('should display an alert if get import job api fails', async () => {
+    (useFormikContext as jest.Mock).mockReturnValue({
+      status: {
+        title: 'Not found',
+        url: 'https://xyz',
+      },
+      setFieldValue: jest.fn(),
+    });
+    mockUseAddedRepositories.mockReturnValue({ ...mockAsyncData, data: [] });
+    render(
+      <Router>
+        <TestApiProvider apis={[[identityApiRef, mockIdentityApi]]}>
+          <RepositoriesList />
+        </TestApiProvider>
+      </Router>,
+    );
+
+    expect(
+      screen.getByText('Not found https://xyz', { exact: false }),
+    ).toBeInTheDocument();
   });
 });

--- a/plugins/bulk-import/src/components/Repositories/RepositoriesList.tsx
+++ b/plugins/bulk-import/src/components/Repositories/RepositoriesList.tsx
@@ -47,6 +47,7 @@ export const RepositoriesList = () => {
 
   const closeDrawer = () => {
     searchParams.delete('repository');
+    searchParams.delete('defaultBranch');
     navigate({
       pathname: location.pathname,
       search: `?${searchParams.toString()}`,

--- a/plugins/bulk-import/src/components/Repositories/RepositoriesListToolbar.tsx
+++ b/plugins/bulk-import/src/components/Repositories/RepositoriesListToolbar.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import { LinkButton } from '@backstage/core-components';
 
 import { makeStyles } from '@material-ui/core';
+import { Alert, AlertTitle } from '@material-ui/lab';
+import { useFormikContext } from 'formik';
+
+import { AddRepositoriesFormValues } from '../../types';
 
 const useStyles = makeStyles(theme => ({
   toolbar: {
@@ -19,9 +23,25 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export const RepositoriesListToolbar = () => {
+  const { status, setStatus } = useFormikContext<AddRepositoriesFormValues>();
   const classes = useStyles();
+
+  const handleCloseAlert = () => {
+    setStatus(null);
+  };
   return (
     <div>
+      {status && (
+        <>
+          <Alert severity="error" onClose={() => handleCloseAlert()}>
+            <AlertTitle>
+              Error occured while fetching the pull request
+            </AlertTitle>
+            {`${status?.title} ${status?.url}`}
+          </Alert>
+          <br />
+        </>
+      )}
       <span className={classes.toolbar}>
         <LinkButton
           to="add"

--- a/plugins/bulk-import/src/hooks/useAddedRepositories.ts
+++ b/plugins/bulk-import/src/hooks/useAddedRepositories.ts
@@ -85,6 +85,7 @@ export const useAddedRepositories = (
                     user as string,
                     baseUrl as string,
                     val.repository.url || '',
+                    val.repository.defaultBranch || 'main',
                   ),
                   pullRequest: val?.github?.pullRequest?.url || '',
                   lastUpdated: val.lastUpdate,

--- a/plugins/bulk-import/src/hooks/useRepositories.ts
+++ b/plugins/bulk-import/src/hooks/useRepositories.ts
@@ -91,6 +91,7 @@ export const useRepositories = (options: {
               user as string,
               baseUrl as string,
               val.url || '',
+              val.defaultBranch || 'main',
             ),
           },
         })) || [];

--- a/plugins/bulk-import/src/types/types.ts
+++ b/plugins/bulk-import/src/types/types.ts
@@ -17,6 +17,7 @@ export type PullRequestPreview = {
   prAnnotations?: string;
   prLabels?: string;
   prSpec?: string;
+  pullRequestUrl?: string;
   componentName?: string;
   entityOwner?: string;
   useCodeOwnersFile: boolean;
@@ -47,7 +48,6 @@ export type AddRepositoryData = {
   catalogInfoYaml?: {
     status?: ImportStatus;
     prTemplate?: PullRequestPreview;
-    pullRequestUrl?: string;
     lastUpdated?: string;
   };
   lastUpdated?: string;

--- a/plugins/bulk-import/src/utils/repository-utils.test.tsx
+++ b/plugins/bulk-import/src/utils/repository-utils.test.tsx
@@ -5,6 +5,7 @@ import {
 import { ImportJobResponse, RepositoryStatus } from '../types';
 import {
   componentNameRegex,
+  evaluatePRTemplate,
   getJobErrors,
   getNewOrgsData,
   getYamlKeyValuePairs,
@@ -241,5 +242,38 @@ describe('Repository utils', () => {
     expect(componentNameRegex.test('s-cat')).toBe(true);
     expect(componentNameRegex.test('s-cat12')).toBe(true);
     expect(componentNameRegex.test('s-cat@')).toBe(false);
+  });
+
+  it('should load catalog info content and evaluate PR template', () => {
+    const importJobStatus = {
+      approvalTool: 'GIT',
+      github: {
+        pullRequest: {
+          number: 105,
+          url: 'https://github.com/che-electron/client/pull/105',
+          title: 'Add catalog-info.yaml config file',
+          body: 'This pull request adds a **Backstage entity metadata file**\nto this repository so that the component can\nbe added to the [software catalog](http://localhost:3000/catalog).\nAfter this pull request is merged, the component will become available.\nFor more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).\nView the import job in your app [here](http://localhost:3000/bulk-import/repositories?repository=https://github.com/che-electron/client&defaultBranch=master).',
+          catalogInfoContent:
+            'apiVersion: backstage.io/v1alpha1\nkind: Component\nmetadata:\n  name: client\n  annotations:\n    github.com/project-slug: che-electron/client\nspec:\n  type: other\n  lifecycle: unknown\n  owner: user:default/debsmita1\n',
+        },
+      },
+      id: 'https://github.com/che-electron/client',
+      lastUpdate: '2024-09-11T18:37:28Z',
+      repository: {
+        url: 'https://github.com/che-electron/client',
+        name: 'client',
+        organization: 'che-electron',
+        id: 'che-electron/client',
+        defaultBranch: 'main',
+      },
+      status: 'WAIT_PR_APPROVAL',
+    };
+    expect(evaluatePRTemplate(importJobStatus).isInvalidEntity).toBeFalsy();
+
+    importJobStatus.github.pullRequest.catalogInfoContent = '---\n';
+    expect(evaluatePRTemplate(importJobStatus).isInvalidEntity).toBeTruthy();
+    importJobStatus.github.pullRequest.catalogInfoContent =
+      'kind: Component\nmetadata:\n  name: client\n  annotations:\n    github.com/project-slug: che-electron/client\nspec:\n  type: other\n  lifecycle: unknown\n  owner: user:default/debsmita1\n';
+    expect(evaluatePRTemplate(importJobStatus).isInvalidEntity).toBeTruthy();
   });
 });


### PR DESCRIPTION
**Resolves:**
https://issues.redhat.com/browse/RHIDP-3942

**Fixes:**
- Handled invalid entity YAML in the pull request (empty file or entity yaml without `apiVersion` or `kind` or `metadata.name` is considered invalid)
- As of today, the preview panel supports the visualization of only one entity from a catalog-info.yaml file. If the entity YAML file has multiple entities, the preview panel will show only the first entity
- Fixed the `navigate to` url after creating the import
- Removes the repository query param from the import page URL if the repository is not added or the URL/branch is invalid
- Added error handling in the side panel

**Screenshot:**

![Screenshot 2024-09-12 at 12 19 51 PM](https://github.com/user-attachments/assets/d409e31d-2e91-425d-8725-ec843b4d4653)
![Screenshot 2024-09-12 at 12 18 57 PM](https://github.com/user-attachments/assets/903ade2e-4aca-42c7-9347-b7755a67dd4f)

