### PR TITLE
chore(release): revert downgrade of several plugins

### DIFF
--- a/plugins/bulk-import-backend/CHANGELOG.md
+++ b/plugins/bulk-import-backend/CHANGELOG.md
@@ -1,11 +1,5 @@
 ### Dependencies
 
-* **@janus-idp/backstage-plugin-bulk-import-common:** upgraded to 1.0.0
-* **@janus-idp/cli:** upgraded to 1.0.0
-* **@janus-idp/backstage-plugin-audit-log-node:** upgraded to 1.0.0
-
-### Dependencies
-
 * **@janus-idp/backstage-plugin-bulk-import-common:** upgraded to 1.0.1
 
 ### Dependencies

--- a/plugins/bulk-import-backend/dist-dynamic/package.json
+++ b/plugins/bulk-import-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-bulk-import-backend-dynamic",
-  "version": "1.0.0",
+  "version": "1.4.3",
   "main": "./dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {},
   "peerDependencies": {
-    "@janus-idp/backstage-plugin-audit-log-node": "1.0.0",
+    "@janus-idp/backstage-plugin-audit-log-node": "1.4.0",
     "@backstage/backend-app-api": "^0.8.0",
     "@backstage/backend-common": "^0.23.3",
     "@backstage/backend-dynamic-feature-service": "^0.2.15",

--- a/plugins/bulk-import-backend/package.json
+++ b/plugins/bulk-import-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-bulk-import-backend",
-  "version": "1.0.0",
+  "version": "1.4.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -57,7 +57,7 @@
     "@backstage/plugin-catalog-node": "^1.12.4",
     "@backstage/plugin-permission-common": "^0.8.0",
     "@backstage/plugin-permission-node": "^0.8.0",
-    "@janus-idp/backstage-plugin-bulk-import-common": "1.0.0",
+    "@janus-idp/backstage-plugin-bulk-import-common": "1.0.1",
     "@octokit/auth-app": "^6.0.3",
     "@octokit/core": "^5.1.0",
     "@octokit/rest": "^20.0.2",
@@ -78,12 +78,12 @@
     "@backstage/backend-test-utils": "0.4.4",
     "@backstage/cli": "0.26.11",
     "@backstage/plugin-catalog-backend": "1.24.0",
-    "@janus-idp/cli": "1.0.0",
+    "@janus-idp/cli": "1.13.1",
     "@types/supertest": "2.0.16",
     "supertest": "6.3.4"
   },
   "peerDependencies": {
-    "@janus-idp/backstage-plugin-audit-log-node": "1.0.0"
+    "@janus-idp/backstage-plugin-audit-log-node": "1.4.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Yet another MSR issue after https://github.com/janus-idp/backstage-plugins/pull/2156 has been merged: https://github.com/janus-idp/backstage-plugins/actions/runs/10834290717/job/30063107649

This reverts commit 35b1bca5e8aa3532227a5e5632d86434f07cede3.

@debsmita1 This should allow releasing the bulk-import frontend plugin correctly.

/cc @PatAKnight @AndrienkoAleksandr