### PR TITLE
chore(release): catch scaffolder annotator 1.3.x up with showcase 1.3.x

### DIFF
--- a/plugins/scaffolder-annotator-action/dist-dynamic/package.json
+++ b/plugins/scaffolder-annotator-action/dist-dynamic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-scaffolder-backend-module-annotator-dynamic",
   "description": "The annotator module for @backstage/plugin-scaffolder-backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "./dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-annotator-action/package.json
+++ b/plugins/scaffolder-annotator-action/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-scaffolder-backend-module-annotator",
   "description": "The annotator module for @backstage/plugin-scaffolder-backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-annotator-action/src/actions/annotator/annotator.test.ts
+++ b/plugins/scaffolder-annotator-action/src/actions/annotator/annotator.test.ts
@@ -20,7 +20,11 @@ describe('catalog annotator', () => {
       'catalog:timestamping',
       'Creates a new `catalog:timestamping` Scaffolder action to annotate scaffolded entities with creation timestamp.',
       'some logger info msg',
-      { annotations: { 'backstage.io/createdAt': getCurrentTimestamp() } },
+      () => {
+        return {
+          annotations: { 'backstage.io/createdAt': getCurrentTimestamp() },
+        };
+      },
     );
 
     const logger = getVoidLogger();
@@ -67,7 +71,9 @@ describe('catalog annotator', () => {
       'catalog:test-annotate',
       'Creates a new `catalog:test-annotate` Scaffolder action to annotate catalog-info.yaml with labels and annotations.',
       '',
-      {},
+      () => {
+        return {};
+      },
     );
 
     const logger = getVoidLogger();
@@ -126,7 +132,9 @@ describe('catalog annotator', () => {
       'catalog:test-annotate-obj',
       'Creates a new `catalog:test-annotate-obj` Scaffolder action to annotate any object yaml with labels and annotations.',
       'some logger info message',
-      {},
+      () => {
+        return {};
+      },
     );
 
     const logger = getVoidLogger();
@@ -199,8 +207,8 @@ describe('catalog annotator', () => {
       'catalog:entityRef',
       'Some description',
       'some logger info msg',
-      {
-        spec: { scaffoldedFrom: 'testt-ref' },
+      () => {
+        return { spec: { scaffoldedFrom: 'testt-ref' } };
       },
     );
 
@@ -245,8 +253,12 @@ describe('catalog annotator', () => {
       'catalog:entityRef',
       'Some description',
       'some logger info msg',
-      {
-        spec: { scaffoldedFrom: { readFromContext: 'templateInfo.entityRef' } },
+      () => {
+        return {
+          spec: {
+            scaffoldedFrom: { readFromContext: 'templateInfo.entityRef' },
+          },
+        };
       },
     );
 

--- a/plugins/scaffolder-annotator-action/src/actions/annotator/annotator.ts
+++ b/plugins/scaffolder-annotator-action/src/actions/annotator/annotator.ts
@@ -16,7 +16,7 @@ export const createAnnotatorAction = (
   actionId: string = 'catalog:annotate',
   actionDescription?: string,
   loggerInfoMsg?: string,
-  annotateEntityObject?: {
+  annotateEntityObjectProvider?: () => {
     annotations?: { [key: string]: string };
     labels?: { [key: string]: string };
     spec?: { [key: string]: Value };
@@ -86,6 +86,7 @@ export const createAnnotatorAction = (
       },
     },
     async handler(ctx) {
+      const annotateEntityObject = annotateEntityObjectProvider?.();
       let objToAnnotate: { [key: string]: any };
 
       if (ctx.input?.objectYaml) {

--- a/plugins/scaffolder-annotator-action/src/actions/customActions/createScaffoldedFromAction.ts
+++ b/plugins/scaffolder-annotator-action/src/actions/customActions/createScaffoldedFromAction.ts
@@ -5,10 +5,12 @@ export const createScaffoldedFromAction = () => {
     'catalog:scaffolded-from',
     'Creates a new `catalog:scaffolded-from` scaffolder action to update a catalog-info.yaml with the entityRef of the template that created it.',
     'Annotating catalog-info.yaml with template entityRef',
-    {
-      spec: {
-        scaffoldedFrom: { readFromContext: 'templateInfo.entityRef' },
-      },
+    () => {
+      return {
+        spec: {
+          scaffoldedFrom: { readFromContext: 'templateInfo.entityRef' },
+        },
+      };
     },
   );
 };

--- a/plugins/scaffolder-annotator-action/src/actions/customActions/createTimestampAction.ts
+++ b/plugins/scaffolder-annotator-action/src/actions/customActions/createTimestampAction.ts
@@ -6,6 +6,10 @@ export const createTimestampAction = () => {
     'catalog:timestamping',
     'Creates a new `catalog:timestamping` Scaffolder action to annotate scaffolded entities with creation timestamp.',
     'Annotating catalog-info.yaml with current timestamp',
-    { annotations: { 'backstage.io/createdAt': getCurrentTimestamp() } },
+    () => {
+      return {
+        annotations: { 'backstage.io/createdAt': getCurrentTimestamp() },
+      };
+    },
   );
 };


### PR DESCRIPTION
## Description
Copies the current version of the scaffolder backend module annotator over to the 1.3.x to ensure that we get caught back up.

## Additional Notes
Scaffolder backend module annotator version in the showcase 1.3.x branch: [1.3.0](https://github.com/janus-idp/backstage-showcase/blob/1.3.x/packages/backend/package.json#L48)

Version in the PR is 1.3.1, [PR](https://github.com/janus-idp/backstage-showcase/pull/1630) opened up in the showcase repo to bump this plugin one more time.