### PR TITLE
docs(topology): adding vm vmi in clusterrole file for read access

### DIFF
--- a/plugins/topology/manifests/clusterrole.yaml
+++ b/plugins/topology/manifests/clusterrole.yaml
@@ -71,6 +71,14 @@ rules:
       - get
       - list
   - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - route.openshift.io
     resources:
       - routes


### PR DESCRIPTION
Bug : https://issues.redhat.com/projects/RHIDP/issues/RHIDP-4020?
1. Readme of topology 
<img width="1710" alt="Screenshot 2024-09-16 at 11 46 24 AM" src="https://github.com/user-attachments/assets/5b0a9a00-c5e9-497f-b348-237ef92d7b69">
2. clusterrole.yaml
<img width="1710" alt="Screenshot 2024-09-16 at 12 56 55 PM" src="https://github.com/user-attachments/assets/6af6ad46-f72e-41ba-8152-ed536856eebf">
