### PR TITLE
fix(bulk-import): refresh the Location entity when the Import is `ADDED`

### DIFF
--- a/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
@@ -346,6 +346,12 @@ export async function createImportJobs(
       const ghRepo = await githubApiService.getRepositoryFromIntegrations(
         req.repository.url,
       );
+      // Force a refresh of the Location, so that the entities from the catalog-info.yaml can show up quickly (not guaranteed however).
+      await catalogInfoGenerator.refreshLocationByRepoUrl(
+        config,
+        req.repository.url,
+        req.repository.defaultBranch,
+      );
       result.push({
         status: 'ADDED',
         lastUpdate: ghRepo?.repository?.updated_at ?? undefined,
@@ -386,6 +392,13 @@ export async function createImportJobs(
       if (prToRepo.hasChanges === false) {
         logger.debug(
           `No bulk import PR created on ${req.repository.url} since its default branch (${req.repository.defaultBranch}) already contains a catalog-info file`,
+        );
+
+        // Force a refresh of the Location, so that the entities from the catalog-info.yaml can show up quickly (not guaranteed however).
+        await catalogInfoGenerator.refreshLocationByRepoUrl(
+          config,
+          req.repository.url,
+          req.repository.defaultBranch,
         );
         result.push({
           status: 'ADDED',
@@ -593,6 +606,12 @@ export async function findImportStatusByRepo(
         }))
       ) {
         result.status = 'ADDED';
+        // Force a refresh of the Location, so that the entities from the catalog-info.yaml can show up quickly (not guaranteed however).
+        await catalogInfoGenerator.refreshLocationByRepoUrl(
+          config,
+          repoUrl,
+          defaultBranch,
+        );
       }
       // No import PR => let's determine last update from the repository
       const ghRepo =

--- a/plugins/bulk-import-backend/src/service/handlers/importStatus.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/importStatus.ts
@@ -80,6 +80,12 @@ async function getImportStatusWithCheckerFn(
         defaultBranch,
       });
     if (existsInCatalog && existsInRepo) {
+      // Force a refresh of the Location, so that the entities from the catalog-info.yaml can show up quickly (not guaranteed however).
+      await catalogInfoGenerator.refreshLocationByRepoUrl(
+        config,
+        repoUrl,
+        defaultBranch,
+      );
       return { status: 'ADDED' };
     }
     return null;


### PR DESCRIPTION
**What does this PR do / why we need it:**

This PR forces a refresh of the Location when the backend returns an Import as `ADDED` (which, as a reminder, means that the repository now has a `catalog-info.yaml` file in its default branch - either because it was already present when the Import was requested, or the import PR has been merged).
This is to make the Entities from the `catalog-info.yaml` show up quickly in the Backstage catalog.
This mimics the behavior of the "Register existing component" feature in Backstage: after you import a URL to a valid catalog-info.yaml, you can view the Entities right away in the catalog.

**NOTES**:
- I noticed that the refresh works quite immediately if the repository already has a `catalog-info.yaml` file in its default branch when it is bulk-imported

https://github.com/user-attachments/assets/548d57bd-0031-4eae-a89c-6cb591656e24

- When there is no `catalog-info.yaml` file and an import PR is created by the Bulk Import, there might still be some delay for the Entity to show up in the catalog after the import PR is merged. The "Register existing component" workflow also has the same behavior when it creates a PR.

**Which issue(s) this PR fixes:**

**PR acceptance criteria:**

- [x] Unit tests

- [ ] Integration tests

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

Bulk-import a repository.

/cc @subhashkhileri @debsmita1 @PatAKnight 