### PR TITLE
chore(release): catch audit log 1.3.x up with showcase 1.3.x

### DIFF
--- a/plugins/audit-log-node/README.md
+++ b/plugins/audit-log-node/README.md
@@ -61,6 +61,7 @@ import {
   HttpAuthService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
 
 /* highlight-add-start */
 import { DefaultAuditLogger } from '@janus-idp/backstage-plugin-audit-log-node';
@@ -69,6 +70,7 @@ import { DefaultAuditLogger } from '@janus-idp/backstage-plugin-audit-log-node';
 
 export interface RouterOptions {
   logger: LoggerService;
+  config: Config;
   auth: AuthService;
   httpAuth: HttpAuthService;
 }
@@ -76,7 +78,7 @@ export interface RouterOptions {
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { logger, auth, httpAuth } = options;
+  const { logger, config, auth, httpAuth } = options;
 
   /* highlight-add-start */
   const auditLogger = new DefaultAuditLogger({
@@ -111,7 +113,10 @@ export async function createRouter(
     });
     /* highlight-add-end */
   });
-  router.use(errorHandler());
+
+  const middleware = MiddlewareFactory.create({ logger, config });
+
+  router.use(middleware.error());
   return router;
 }
 ```

--- a/plugins/audit-log-node/package.json
+++ b/plugins/audit-log-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-audit-log-node",
   "description": "Node.js library for the audit-log plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5816,6 +5816,17 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
+"@janus-idp/backstage-plugin-audit-log-node@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@janus-idp/backstage-plugin-audit-log-node/-/backstage-plugin-audit-log-node-1.4.0.tgz#5fa861bd25c6073024a0935297b14f7ade68c957"
+  integrity sha512-qqxb9DzBeL9BQRk3x5QNBKRV1woHHqEEPvrNKJl56ycZv60EFDN6HHqSsPljc4LLzQc15au9RDYp9Ji5M2ZH+A==
+  dependencies:
+    "@backstage/backend-plugin-api" "^0.7.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/types" "^1.1.1"
+    express "^4.19.2"
+    lodash "^4.17.21"
+
 "@janus-idp/cli@1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@janus-idp/cli/-/cli-1.13.0.tgz#acdd10ad3239f3c8951caebd3d4611b6982036f6"


### PR DESCRIPTION
## Description
Copies the current version of the audit log over to the 1.3.x to ensure that we get caught back up.

## Additional Notes
Audit log version in the showcase 1.3.x branch: [1.4.0](https://github.com/janus-idp/backstage-showcase/blob/1.3.x/packages/backend/package.json#L45)
Audit log version in the PR is 1.4.1, PR needs to be opened up in the showcase repo to bump this plugin one more time.