### PR TITLE
chore(deps): bump all plugins up to use...

### DIFF
--- a/plugins/3scale-backend/package.json
+++ b/plugins/3scale-backend/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.11",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@types/supertest": "2.0.16",
     "msw": "1.3.3",
     "supertest": "6.3.4"

--- a/plugins/aap-backend/package.json
+++ b/plugins/aap-backend/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.11",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@types/supertest": "2.0.16",
     "msw": "1.3.3",
     "supertest": "6.3.4"

--- a/plugins/acr/package.json
+++ b/plugins/acr/package.json
@@ -51,7 +51,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",

--- a/plugins/analytics-module-matomo/package.json
+++ b/plugins/analytics-module-matomo/package.json
@@ -41,7 +41,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",

--- a/plugins/analytics-provider-segment/package.json
+++ b/plugins/analytics-provider-segment/package.json
@@ -52,7 +52,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/dom": "9.3.4",
     "@testing-library/jest-dom": "6.4.8",

--- a/plugins/argocd/package.json
+++ b/plugins/argocd/package.json
@@ -64,7 +64,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@playwright/test": "1.45.3",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",

--- a/plugins/bulk-import-backend/package.json
+++ b/plugins/bulk-import-backend/package.json
@@ -80,7 +80,7 @@
     "@backstage/backend-test-utils": "0.4.4",
     "@backstage/cli": "0.26.11",
     "@backstage/plugin-catalog-backend": "1.24.0",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@types/supertest": "2.0.16",
     "supertest": "6.3.4"
   },

--- a/plugins/bulk-import/package.json
+++ b/plugins/bulk-import/package.json
@@ -63,7 +63,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@playwright/test": "1.45.3",
     "@redhat-developer/red-hat-developer-hub-theme": "0.3.0",
     "@testing-library/jest-dom": "6.4.8",

--- a/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "0.4.4",
     "@backstage/cli": "0.26.11",
-    "@janus-idp/cli": "1.13.1"
+    "@janus-idp/cli": "1.13.2"
   },
   "files": [
     "dist",

--- a/plugins/feedback-backend/package.json
+++ b/plugins/feedback-backend/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.11",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@types/nodemailer": "6.4.15",
     "@types/supertest": "2.0.16",
     "msw": "1.3.3",

--- a/plugins/feedback/package.json
+++ b/plugins/feedback/package.json
@@ -52,7 +52,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",

--- a/plugins/jfrog-artifactory/package.json
+++ b/plugins/jfrog-artifactory/package.json
@@ -52,7 +52,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",

--- a/plugins/keycloak-backend/package.json
+++ b/plugins/keycloak-backend/package.json
@@ -63,7 +63,7 @@
     "@backstage/plugin-catalog-backend": "1.24.0",
     "@backstage/plugin-permission-common": "0.8.0",
     "@backstage/plugin-permission-node": "0.8.0",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@types/lodash": "4.17.5",
     "@types/supertest": "2.0.16",
     "@types/uuid": "9.0.8",

--- a/plugins/kiali-backend/package.json
+++ b/plugins/kiali-backend/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.11",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@types/express": "4.17.21",
     "@types/supertest": "2.0.16",
     "msw": "1.3.3",

--- a/plugins/kiali/package.json
+++ b/plugins/kiali/package.json
@@ -83,7 +83,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@playwright/test": "1.45.3",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",

--- a/plugins/kubernetes-actions/package.json
+++ b/plugins/kubernetes-actions/package.json
@@ -53,7 +53,7 @@
     "@backstage/backend-common": "0.23.3",
     "@backstage/cli": "0.26.11",
     "@backstage/plugin-scaffolder-node-test-utils": "0.1.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "msw": "1.3.3"
   },
   "files": [

--- a/plugins/lightspeed/package.json
+++ b/plugins/lightspeed/package.json
@@ -53,7 +53,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.0",
+    "@janus-idp/cli": "1.13.2",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",
     "@testing-library/react-hooks": "8.0.1",

--- a/plugins/matomo-backend/package.json
+++ b/plugins/matomo-backend/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.11",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@types/supertest": "2.0.16",
     "msw": "1.3.3",
     "supertest": "6.3.4"

--- a/plugins/matomo/package.json
+++ b/plugins/matomo/package.json
@@ -53,7 +53,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",

--- a/plugins/nexus-repository-manager/package.json
+++ b/plugins/nexus-repository-manager/package.json
@@ -55,7 +55,7 @@
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
     "@hey-api/openapi-ts": "0.34.5",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -74,7 +74,7 @@
     "@backstage/plugin-catalog-backend": "1.24.0",
     "@backstage/plugin-permission-common": "0.8.0",
     "@backstage/plugin-permission-node": "0.8.0",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@types/express": "4.17.21",
     "@types/supertest": "2.0.16",
     "msw": "1.3.3",

--- a/plugins/ocm/package.json
+++ b/plugins/ocm/package.json
@@ -61,7 +61,7 @@
     "@backstage/dev-utils": "1.0.36",
     "@backstage/plugin-catalog": "1.21.1",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",

--- a/plugins/openshift-image-registry/package.json
+++ b/plugins/openshift-image-registry/package.json
@@ -50,7 +50,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",

--- a/plugins/orchestrator-backend/package.json
+++ b/plugins/orchestrator-backend/package.json
@@ -102,7 +102,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "0.4.4",
     "@backstage/cli": "0.26.11",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@types/express": "4.17.21",
     "@types/fs-extra": "11.0.4",
     "@types/json-schema": "7.0.15"

--- a/plugins/orchestrator/package.json
+++ b/plugins/orchestrator/package.json
@@ -83,7 +83,7 @@
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
     "@backstage/types": "^1.1.1",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@storybook/preview-api": "7.6.20",
     "@storybook/react": "7.6.20",

--- a/plugins/quay-actions/package.json
+++ b/plugins/quay-actions/package.json
@@ -50,7 +50,7 @@
     "@backstage/backend-common": "0.23.3",
     "@backstage/cli": "0.26.11",
     "@backstage/plugin-scaffolder-node-test-utils": "0.1.9",
-    "@janus-idp/cli": "1.13.1"
+    "@janus-idp/cli": "1.13.2"
   },
   "files": [
     "dist",

--- a/plugins/quay/package.json
+++ b/plugins/quay/package.json
@@ -59,7 +59,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@playwright/test": "1.45.3",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",

--- a/plugins/rbac-backend-module-test/package.json
+++ b/plugins/rbac-backend-module-test/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "0.4.4",
     "@backstage/cli": "0.26.11",
-    "@janus-idp/cli": "1.13.0"
+    "@janus-idp/cli": "1.13.2"
   },
   "files": [
     "dist",

--- a/plugins/rbac/package.json
+++ b/plugins/rbac/package.json
@@ -68,7 +68,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@playwright/test": "1.45.3",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",

--- a/plugins/regex-actions/package.json
+++ b/plugins/regex-actions/package.json
@@ -52,7 +52,7 @@
     "@backstage/backend-common": "0.23.3",
     "@backstage/cli": "0.26.11",
     "@backstage/plugin-scaffolder-node-test-utils": "0.1.9",
-    "@janus-idp/cli": "1.13.1"
+    "@janus-idp/cli": "1.13.2"
   },
   "files": [
     "dist",

--- a/plugins/servicenow-actions/package.json
+++ b/plugins/servicenow-actions/package.json
@@ -60,7 +60,7 @@
     "@backstage/plugin-scaffolder-node-test-utils": "0.1.9",
     "@backstage/types": "1.1.1",
     "@hey-api/openapi-ts": "0.34.5",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@types/node-fetch": "2.6.11",
     "msw": "1.3.3"
   },

--- a/plugins/sonarqube-actions/package.json
+++ b/plugins/sonarqube-actions/package.json
@@ -51,7 +51,7 @@
     "@backstage/backend-common": "0.23.3",
     "@backstage/cli": "0.26.11",
     "@backstage/plugin-scaffolder-node-test-utils": "0.1.9",
-    "@janus-idp/cli": "1.13.1"
+    "@janus-idp/cli": "1.13.2"
   },
   "files": [
     "dist",

--- a/plugins/tekton/package.json
+++ b/plugins/tekton/package.json
@@ -74,7 +74,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@playwright/test": "1.45.3",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",

--- a/plugins/topology/package.json
+++ b/plugins/topology/package.json
@@ -72,7 +72,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",

--- a/plugins/web-terminal/package.json
+++ b/plugins/web-terminal/package.json
@@ -55,7 +55,7 @@
     "@backstage/core-app-api": "1.14.1",
     "@backstage/dev-utils": "1.0.36",
     "@backstage/test-utils": "1.5.9",
-    "@janus-idp/cli": "1.13.1",
+    "@janus-idp/cli": "1.13.2",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5816,10 +5816,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@janus-idp/cli@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@janus-idp/cli/-/cli-1.13.0.tgz#acdd10ad3239f3c8951caebd3d4611b6982036f6"
-  integrity sha512-TVAjdCKwKodXKM0ztS6FC5kiHaabDpUxak2zHxqg12SStgthDbckbzS1bt9CoKaWZXhAPG8Xyt+Hw1ISJbHK1g==
+"@janus-idp/cli@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@janus-idp/cli/-/cli-1.13.2.tgz#ff63fc07442999ea45286ee4a16a79e271d8a6bc"
+  integrity sha512-2UsvnIJgx1v9BgVrroz8pjn4OBpUvpZ7/Xl3sPWCkQh4KI0Rj50MWHP1B8W65WwBC1Zh/naANKBdGKtX4VAsmg==
   dependencies:
     "@backstage/cli-common" "^0.1.14"
     "@backstage/cli-node" "^0.2.7"
@@ -31724,16 +31724,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -31828,7 +31819,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -31841,13 +31832,6 @@ strip-ansi@5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -34641,7 +34625,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -34654,15 +34638,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### What does this PR do?

chore(deps): bump all plugins up to use @janus-idp/cli/-/cli-1.13.2; regen yarn lock

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.