### PR TITLE
fix(bulk-import): handle Location entities created from other sources like the GH discovery as Import candidates [RHIDP-4021]

### DIFF
--- a/plugins/bulk-import-backend/src/helpers/catalogInfoGenerator.ts
+++ b/plugins/bulk-import-backend/src/helpers/catalogInfoGenerator.ts
@@ -16,6 +16,7 @@
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { AuthService, DiscoveryService } from '@backstage/backend-plugin-api';
 import { CatalogApi } from '@backstage/catalog-client';
+import { LocationEntity } from '@backstage/catalog-model';
 import type { Config } from '@backstage/config';
 
 import gitUrlParse from 'git-url-parse';
@@ -134,12 +135,13 @@ ${jsYaml.dump(generatedEntity.entity)}`,
   async listCatalogUrlLocationsById(
     config: Config,
     search?: string,
-    _pageNumber: number = DefaultPageNumber,
-    _pageSize: number = DefaultPageSize,
+    pageNumber: number = DefaultPageNumber,
+    pageSize: number = DefaultPageSize,
   ): Promise<{ id?: string; target: string }[]> {
     const result = await Promise.all([
       this.listCatalogUrlLocationsFromConfig(config, search),
       this.listCatalogUrlLocationsByIdFromLocationsEndpoint(search),
+      this.listCatalogUrlLocationEntitiesById(search, pageNumber, pageSize),
     ]);
     return result.flat();
   }
@@ -191,6 +193,39 @@ ${jsYaml.dump(generatedEntity.entity)}`,
         return {
           id: `app-config-location--${target}`,
           target,
+        };
+      });
+    return this.filterLocations(res, search);
+  }
+
+  async listCatalogUrlLocationEntitiesById(
+    search?: string,
+    _pageNumber: number = DefaultPageNumber,
+    _pageSize: number = DefaultPageSize,
+  ): Promise<{ id?: string; target: string }[]> {
+    const result = await this.catalogApi.getEntities(
+      {
+        filter: {
+          kind: 'Location',
+        },
+        // There is no query parameter to find entities with target URLs containing a string.
+        // The existing filter does an exact matching. That's why we are retrieving this hard-coded high number of Locations.
+        limit: 1000,
+        offset: 0,
+      },
+      {
+        token: await getTokenForPlugin(this.auth, 'catalog'),
+      },
+    );
+    const locations = (result?.items ?? []) as LocationEntity[];
+    const res = locations
+      .filter(
+        location => location.spec?.target && location.spec?.type === 'url',
+      )
+      .map(location => {
+        return {
+          id: location.metadata.uid,
+          target: location.spec.target!,
         };
       });
     return this.filterLocations(res, search);

--- a/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
+++ b/plugins/bulk-import-backend/src/service/handlers/bulkImports.ts
@@ -80,11 +80,17 @@ export async function findAllImports(
     catalogFilename,
   );
 
+  // Keep only repos that are accessible from the configured GH integrations
+  const importsReachableFromGHIntegrations =
+    await githubApiService.filterLocationsAccessibleFromIntegrations(
+      importCandidates,
+    );
+
   // now fetch the import statuses in different promises
   const importStatusPromises: Promise<
     HandlerResponse<Components.Schemas.Import>
   >[] = [];
-  for (const loc of importCandidates) {
+  for (const loc of importsReachableFromGHIntegrations) {
     const repoUrl = repoUrlFromLocation(loc);
     if (!repoUrl) {
       continue;

--- a/plugins/bulk-import-backend/src/service/router.test.ts
+++ b/plugins/bulk-import-backend/src/service/router.test.ts
@@ -174,6 +174,7 @@ describe('createRouter', () => {
       getEntitiesByRefs: mockGetEntitiesByRefs,
       validateEntity: mockValidateEntity,
       addLocation: mockAddLocation,
+      getEntities: jest.fn(),
       queryEntities: jest.fn(),
       refreshEntity: jest.fn(),
     } as unknown as CatalogClient;
@@ -966,6 +967,15 @@ describe('createRouter', () => {
         )
         .mockResolvedValue(fromLocationsEndpoint);
       jest
+        .spyOn(
+          mockGithubApiService,
+          'filterLocationsAccessibleFromIntegrations',
+        )
+        .mockImplementation((locationUrls: string[]) => {
+          // filter returning the same input
+          return Promise.resolve(locationUrls);
+        });
+      jest
         .spyOn(mockGithubApiService, 'getRepositoryFromIntegrations')
         .mockImplementation(repoUrl => {
           let defaultBranch: string | undefined;
@@ -1053,7 +1063,7 @@ describe('createRouter', () => {
                   },
                 },
               ],
-              totalItems: 0,
+              totalItems: 1,
               pageInfo: {},
             };
           },
@@ -1250,7 +1260,7 @@ describe('createRouter', () => {
                   },
                 },
               ],
-              totalItems: 0,
+              totalItems: 1,
               pageInfo: {},
             };
           },
@@ -1358,7 +1368,7 @@ spec:
               ],
             };
           }
-          return { items: [] };
+          return { totalItems: 0, items: [] };
         },
       );
 


### PR DESCRIPTION
**What does this PR do / why we need it:**

This PR makes sure to also include existing Location entities (like the ones that might have been added through the GH auto-discovery plugin) as potential Import jobs.
And, to make sure the bulk import backend does not return any kind of Locations, it returns only the repos that are accessible from the configured GH integrations.

**Which issue(s) this PR fixes:**
https://issues.redhat.com/browse/RHIDP-4021

This fixes the following issues:
- adding any public repos in the app-config.yaml would make it be shown as an Import job, even if that repo is not accessible from any of the configured GH integrations
- repos auto-added by the GH discovery plugin would not be shown as Import jobs, leading users to try to bulk-import them (they are shown in the Bbulk Import pages because they are accessible from the configured GH integrations).

**PR acceptance criteria:**

- [x] Unit tests

- [ ] Integration tests

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

- In your app-config.yaml, add a mix of Locations accessible from your GH integrations, and some others that are public, e.g.:
```yaml
integrations:
  # TODO: configure your GH integrations
  # https://backstage.io/docs/integrations/github/locations/#configuration
  github: []

catalog:
  locations:
    - type: url
      # Valid Import location pattern,
      # but should be ignored because 'janus-qe/acr-catalog' is not accessible from the configured GH integrations
      target: https://github.com/janus-qe/acr-catalog/blob/main/catalog-info.yaml

    - type: url
      # Valid Import location pattern. Repo is accessible from the configured GH integrations
      # => should be returned by the `GET /imports` endpoint along with the right status
      target: https://github.com/lemra-org-ent-2/expert-octo-guide/blob/main/catalog-info.yaml
```

- If you have the GH Discovery plugin enabled:

<details>
<summary>enabling the GH Discovery dynamic plugin</summary>

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: dynamic-plugins-rhdh
data:
  dynamic-plugins.yaml: |
    includes:
      - dynamic-plugins.default.yaml
    plugins:
	  # TRUNCATED
      - package: './dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic'
        disabled: false
        pluginConfig:
          catalog:
            providers:
              github:
                myorg:
                  organization: '${GH_ORG}'
                  schedule:
                    # supports cron, ISO duration, "human duration" (used below)
                    frequency: { minutes: 5}
                    # supports ISO duration, "human duration (used below)
                    timeout: { minutes: 3}
                    initialDelay: { seconds: 15}
```

</details>

With the examples above, this is how it looks like:

**Before**

![image](https://github.com/user-attachments/assets/829af084-1ab0-4f16-965d-dd4e4da3fc9c)

- `janus-qe/acr-catalog` would be returned in the list of Imports, even if it is not accessible from any of my configured GH integrations. This makes it confusing since this repo will never be displayed in the list of organizations/repositories from the Bulk Import pages.
- none of the repos monitored by the GitHub auto-discovery plugin would show up in this list and their Import status won't be accurate, even though they are accessible from my configured GH integrations. The org watched is `lemra-org`.

![image](https://github.com/user-attachments/assets/747db122-6002-4a1f-914c-fa3bbc84de05)

**With the changes here**

![Screenshot from 2024-09-16 10-11-29](https://github.com/user-attachments/assets/019c6b90-092e-465a-b121-9f88d500fa68)

- `janus-qe/acr-catalog` is no longer being returned in the list of Imports, since it is not accessible from any of my configured GH integrations
- all the repos monitored by the GitHub auto-discovery plugin now show up in this list and have the right Import status, since they are accessible from my configured GH integrations. The org watched is `lemra-org`.

![Screenshot from 2024-09-16 10-12-40](https://github.com/user-attachments/assets/2d9ab11c-bb48-4d6a-9da6-3b2966fe0df0)


/cc @subhashkhileri 