### PR TITLE
fix(rbac): fix ownerRefs alias after upgrade backstage to 1.29

### DIFF
--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -159,6 +159,7 @@ export class PolicyBuilder {
       ),
       auth: auth,
       httpAuth: httpAuth,
+      userInfo: env.userInfo,
     };
 
     const server = new PoliciesServer(


### PR DESCRIPTION
### What does this pr do:

Fix ownerRefs alias after upgrade backstage to 1.29

### What does this pr fixes

Fixes: 

https://issues.redhat.com/browse/RHIDP-4069