### PR TITLE
chore(release): revert unexpected downgrade of `backstage-plugin-topology-common`

### DIFF
--- a/plugins/topology-common/package.json
+++ b/plugins/topology-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-topology-common",
   "description": "Common functionalities for the topology plugin",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
This reverts commit 992a331bf23b3a823d45fa42549deaf9acc54d18.

This was caused by another MSR failure - see
https://github.com/janus-idp/backstage-plugins/actions/runs/11021241904/job/30607878372
