### PR TITLE
fix(rbac): improve members dropdown to handle large no. of users/groups

### DIFF
--- a/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
+++ b/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
@@ -51,23 +51,35 @@ export const AddMembersForm = ({
       : undefined;
   };
 
-  const membersOptions: SelectedMember[] = membersData.members
-    ? membersData.members.map((member: MemberEntity, index: number) => {
-        const tag =
-          member.metadata.etag ??
-          `${member.metadata.name}-${member.kind}-${index}`;
-        return {
-          id: tag,
-          label: member.spec?.profile?.displayName ?? member.metadata.name,
-          description: getDescription(member),
-          etag: tag,
-          type: member.kind,
-          namespace: member.metadata.namespace,
-          members: getMembersCount(member),
-          ref: stringifyEntityRef(member),
-        };
-      })
-    : ([] as SelectedMember[]);
+  const membersOptions: SelectedMember[] = React.useMemo(() => {
+    return membersData.members
+      ? membersData.members.map((member: MemberEntity, index: number) => {
+          const tag =
+            member.metadata.etag ??
+            `${member.metadata.name}-${member.kind}-${index}`;
+          return {
+            id: tag,
+            label: member.spec?.profile?.displayName ?? member.metadata.name,
+            description: getDescription(member),
+            etag: tag,
+            type: member.kind,
+            namespace: member.metadata.namespace,
+            members: getMembersCount(member),
+            ref: stringifyEntityRef(member),
+          };
+        })
+      : ([] as SelectedMember[]);
+  }, [membersData.members]);
+
+  const filteredMembers = React.useMemo(() => {
+    if (search) {
+      return membersOptions
+        .filter(m => m.label.toLowerCase().includes(search.toLowerCase()))
+        .slice(0, 99);
+    }
+
+    return membersOptions.slice(0, 99);
+  }, [membersOptions, search]);
 
   return (
     <>
@@ -77,7 +89,7 @@ export const AddMembersForm = ({
       </FormHelperText>
       <br />
       <Autocomplete
-        options={membersOptions || []}
+        options={filteredMembers || []}
         getOptionLabel={(option: SelectedMember) => option.label ?? ''}
         getOptionSelected={(option: SelectedMember, value: SelectedMember) =>
           value.etag


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHDHBUGS-73

This PR fixes this issue by limiting the initial users/groups shown to 100 and once the user starts to search the search happens accross the whole data-set (tested with 45k users) and only top 100 results are rendered, for more options users can refine their search to get to the required user/group.


https://github.com/user-attachments/assets/2ed9bc2d-3d8f-4cd7-ba48-d87fa2aae637


