### PR TITLE
chore(release): revert downgrade of `catalog-backend-module-scaffolder-relation-processor`

### DIFF
--- a/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
@@ -1,9 +1,5 @@
 ### Dependencies
 
-* **@janus-idp/cli:** upgraded to 1.0.0
-
-### Dependencies
-
 * **@janus-idp/cli:** upgraded to 1.13.1
 
 ## @janus-idp/backstage-plugin-catalog-backend-module-scaffolder-relation-processor [1.3.1](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-catalog-backend-module-scaffolder-relation-processor@1.3.0...@janus-idp/backstage-plugin-catalog-backend-module-scaffolder-relation-processor@1.3.1) (2024-07-26)

--- a/plugins/catalog-backend-module-scaffolder-relation-processor/dist-dynamic/package.json
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/dist-dynamic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic",
   "description": "The scaffolder-relation-processor backend module for the catalog plugin.",
-  "version": "1.0.0",
+  "version": "1.3.2",
   "main": "./dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-catalog-backend-module-scaffolder-relation-processor",
   "description": "The scaffolder-relation-processor backend module for the catalog plugin.",
-  "version": "1.0.0",
+  "version": "1.3.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "0.4.4",
     "@backstage/cli": "0.26.11",
-    "@janus-idp/cli": "1.0.0"
+    "@janus-idp/cli": "1.13.1"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This reverts commit 31930b1f2da0d4654aa4fa714aea3a05795fbc60.

Yet another MSR issue after the merging of https://github.com/janus-idp/backstage-plugins/pull/2178. 
Release logs: https://github.com/janus-idp/backstage-plugins/actions/runs/10885652616/job/30203777287