### PR TITLE
fix(cli): avoid packing "binary" packages

### DIFF
--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -499,6 +499,7 @@ async function searchEmbedded(
 
         let resolvedPackage: BackstagePackageJson | undefined;
         let resolvedPackageDir: string;
+        let alreadyPacked = false;
         if (relatedMonoRepoPackages.length === 1) {
           const monoRepoPackage = relatedMonoRepoPackages[0];
 
@@ -547,6 +548,7 @@ async function searchEmbedded(
               `Resolved package named '${dep}' at '${resolvedPackageDir}' doesn't satisfy dependency version requirement in parent package '${pkg.name}': '${resolvedPackage.version}', '${dependencyVersion}'.`,
             );
           }
+          alreadyPacked = !resolvedPackage.main?.endsWith('.ts');
         }
 
         if (resolvedPackage.bundled) {
@@ -565,7 +567,7 @@ async function searchEmbedded(
             packageName: resolvedPackage.name,
             version: resolvedPackage.version ?? '0.0.0',
             parentPackageName: pkg.name,
-            alreadyPacked: resolvedPackage.main?.endsWith('.cjs.js') || false,
+            alreadyPacked,
           });
 
           resolved.push(


### PR DESCRIPTION
This change updates the export-dynamic-plugin command's default behavior to widen the check used to determine if an embedded dependency needs to be built.  If an embedded dependency is outside of the yarn workspace and does not appear to be a source package (where "main" is a file ending in ".ts") then it will not be rebuilt during export-dynamic-plugin.  This caters for cases such as a backend plugin doing a runtime import of an ESM module, the ESM module can be built and embedded into the dynamic plugin and be available on the package path at runtime.

Part of fixing [RHIDP-4148](https://issues.redhat.com/browse/RHIDP-4148)

@04kash with the new CLI version from this the `export-dynamic` command for keycloak-backend would need to be changed to remove the `--no-embed-as-dependencies` flag.