### PR TITLE
fix(lightspeed): downversion lightspeed frontend to v0.1.1

### DIFF
--- a/plugins/lightspeed/package.json
+++ b/plugins/lightspeed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-lightspeed",
-  "version": "1.0.2",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Since we don't want the lightspeed plugin to be published at v1.x.x as of now, we are planning to deprecate the already published 1.x.x versions(3 published) of frontend plugin and manually release a v0.1.1.