### PR TITLE
fix(ocm): replace usage of pf-icons to mui icons

### DIFF
--- a/.changeset/green-trees-fly.md
+++ b/.changeset/green-trees-fly.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/shared-react": minor
+---
+
+Modified the package to enable the StatusIcon component to accept className as a prop

--- a/.changeset/hip-walls-kiss.md
+++ b/.changeset/hip-walls-kiss.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/backstage-plugin-ocm": minor
+---
+
+replaced pf-icons with mui icons

--- a/plugins/ocm/README.md
+++ b/plugins/ocm/README.md
@@ -187,7 +187,7 @@ catalog:
    yarn workspace app add @janus-idp/backstage-plugin-ocm
    ```
 
-1. Select the components that you want to use, such as:
+2. Select the components that you want to use, such as:
 
    - `OcmPage`: This is a standalone page or dashboard displaying all clusters as tiles. You can add `OcmPage` to `packages/app/src/App.tsx` file as follows:
 
@@ -208,7 +208,7 @@ catalog:
 
      ```tsx title="packages/app/src/components/Root/Root.tsx"
      /* highlight-add-next-line */
-     import StorageIcon from '@material-ui/icons/Storage';
+     import { OcmIcon } from '@janus-idp/backstage-plugin-ocm';
 
      export const Root = ({ children }: PropsWithChildren<{}>) => (
        <SidebarPage>
@@ -216,7 +216,7 @@ catalog:
            <SidebarGroup label="Menu" icon={<MenuIcon />}>
              {/* ... */}
              {/* highlight-add-next-line */}
-             <SidebarItem icon={StorageIcon} to="ocm" text="Clusters" />
+             <SidebarItem icon={OcmIcon} to="ocm" text="Clusters" />
            </SidebarGroup>
            {/* ... */}
          </Sidebar>

--- a/plugins/ocm/dev/index.tsx
+++ b/plugins/ocm/dev/index.tsx
@@ -19,7 +19,7 @@ import {
   ClusterContextProvider,
   ClusterInfoCard,
 } from '../src';
-import { OcmPage, ocmPlugin } from '../src/plugin';
+import { OcmIcon, OcmPage, ocmPlugin } from '../src/plugin';
 
 const clusterEntity = (name: string): Entity => ({
   apiVersion: 'backstage.io/v1beta1',
@@ -87,8 +87,9 @@ createDevApp()
   .addThemes(getAllThemes())
   .addPage({
     element: <OcmPage />,
-    title: 'Root Page',
+    title: 'Clusters',
     path: '/ocm',
+    icon: OcmIcon,
   })
   .addPage({
     path: '/catalog/:kind/:namespace/:name',

--- a/plugins/ocm/package.json
+++ b/plugins/ocm/package.json
@@ -50,8 +50,8 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.45",
+    "@mui/icons-material": "^5.16.4",
     "@patternfly/patternfly": "^5.1.0",
-    "@patternfly/react-icons": "^5.1.1",
     "react-use": "^17.4.0",
     "semver": "^7.5.4"
   },

--- a/plugins/ocm/src/components/common.tsx
+++ b/plugins/ocm/src/components/common.tsx
@@ -7,7 +7,7 @@ import {
 } from '@backstage/core-components';
 
 import { Button, Grid, makeStyles, Tooltip } from '@material-ui/core';
-import { ArrowCircleUpIcon } from '@patternfly/react-icons';
+import ArrowCircleUpIcon from '@mui/icons-material/ArrowCircleUp';
 
 import { ClusterStatus } from '@janus-idp/backstage-plugin-ocm-common';
 

--- a/plugins/ocm/src/index.ts
+++ b/plugins/ocm/src/index.ts
@@ -1,8 +1,7 @@
-export { ocmPlugin, OcmPage } from './plugin';
+export { ocmPlugin, OcmPage, OcmIcon } from './plugin';
 export { ClusterAvailableResourceCard } from './components/ClusterAvailableResourcesCard';
 export {
   ClusterContextProvider,
   useCluster,
 } from './components/ClusterContext';
 export { ClusterInfoCard } from './components/ClusterInfoCard';
-export { default as OcmIcon } from '@material-ui/icons/Storage';

--- a/plugins/ocm/src/plugin.ts
+++ b/plugins/ocm/src/plugin.ts
@@ -3,8 +3,11 @@ import {
   createApiFactory,
   createPlugin,
   createRoutableExtension,
+  IconComponent,
   identityApiRef,
 } from '@backstage/core-plugin-api';
+
+import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 
 import { OcmApiClient, OcmApiRef } from './api';
 import { rootRouteRef } from './routes';
@@ -35,3 +38,5 @@ export const OcmPage = ocmPlugin.provide(
     mountPoint: rootRouteRef,
   }),
 );
+
+export const OcmIcon = HubOutlinedIcon as IconComponent;

--- a/plugins/shared-react/src/components/common/Status.tsx
+++ b/plugins/shared-react/src/components/common/Status.tsx
@@ -9,25 +9,28 @@ import {
   StatusWarning,
 } from '@backstage/core-components';
 
-import { makeStyles } from '@material-ui/core';
+import { createStyles, makeStyles, Theme } from '@material-ui/core';
 import OffIcon from '@mui/icons-material/DoNotDisturbOnOutlined';
 import UnknownIcon from '@mui/icons-material/HelpOutline';
 import AngleDoubleRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';
 import BanIcon from '@mui/icons-material/NotInterestedOutlined';
 import PauseIcon from '@mui/icons-material/PauseCircleOutlineOutlined';
+import cx from 'classnames';
 
 import { StatusIconAndText } from './StatusIconAndText';
 
-const useStyles = makeStyles({
-  iconStyles: {
-    height: '0.8em',
-    width: '0.8em',
-    top: '0.125em',
-    position: 'relative',
-    flexShrink: 0,
-    marginRight: '8px',
-  },
-});
+const useStyles = makeStyles<Theme>(theme =>
+  createStyles({
+    iconStyles: {
+      height: '0.8em',
+      width: '0.8em',
+      top: '0.125em',
+      position: 'relative',
+      flexShrink: 0,
+      marginRight: theme.spacing(0.6),
+    },
+  }),
+);
 
 const DASH = '-';
 
@@ -59,37 +62,43 @@ const useStatusStyles = makeStyles(theme => ({
   },
 }));
 
-const StatusIcon = ({ statusKey }: { statusKey: StatusClassKey }) => {
+const StatusIcon = ({
+  statusKey,
+  className,
+}: {
+  statusKey: StatusClassKey;
+  className?: string;
+}) => {
   const statusStyles = useStatusStyles();
 
   switch (statusKey) {
     case 'ok':
       return (
-        <g className={statusStyles.success}>
+        <g className={cx(statusStyles.success, className)}>
           <StatusOK />{' '}
         </g>
       );
     case 'pending':
       return (
-        <g className={statusStyles.pending}>
+        <g className={cx(statusStyles.pending, className)}>
           <StatusPending />{' '}
         </g>
       );
     case 'running':
       return (
-        <g className={statusStyles.running}>
+        <g className={cx(statusStyles.running, className)}>
           <StatusRunning />{' '}
         </g>
       );
     case 'warning':
       return (
-        <g className={statusStyles.warning}>
+        <g className={cx(statusStyles.warning, className)}>
           <StatusWarning />{' '}
         </g>
       );
     case 'error':
       return (
-        <g className={statusStyles.error}>
+        <g className={cx(statusStyles.error, className)}>
           <StatusError />{' '}
         </g>
       );
@@ -103,6 +112,7 @@ const StatusIcon = ({ statusKey }: { statusKey: StatusClassKey }) => {
  * @param {string} status - type of status to be displayed
  * @param {boolean} [iconOnly] - (optional) if true, only displays icon
  * @param {string} [className] - (optional) additional class name for the component
+ * @param {string} [displayStatusText] - (optional) use a different text to display the status
 
  * @example
  * ```tsx
@@ -114,17 +124,24 @@ export const Status = ({
   iconOnly,
   className,
   displayStatusText,
+  dataTestId,
+  iconStyles,
+  iconClassName,
 }: {
   status: string | null;
   displayStatusText?: string;
   iconOnly?: boolean;
   className?: string;
+  dataTestId?: string;
+  iconStyles?: React.CSSProperties;
+  iconClassName?: string;
 }): React.ReactElement => {
   const classes = useStyles();
   const statusProps = {
     title: displayStatusText || status || '',
     iconOnly,
     className,
+    dataTestId,
   };
 
   switch (status) {
@@ -135,12 +152,13 @@ export const Status = ({
       return (
         <StatusIconAndText
           {...statusProps}
-          icon={<StatusIcon statusKey="pending" />}
+          icon={<StatusIcon statusKey="pending" className={iconClassName} />}
         />
       );
 
     case 'In Progress':
     case 'Progress':
+    case 'Progressing':
     case 'Installing':
     case 'InstallReady':
     case 'Replacing':
@@ -151,7 +169,7 @@ export const Status = ({
       return (
         <StatusIconAndText
           {...statusProps}
-          icon={<StatusIcon statusKey="running" />}
+          icon={<StatusIcon statusKey="running" className={iconClassName} />}
         />
       );
 
@@ -166,7 +184,7 @@ export const Status = ({
       return (
         <StatusIconAndText
           {...statusProps}
-          icon={<BanIcon className={classes.iconStyles} />}
+          icon={<BanIcon className={classes.iconStyles} style={iconStyles} />}
         />
       );
 
@@ -175,28 +193,30 @@ export const Status = ({
       return (
         <StatusIconAndText
           {...statusProps}
-          icon={<StatusIcon statusKey="warning" />}
+          icon={<StatusIcon statusKey="warning" className={iconClassName} />}
         />
       );
 
     case 'ImagePullBackOff':
     case 'Error':
     case 'Failed':
+    case 'Failure':
     case 'CrashLoopBackOff':
     case 'ErrImagePull':
       return (
         <StatusIconAndText
           {...statusProps}
-          icon={<StatusIcon statusKey="error" />}
+          icon={<StatusIcon statusKey="error" className={iconClassName} />}
         />
       );
 
     case 'Completed':
     case 'Succeeded':
+    case 'Synced':
       return (
         <StatusIconAndText
           {...statusProps}
-          icon={<StatusIcon statusKey="ok" />}
+          icon={<StatusIcon statusKey="ok" className={iconClassName} />}
         />
       );
 
@@ -204,21 +224,26 @@ export const Status = ({
       return (
         <StatusIconAndText
           {...statusProps}
-          icon={<AngleDoubleRightIcon className={classes.iconStyles} />}
+          icon={
+            <AngleDoubleRightIcon
+              className={classes.iconStyles}
+              style={iconStyles}
+            />
+          }
         />
       );
     case 'Paused':
       return (
         <StatusIconAndText
           {...statusProps}
-          icon={<PauseIcon className={classes.iconStyles} />}
+          icon={<PauseIcon className={classes.iconStyles} style={iconStyles} />}
         />
       );
     case 'Stopped':
       return (
         <StatusIconAndText
           {...statusProps}
-          icon={<OffIcon className={classes.iconStyles} />}
+          icon={<OffIcon className={classes.iconStyles} style={iconStyles} />}
         />
       );
 
@@ -226,7 +251,9 @@ export const Status = ({
       return (
         <StatusIconAndText
           {...statusProps}
-          icon={<UnknownIcon className={classes.iconStyles} />}
+          icon={
+            <UnknownIcon className={classes.iconStyles} style={iconStyles} />
+          }
         />
       );
 

--- a/plugins/shared-react/src/components/common/StatusIconAndText.tsx
+++ b/plugins/shared-react/src/components/common/StatusIconAndText.tsx
@@ -6,14 +6,6 @@ import CamelCaseWrap from './CamelCaseWrap';
 
 import './StatusIconAndText.css';
 
-type StatusIconAndTextProps = {
-  title: string;
-  iconOnly?: boolean;
-  className?: string;
-  icon: React.ReactElement;
-  spin?: boolean;
-};
-
 const DASH = '-';
 
 export const StatusIconAndText = ({
@@ -22,7 +14,15 @@ export const StatusIconAndText = ({
   spin,
   iconOnly,
   className,
-}: StatusIconAndTextProps): React.ReactElement => {
+  dataTestId,
+}: {
+  title: string;
+  iconOnly?: boolean;
+  className?: string;
+  icon: React.ReactElement;
+  spin?: boolean;
+  dataTestId?: string;
+}): React.ReactElement => {
   if (!title) {
     return <>{DASH}</>;
   }
@@ -31,7 +31,7 @@ export const StatusIconAndText = ({
     return (
       <>
         {React.cloneElement(icon, {
-          'data-testid': `icon-only-${title}`,
+          'data-testid': dataTestId ?? `icon-only-${title}`,
           className: icon.props.className,
         })}
       </>
@@ -41,7 +41,7 @@ export const StatusIconAndText = ({
   return (
     <span
       className={classNames('bs-shared-icon-and-text', className)}
-      data-testid={`icon-with-title-${title}`}
+      data-testid={dataTestId ?? `icon-with-title-${title}`}
       title={title}
     >
       {React.cloneElement(icon, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7352,6 +7352,13 @@
   dependencies:
     "@babel/runtime" "^7.23.9"
 
+"@mui/icons-material@^5.16.4":
+  version "5.16.7"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.16.7.tgz#e27f901af792065efc9f3d75d74a66af7529a10a"
+  integrity sha512-UrGwDJCXEszbDI7yV047BYU5A28eGJ79keTCP4cc74WyncuVrnurlmIRxaHL8YK+LI1Kzq+/JM52IAkNnv4u+Q==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+
 "@mui/material@^5.12.2", "@mui/material@^5.14.18", "@mui/material@^5.15.16":
   version "5.15.17"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.15.17.tgz#1e30bacc940573813cc418aebd4484708a407ba6"


### PR DESCRIPTION
Resolves:
https://issues.redhat.com/browse/RHIDP-3796

Screenshot:


![Screenshot 2024-10-01 at 4 09 45 PM](https://github.com/user-attachments/assets/3f93c6ba-cf94-4ed2-a72b-240910c4a0c0)


Test setup

OCM plugin setup


- Create a namespace “deb-test”
- Install the Advanced Cluster Management for Kubernetes operator
- Create MultiClusterHub Custom resource under deb-test namespace
    - Execute steps [https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/install/installing#custom-im[…]ull-secret](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/install/installing#custom-im%5B%E2%80%A6%5Dull-secret) from 1.4.2 - 1.4.5
	
- oc create secret generic my-image-secret -n deb-test --from-file=.dockerconfigjson=./pull-secret.txt --type=kubernetes.io/dockerconfigjson

```
apiVersion: operator.open-cluster-management.io/v1
kind: MultiClusterHub
metadata:
  name: multiclusterhub
  namespace: deb-test
spec:
  imagePullSecret: my-image-secret
  tolerations:
  - key: node-role.kubernetes.io/infra
    effect: NoSchedule
    operator: Exists
  availabilityConfig: "Basic"
  nodeSelector:
    node-role.kubernetes.io/infra: ""

```