### PR TITLE
chore(release): catch shared react 1.3.x up with showcase 1.3.x

### DIFF
--- a/plugins/shared-react/package.json
+++ b/plugins/shared-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/shared-react",
-  "version": "2.10.0",
+  "version": "2.10.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -19,7 +19,9 @@
       "@janus-idp/shared-react"
     ]
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./**/*.css"
+  ],
   "scripts": {
     "build": "backstage-cli package build",
     "tsc": "tsc",

--- a/plugins/shared-react/src/components/common/DeleteDialogContext.tsx
+++ b/plugins/shared-react/src/components/common/DeleteDialogContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext } from 'react';
+
+type DeleteDialogContextType = {
+  deleteComponent: { [key: string]: any };
+  setDeleteComponent: (component: { [key: string]: any }) => void;
+  openDialog: boolean;
+  setOpenDialog: (open: boolean) => void;
+};
+
+export const DeleteDialogContext = createContext<DeleteDialogContextType>({
+  deleteComponent: {},
+  setDeleteComponent: () => {},
+  openDialog: false,
+  setOpenDialog: () => {},
+});
+
+export const DeleteDialogContextProvider = (props: any) => {
+  const [openDialog, setOpenDialog] = React.useState(false);
+  const [deleteComponent, setDeleteComponent] = React.useState({});
+
+  const deleteDialogContextProviderValue = React.useMemo(
+    () => ({
+      openDialog,
+      setOpenDialog,
+      deleteComponent,
+      setDeleteComponent,
+    }),
+    [openDialog, setOpenDialog, deleteComponent, setDeleteComponent],
+  );
+  return (
+    <DeleteDialogContext.Provider value={deleteDialogContextProviderValue}>
+      {props.children}
+    </DeleteDialogContext.Provider>
+  );
+};
+export const useDeleteDialog = () => useContext(DeleteDialogContext);

--- a/plugins/shared-react/src/components/common/DrawerContext.tsx
+++ b/plugins/shared-react/src/components/common/DrawerContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext } from 'react';
+
+type DrawerContextType = {
+  drawerData: any;
+  setDrawerData: (data: any) => void;
+  openDrawer: boolean;
+  setOpenDrawer: (open: boolean) => void;
+};
+
+export const DrawerContext = createContext<DrawerContextType>({
+  drawerData: {},
+  setDrawerData: () => {},
+  openDrawer: false,
+  setOpenDrawer: () => {},
+});
+
+export const DrawerContextProvider = ({
+  children,
+}: {
+  children: React.ReactElement;
+}) => {
+  const [openDrawer, setOpenDrawer] = React.useState(false);
+  const [drawerData, setDrawerData] = React.useState({});
+
+  const drawerContextProviderValue = React.useMemo(
+    () => ({
+      openDrawer,
+      setOpenDrawer,
+      drawerData,
+      setDrawerData,
+    }),
+    [openDrawer, setOpenDrawer, drawerData, setDrawerData],
+  );
+  return (
+    <DrawerContext.Provider value={drawerContextProviderValue}>
+      {children}
+    </DrawerContext.Provider>
+  );
+};
+export const useDrawer = () => useContext(DrawerContext);

--- a/plugins/shared-react/src/components/common/StatusIconAndText.test.tsx
+++ b/plugins/shared-react/src/components/common/StatusIconAndText.test.tsx
@@ -29,6 +29,18 @@ describe('StatusIconAndText', () => {
     expect(getByTestId('status-text')).not.toBeNull();
   });
 
+  it('should render with status text', () => {
+    const { getByTestId } = render(
+      <StatusIconAndText
+        icon={<div id="green-check-icon" />}
+        title={ComputedStatus.Succeeded}
+      />,
+    );
+
+    expect(getByTestId('icon-with-title-Succeeded')).not.toBeNull();
+    expect(getByTestId('status-text')).toHaveTextContent('Succeeded');
+  });
+
   it('should render DASH when there is not title', () => {
     const { getByText } = render(
       <StatusIconAndText

--- a/plugins/shared-react/src/components/index.ts
+++ b/plugins/shared-react/src/components/index.ts
@@ -2,3 +2,13 @@ export { HorizontalStackedBars } from './pipeline/HorizontalStackedBars';
 export { CamelCaseWrap } from './common/CamelCaseWrap';
 export { TaskStatusTooltip } from './pipeline/TaskStatusTooltip';
 export { StatusIconAndText } from './common/StatusIconAndText';
+export {
+  DeleteDialogContextProvider,
+  DeleteDialogContext,
+  useDeleteDialog,
+} from './common/DeleteDialogContext';
+export {
+  DrawerContextProvider,
+  DrawerContext,
+  useDrawer,
+} from './common/DrawerContext';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5882,6 +5882,23 @@
     yml-loader "^2.1.0"
     yn "^4.0.0"
 
+"@janus-idp/shared-react@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@janus-idp/shared-react/-/shared-react-2.10.0.tgz#17818a94fcf484b76e53f1a4f3773df4a4eb46d2"
+  integrity sha512-rjhpg8xmK+yQWytu/5MmhjjpB+7LMfjlGOiy1yZLphyqKNlJgD+ATGpId85rqNwwDa8U/KG+EzFz+OTd+YlQdA==
+  dependencies:
+    "@backstage/catalog-model" "1.5.0"
+    "@backstage/core-plugin-api" "^1.9.3"
+    "@backstage/plugin-kubernetes-common" "0.8.0"
+    "@backstage/plugin-kubernetes-react" "0.4.0"
+    "@kubernetes/client-node" "^0.20.0"
+    classnames "^2.3.2"
+    date-fns "^2.30.0"
+    file-saver "^2.0.5"
+    lodash "^4.17.21"
+    mathjs "^11.11.2"
+    react-use "^17.5.0"
+
 "@jest/console@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.7.0.tgz#cd4822dbdb84529265c5a2bdb529a3c9cc950ffc"


### PR DESCRIPTION
## Description
Copies the current version of the shared react over to the 1.3.x to ensure that we get caught back up.

## Additional Notes
This plugin is need for a number of other 1.3.x plugin updates.