### PR TITLE
chore: tagRelease.sh: bump to 3.2.5 in 1.2.x branch + regen yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.2.3",
+  "version": "3.2.5",
   "private": true,
   "engines": {
     "node": "18 || 20"


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>
