### PR TITLE
chore(cli): document forked changes

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,13 @@
 # @janus-idp/cli
 
-This package provides a CLI for developing Backstage plugins and apps.
+This package provides a CLI for developing and exporting Backstage plugins as dynamic plugins. It implements a few new commands on top of the @backstage/cli codebase:
+
+- `package export-dynamic plugin` - Exports a Backstage plugin to a dynamic plugin package
+- `package package-dynamic-plugins` - Exports a monorepo of Backstage plugins to dynamic plugin packages in a container image
+- `package schema` - Print configuration schema for a package
+- `package metadata` - Add metadata to a package.json file
+
+This package also has a modified version of the `package start` and `package build` commands that focus on building frontend plugins as well as the Developer Hub frontend app.
 
 ## Installation
 
@@ -14,8 +21,6 @@ yarn add @janus-idp/cli
 
 For local development the cli can be used directly, even from other packages in this repo. The `bin/janus-cli` entrypoint contains a switch that will load the implementation from the `src` directory when executed inside this repo.
 
-To run the cli in watch mode, use `yarn start <args>`. For example `yarn start lint --help`.
-
 To try out the command locally, you can execute the following from the parent directory of this repo:
 
 ```bash
@@ -24,5 +29,4 @@ To try out the command locally, you can execute the following from the parent di
 
 ## Documentation
 
-- [Backstage Readme](https://github.com/backstage/backstage/blob/master/README.md)
-- [Backstage Documentation](https://backstage.io/docs)
+- [Dynamic Plugins Documentation](https://github.com/janus-idp/backstage-showcase/blob/main/docs/dynamic-plugins.md#dynamic-plugins-support)

--- a/packages/cli/src/commands/build/buildFrontend.ts
+++ b/packages/cli/src/commands/build/buildFrontend.ts
@@ -30,6 +30,10 @@ interface BuildAppOptions {
   pluginMetadata?: PluginBuildMetadata;
 }
 
+/*
+ * A variant of buildFrontend that adds plugin metadata to support dynamic
+ * frontend plugins.
+ */
 export async function buildFrontend(options: BuildAppOptions) {
   const { targetDir, writeStats, configPaths, pluginMetadata } = options;
   const { name } = await fs.readJson(resolvePath(targetDir, 'package.json'));

--- a/packages/cli/src/commands/build/command.ts
+++ b/packages/cli/src/commands/build/command.ts
@@ -21,6 +21,12 @@ import { findRoleFromCommand } from '../../lib/role';
 import { isValidUrl } from '../../lib/urls';
 import { buildFrontend } from './buildFrontend';
 
+/**
+ * A simplified build command as compared to `@backstage/cli package build`
+ * that only builds frontend packages.  This command is used to build the
+ * RHDH frontend app in `packages/app` as it adds the build configuration for
+ * webpack module federation support via Scalprum.
+ */
 export async function command(opts: OptionValues): Promise<void> {
   const role = await findRoleFromCommand(opts);
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -27,6 +27,10 @@ const configOption = [
   Array<string>(),
 ] as const;
 
+/**
+ * A subset of commands as compared to @backstage/cli that focuses on what
+ * is needed to support dynamic plugins
+ */
 export function registerScriptCommand(program: Command) {
   const command = program
     .command('package [command]')

--- a/packages/cli/src/commands/install/steps/dependencies.ts
+++ b/packages/cli/src/commands/install/steps/dependencies.ts
@@ -32,6 +32,10 @@ type Data = {
   }>;
 };
 
+/*
+ * This is referred to by lib/builder/embedPlugin but does not
+ * differ from the `@backstage/cli` implementation
+ */
 class DependenciesStep implements Step {
   constructor(private readonly data: Data) {}
 

--- a/packages/cli/src/commands/start/command.ts
+++ b/packages/cli/src/commands/start/command.ts
@@ -19,6 +19,11 @@ import { OptionValues } from 'commander';
 import { findRoleFromCommand } from '../../lib/role';
 import { startFrontend } from './startFrontend';
 
+/**
+ * This version of the "package start" command is used to start the RHDH
+ * frontend in packages/app.  It is simplified from the "@backstage/cli package
+ * start" command to remove support for starting the backend package.
+ */
 export async function command(opts: OptionValues): Promise<void> {
   const role = await findRoleFromCommand(opts);
 

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -51,6 +51,11 @@ function isFileImport(source: string) {
   return false;
 }
 
+/**
+ * A version of makeRollupConfigs that is identical to the original
+ * implementation in @backstage/cli released with 1.18.0 except that it
+ * adds named imports to the rollup configuration for commonjs modules
+ */
 export async function makeRollupConfigs(
   options: BuildOptions,
 ): Promise<RollupOptions[]> {

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -89,6 +89,11 @@ async function readBuildInfo() {
   };
 }
 
+/**
+ * A version of createConfig that differs from the version in @backstage/cli
+ * from 1.18.0 by adding the scalprum plugin, cache settings and an alias to
+ * the webpack config.
+ */
 export async function createConfig(
   paths: BundlingPaths,
   options: BundlingOptions,

--- a/packages/cli/src/lib/bundler/packageDetection.ts
+++ b/packages/cli/src/lib/bundler/packageDetection.ts
@@ -54,6 +54,11 @@ function readPackageDetectionConfig(
   };
 }
 
+/**
+ * This version of detectPackages differs from the implementation in
+ * @backstage/cli from 1.18.0 by omitting a block of code that includes the
+ * alpha entry point if available for frontend plugins.
+ */
 async function detectPackages(
   targetPath: string,
   { include, exclude }: PackageDetectionConfig,
@@ -72,6 +77,7 @@ async function detectPackages(
           depPackageJson.backstage?.role ?? '',
         )
       ) {
+        // omitted block of code here
         return [depName];
       }
       return [];

--- a/packages/cli/src/lib/bundler/types.ts
+++ b/packages/cli/src/lib/bundler/types.ts
@@ -31,6 +31,9 @@ export type BundlingOptions = {
   additionalEntryPoints?: string[];
 };
 
+/**
+ * This type is added to support dynamic plugins
+ */
 export type DynamicPluginOptions = {
   checksEnabled?: boolean;
   isDev?: boolean;
@@ -44,6 +47,10 @@ export type ServeOptions = BundlingPathsOptions & {
   verifyVersions?: boolean;
 };
 
+/**
+ * This version of BuildOptions adds the pluginMetadata field as compared to
+ * the type defined in @backstage/cli from 1.18.0
+ */
 export type BuildOptions = BundlingPathsOptions & {
   // Target directory, defaulting to paths.targetDir
   targetDir?: string;

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -38,6 +38,11 @@ type Options = {
   watch?: (newFrontendAppConfigs: AppConfig[]) => void;
 };
 
+/**
+ * This version of loadCliConfig only differs from the implementation used in
+ * @backstage/cli from 1.18.0 by the package name check for the CLI package,
+ * indicated by a comment below
+ */
 export async function loadCliConfig(options: Options) {
   const configTargets: ConfigTarget[] = [];
   options.args.forEach(arg => {
@@ -56,6 +61,7 @@ export async function loadCliConfig(options: Options) {
       localPackageNames = Array.from(
         graph.collectPackageNames([options.fromPackage], node => {
           // Workaround for Backstage main repo only, since the CLI has some artificial devDependencies
+          // this is the only difference from @backstage/cli
           if (node.name === '@janus-idp/cli') {
             return undefined;
           }

--- a/packages/cli/src/lib/packager/productionPack.ts
+++ b/packages/cli/src/lib/packager/productionPack.ts
@@ -26,6 +26,7 @@ import { readEntryPoints } from '../entryPoints';
 const PKG_PATH = 'package.json';
 const PKG_BACKUP_PATH = 'package.json-prepack';
 
+// This list differs from @backstage/cli from 1.80.0
 const SKIPPED_KEYS = ['access', 'registry', 'tag'];
 const SCRIPT_EXTS = ['.js', '.jsx', '.ts', '.tsx'];
 
@@ -35,6 +36,13 @@ interface ProductionPackOptions {
   customizeManifest?: (pkg: BackstagePackageJson) => undefined | void;
 }
 
+/**
+ * This version of productionPack adjusts the implementation of the
+ * @backstage/cli equivalent from 1.18.0 by adding a hook to customize the
+ * package manifest during the packing process.  It also omits some blocks
+ * concerning alphaTypes and betaTypes as indicated by comments in the
+ * function body.
+ */
 export async function productionPack(options: ProductionPackOptions) {
   const { packageDir, targetDir } = options;
   const pkgPath = resolvePath(packageDir, PKG_PATH);
@@ -46,6 +54,7 @@ export async function productionPack(options: ProductionPackOptions) {
     await fs.writeFile(PKG_BACKUP_PATH, pkgContent);
   }
 
+  // removed block
   // This mutates pkg to fill in index exports, so call it before applying publishConfig
   const writeCompatibilityEntryPoints = await prepareExportsEntryPoints(
     pkg,
@@ -72,6 +81,7 @@ export async function productionPack(options: ProductionPackOptions) {
     delete pkg.optionalDependencies;
   }
 
+  // Added hook to allow customizing the package manifest
   if (options.customizeManifest !== undefined) {
     options.customizeManifest(pkg);
   }
@@ -99,10 +109,14 @@ export async function productionPack(options: ProductionPackOptions) {
     await fs.writeJson(pkgPath, pkg, { encoding: 'utf8', spaces: 2 });
   }
 
+  // removed block
   if (writeCompatibilityEntryPoints) {
     await writeCompatibilityEntryPoints(targetDir ?? packageDir);
   }
 }
+
+// revertProductionPack removed from here, after this point there is no
+// difference from @backstage/cli from 1.18.0
 
 const EXPORT_MAP = {
   import: '.esm.js',

--- a/packages/cli/src/lib/version.ts
+++ b/packages/cli/src/lib/version.ts
@@ -31,7 +31,10 @@ This does not create an actual dependency on these packages and does not bring i
 Rollup will extract the value of the version field in each package at build time without
 leaving any imports in place.
 */
-
+/**
+ * In @backstage/cli from 1.18.0 these imports are a block of static imports of
+ * various core backstage packages
+ */
 import Manifest from '../../package.json';
 import { paths } from './paths';
 import { Lockfile } from './versioning';
@@ -43,6 +46,10 @@ export function findVersion() {
 
 export const version = findVersion();
 
+/**
+ * This packageVersions takes the place of the static imports used in
+ * @backstage/cli by building this list based on the @janus-idp/cli package.
+ */
 export const packageVersions: Record<string, string> = {
   ...Object.fromEntries(
     Object.entries(Manifest.devDependencies as Record<string, string>).filter(
@@ -85,6 +92,10 @@ export function createPackageVersionProvider(lockfile?: Lockfile) {
     );
     const highestRange = validRanges?.slice(-1)[0];
 
+    /**
+     * These return statements differ from @backstage/cli by locking the
+     * package dependencies to the exact version rather than accepting a range.
+     */
     if (highestRange?.range) {
       return highestRange?.range.replace(/^\^/, '');
     }


### PR DESCRIPTION
This update adds comments to areas of the CLI code that were modified from the original fork.  This commit also updates the CLI readme to list what commands are added and updates the documentation links to point to the current dynamic plugins documentation.  This change fixes [RHIDP-2168](https://issues.redhat.com/browse/RHIDP-2168).