### PR TITLE
fix(orchestrator): improve error handling in SonataFlowService fetch

### DIFF
--- a/plugins/orchestrator-backend/src/service/SonataFlowService.test.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.test.ts
@@ -1,0 +1,278 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+
+import { DataIndexService } from './DataIndexService';
+import { SonataFlowService } from './SonataFlowService';
+
+describe('SonataFlowService', () => {
+  let loggerMock: jest.Mocked<LoggerService>;
+  let sonataFlowService: SonataFlowService;
+
+  beforeAll(() => {
+    loggerMock = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      child: jest.fn(),
+    };
+    sonataFlowService = new SonataFlowService(
+      {} as DataIndexService,
+      loggerMock,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('fetchWorkflowInfoOnService', () => {
+    const serviceUrl = 'http://example.com';
+    const definitionId = 'workflow-123';
+    const urlToFetch = 'http://example.com/management/processes/workflow-123';
+    const methodName = 'fetchWorkflowInfoOnService';
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return workflow info when the fetch response is ok', async () => {
+      // Given
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({ id: 'workflow-123' }),
+      };
+      global.fetch = jest.fn().mockResolvedValue(mockResponse as any);
+
+      // When
+      const result = await sonataFlowService.fetchWorkflowInfoOnService({
+        definitionId,
+        serviceUrl,
+      });
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(urlToFetch);
+      expect(result).toEqual({ id: definitionId });
+      expect(loggerMock.debug).toHaveBeenCalledWith(
+        `Fetch workflow info result: {"id":"${definitionId}"}`,
+      );
+    });
+
+    it('should log an error and return undefined when the fetch response is not ok', async () => {
+      // Given
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        statusText: 'Not Found',
+        json: jest.fn().mockResolvedValue({
+          details: 'Error details',
+          stack: 'Error stack trace',
+        }),
+      };
+      global.fetch = jest.fn().mockResolvedValue(mockResponse as any);
+
+      // When
+      const result = await sonataFlowService.fetchWorkflowInfoOnService({
+        definitionId,
+        serviceUrl,
+      });
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(urlToFetch);
+      expect(result).toBeUndefined();
+      expect(loggerMock.error).toHaveBeenCalledTimes(1);
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        `Error when fetching workflow info: Error: ${sonataFlowService.createPrefixFetchErrorMessage(urlToFetch, methodName)}`,
+      );
+      expect(loggerMock.info).not.toHaveBeenCalled();
+      expect(loggerMock.debug).not.toHaveBeenCalled();
+      expect(loggerMock.warn).not.toHaveBeenCalled();
+      expect(loggerMock.child).not.toHaveBeenCalled();
+    });
+
+    it('should log an error and return undefined when fetch throws an error', async () => {
+      // Given
+      const testErrorMsg = 'Network Error';
+      global.fetch = jest.fn().mockRejectedValue(new Error('Network Error'));
+
+      // When
+      const result = await sonataFlowService.fetchWorkflowInfoOnService({
+        definitionId,
+        serviceUrl,
+      });
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(urlToFetch);
+      expect(result).toBeUndefined();
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        `Error when fetching workflow info: Error: ${testErrorMsg}`,
+      );
+    });
+  });
+  describe('executeWorkflow', () => {
+    const serviceUrl = 'http://example.com/workflows';
+    const definitionId = 'workflow-123';
+    const urlToFetch = `${serviceUrl}/${definitionId}`;
+    const functionName = 'executeWorkflow';
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    it('should return workflow execution response when the request is successful', async () => {
+      // Given
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: jest
+          .fn()
+          .mockResolvedValue({ id: definitionId, status: 'completed' }),
+      };
+      global.fetch = jest.fn().mockResolvedValue(mockResponse as any);
+
+      // When
+      const result = await sonataFlowService.executeWorkflow({
+        definitionId,
+        serviceUrl,
+        inputData: { var1: 'value1' },
+      });
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(urlToFetch, {
+        method: 'POST',
+        body: JSON.stringify({ var1: 'value1' }),
+        headers: { 'content-type': 'application/json' },
+      });
+      expect(result).toEqual({ id: definitionId, status: 'completed' });
+      expect(loggerMock.debug).toHaveBeenCalledWith(
+        `Execute workflow result: {"id":"${definitionId}","status":"completed"}`,
+      );
+      // Verify that all other logger methods were not called
+      expect(loggerMock.debug).toHaveBeenCalledTimes(1);
+      expect(loggerMock.info).not.toHaveBeenCalled();
+      expect(loggerMock.error).not.toHaveBeenCalled();
+      expect(loggerMock.warn).not.toHaveBeenCalled();
+      expect(loggerMock.child).not.toHaveBeenCalled();
+    });
+
+    it('should include businessKey in the URL if provided', async () => {
+      // Given
+      const businessKey = 'key-123';
+      const inputData = { var1: 'value1' };
+      const mockResponse = {
+        ok: true,
+        json: jest
+          .fn()
+          .mockResolvedValue({ id: definitionId, status: 'completed' }),
+      };
+      global.fetch = jest.fn().mockResolvedValue(mockResponse as any);
+
+      // When
+      const result = await sonataFlowService.executeWorkflow({
+        definitionId,
+        serviceUrl,
+        inputData,
+        businessKey,
+      });
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(
+        `${serviceUrl}/${definitionId}?businessKey=${businessKey}`,
+        {
+          method: 'POST',
+          body: JSON.stringify(inputData),
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+      expect(result).toEqual({ id: definitionId, status: 'completed' });
+    });
+
+    it('should log an error and return undefined when the fetch response is not ok without extra info', async () => {
+      // Given
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: jest.fn().mockResolvedValueOnce({}),
+      };
+      global.fetch = jest.fn().mockResolvedValue(mockResponse as any);
+      const inputData = { var1: 'value1' };
+
+      // When
+      const result = await sonataFlowService.executeWorkflow({
+        definitionId,
+        serviceUrl,
+        inputData,
+      });
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(urlToFetch, {
+        method: 'POST',
+        body: JSON.stringify(inputData),
+        headers: { 'content-type': 'application/json' },
+      });
+      expect(result).toBeUndefined();
+      expect(loggerMock.error).toHaveBeenCalledTimes(1);
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        `Error when executing workflow: Error: ${sonataFlowService.createPrefixFetchErrorMessage(urlToFetch, functionName, 'POST')} - Details: undefined, Stack: undefined`,
+      );
+    });
+    it('should log an error and return undefined when the fetch response is not ok with extra info', async () => {
+      // Given
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: jest.fn().mockResolvedValueOnce({
+          details: 'Error details test',
+          stack: 'Error stacktrace test',
+        }),
+      };
+      global.fetch = jest.fn().mockResolvedValue(mockResponse as any);
+      const inputData = { var1: 'value1' };
+
+      // When
+      const result = await sonataFlowService.executeWorkflow({
+        definitionId,
+        serviceUrl,
+        inputData,
+      });
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(urlToFetch, {
+        method: 'POST',
+        body: JSON.stringify(inputData),
+        headers: { 'content-type': 'application/json' },
+      });
+      expect(result).toBeUndefined();
+      expect(loggerMock.error).toHaveBeenCalledTimes(1);
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        `Error when executing workflow: Error: ${sonataFlowService.createPrefixFetchErrorMessage(urlToFetch, functionName, 'POST')} - Details: Error details test, Stack: Error stacktrace test`,
+      );
+    });
+    it('should log an error and return undefined when fetch throws an error', async () => {
+      // Given
+      global.fetch = jest.fn().mockRejectedValue(new Error('Network Error'));
+      const inputData = { var1: 'value1' };
+
+      // When
+      const result = await sonataFlowService.executeWorkflow({
+        definitionId,
+        serviceUrl,
+        inputData: inputData,
+      });
+
+      // Then
+      expect(fetch).toHaveBeenCalledWith(urlToFetch, {
+        method: 'POST',
+        body: JSON.stringify(inputData),
+        headers: { 'content-type': 'application/json' },
+      });
+      expect(result).toBeUndefined();
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        'Error when executing workflow: Error: Network Error',
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Current issue

In some cases, workflows fail without providing any information about the root cause, making debugging difficult.

For example: 

![image](https://github.com/user-attachments/assets/5d364a47-0fb3-4d48-b6ae-b3ae8d1c1d29)

The backstage log contains:
```
backend:start: {"level":"error","message":"Error when fetching process instances: [GraphQL] Variable 'instanceId' has an invalid value: Variable 'instanceId' has coerced Null value for NonNull type 'String!'","plugin":"orchestrator","service":"backstage","timestamp":"2024-09-19 17:33:03"}
backend:start: {"actor":{"actorId":"user:development/guest","hostname":"localhost","ip":"::ffff:127.0.0.1","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0"},"errors":[{"message":"[GraphQL] Variable 'instanceId' has an invalid value: Variable 'instanceId' has coerced Null value for NonNull type 'String!'","name":"CombinedError","stack":"CombinedError: [GraphQL] Variable 'instanceId' has an invalid value: Variable 'instanceId' has coerced Null value for NonNull type 'String!'\n    at makeResult (/home/gloria/repos/backstage-plugins-devel/node_modules/@urql/core/src/utils/result.ts:43:9)\n    at fetchOperation (/home/gloria/repos/backstage-plugins-devel/node_modules/@urql/core/src/internal/fetchSource.ts:204:11)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async /home/gloria/repos/backstage-plugins-devel/node_modules/wonka/dist/wonka.js:346:20"}],"eventName":"executeWorkflowEndpointHit","isAuditLog":true,"level":"error","message":"Error occured while requesting the '/v2/workflows/m2k/execute' endpoint","meta":{},"plugin":"orchestrator","request":{"body":{"inputData":{"projectId":"p1","recipients":["user:default/jsmith"],"repositoryURL":"https://bitbucket.org/gfarache31/m2k-test","sourceBranch":"master","targetBranch":"g1","workspaceId":"w1"}},"method":"POST","params":{},"query":{},"url":"/api/orchestrator/v2/workflows/m2k/execute"},"response":{"body":{"errors":[{"message":"[GraphQL] Variable 'instanceId' has an invalid value: Variable 'instanceId' has coerced Null value for NonNull type 'String!'","name":"CombinedError"}]},"status":500},"service":"backstage","stage":"completion","status":"failed","timestamp":"2024-09-19 17:33:03"}
```

## Cause

The `fetch` function does not throw an exception for HTTP response codes like `4xx`/`5xx`; it only does so for network-related issues. 
The current implementation does not properly handle these non-successful responses.

# Proposed solution
Check `response.ok` to identify failed responses and handle errors accordingly.

In this way, backstage log contains:

```
backend:start: {"level":"error","message":"Error when executing workflow: Error: Response status was NOT successful when executeWorkflow(POST) fetch(http://m2k-sonataflow-infra.apps.cluster-lw48v.lw48v.sandbox2144.opentlc.com/m2k) - Details: Error id d9d5f1c0-c04e-4c03-91a2-037bc1e099be-2, Stack: No stack trace available","plugin":"orchestrator","service":"backstage","timestamp":"2024-09-20 11:18:24"}
```

# Jira issue
Fix [FLPATH-1032](https://issues.redhat.com/browse/FLPATH-1032)