### PR TITLE
chore(release): revert downgrade of bulk import backend by MSR

### DIFF
--- a/plugins/bulk-import-backend/CHANGELOG.md
+++ b/plugins/bulk-import-backend/CHANGELOG.md
@@ -1,10 +1,5 @@
 ### Dependencies
 
-* **@janus-idp/backstage-plugin-bulk-import-common:** upgraded to 1.0.0
-* **@janus-idp/cli:** upgraded to 1.0.0
-
-### Dependencies
-
 * **@janus-idp/cli:** upgraded to 1.15.0
 
 ### Dependencies

--- a/plugins/bulk-import-backend/dist-dynamic/package.json
+++ b/plugins/bulk-import-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-bulk-import-backend-dynamic",
-  "version": "1.0.0",
+  "version": "1.6.1",
   "main": "./dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/bulk-import-backend/package.json
+++ b/plugins/bulk-import-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-bulk-import-backend",
-  "version": "1.0.0",
+  "version": "1.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -59,7 +59,7 @@
     "@backstage/plugin-catalog-node": "^1.12.4",
     "@backstage/plugin-permission-common": "^0.8.0",
     "@backstage/plugin-permission-node": "^0.8.0",
-    "@janus-idp/backstage-plugin-bulk-import-common": "1.0.0",
+    "@janus-idp/backstage-plugin-bulk-import-common": "1.1.0",
     "@octokit/auth-app": "^6.0.3",
     "@octokit/core": "^5.1.0",
     "@octokit/rest": "^20.0.2",
@@ -80,7 +80,7 @@
     "@backstage/backend-test-utils": "0.4.4",
     "@backstage/cli": "0.26.11",
     "@backstage/plugin-catalog-backend": "1.24.0",
-    "@janus-idp/cli": "1.0.0",
+    "@janus-idp/cli": "1.15.0",
     "@types/supertest": "2.0.16",
     "supertest": "6.3.4"
   },


### PR DESCRIPTION
## Description

MSR downgrade of the bulk import backend plugin
Causing failing release 
Will block some plugins from releasing

Problem [commit](https://github.com/janus-idp/backstage-plugins/commit/c6e5c5b1d3eaee76b0f606ab51b38e281303b060#diff-4b1e942efa156720791d944f042a15ecccae5b91e7f44b56a791866f35fd6f15L83)