### PR TITLE
fix(lightspeed): use lightspeed icon image as bot avatar image

### DIFF
--- a/plugins/lightspeed/src/components/LightspeedChatBox.tsx
+++ b/plugins/lightspeed/src/components/LightspeedChatBox.tsx
@@ -16,6 +16,7 @@ import {
   MessageProps,
 } from '@patternfly/virtual-assistant';
 
+import logo from '../../images/logo.svg';
 import { lightspeedApiRef } from '../api/LightspeedProxyClient';
 import { Conversations } from '../types';
 import {
@@ -120,6 +121,7 @@ export const LightspeedChatBox = ({
         name: `${msg.model}`,
         isLoading: msg.loading,
         timestamp: msg.timestamp,
+        avatar: logo,
       },
     ])
     .flat() as MessageProps[];


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHIDP-3980

<img width="1728" alt="Screenshot 2024-09-12 at 5 18 21 PM" src="https://github.com/user-attachments/assets/6db466c9-89f6-480d-8547-3ad5b938b08c">
