### PR TITLE
fix: tekton table sorting

### DIFF
--- a/plugins/tekton/src/__fixtures__/1-pipelinesData.ts
+++ b/plugins/tekton/src/__fixtures__/1-pipelinesData.ts
@@ -562,7 +562,7 @@ export const mockKubernetesPlrResponse = {
         name: 'pipeline-test-wbvtlk',
         namespace: 'deb-test',
         resourceVersion: '117337',
-        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b24',
+        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9a24',
         creationTimestamp: new Date('2023-04-11T12:31:56Z'),
       },
       spec: {
@@ -649,7 +649,7 @@ export const mockKubernetesPlrResponse = {
         name: 'pipelinerun-with-scanner-task',
         namespace: 'deb-test',
         resourceVersion: '117337',
-        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b24',
+        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b14',
         creationTimestamp: new Date('2023-04-11T12:31:56Z'),
       },
       spec: {
@@ -716,7 +716,7 @@ export const mockKubernetesPlrResponse = {
         name: 'pipelinerun-with-sbom-task',
         namespace: 'deb-test',
         resourceVersion: '117337',
-        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b24',
+        uid: '0a091bbf-3813-48d3-a6ce-fc43644a8b24',
         creationTimestamp: new Date('2023-04-11T12:31:56Z'),
       },
       spec: {
@@ -776,7 +776,7 @@ export const mockKubernetesPlrResponse = {
         name: 'pipelinerun-with-external-sbom-task',
         namespace: 'deb-test',
         resourceVersion: '117337',
-        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b24',
+        uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b26',
         creationTimestamp: new Date('2023-04-11T12:31:56Z'),
       },
       spec: {
@@ -1055,7 +1055,7 @@ export const mockKubernetesPlrResponse = {
             controller: true,
             kind: 'PipelineRun',
             name: 'pipelinerun-with-scanner-task',
-            uid: '0a091bbf-3813-48d3-a6ce-fc43644a9b24',
+            uid: '0a091bbf-3813-48d3-a6ce-fc43644a9t24',
           },
         ],
         resourceVersion: '117189',

--- a/plugins/tekton/src/components/PipelineRunList/PipelineRunList.tsx
+++ b/plugins/tekton/src/components/PipelineRunList/PipelineRunList.tsx
@@ -145,18 +145,18 @@ const PipelineRunList = () => {
       page * rowsPerPage,
       page * rowsPerPage + rowsPerPage,
     );
-  }, [filteredPipelineRuns, page, rowsPerPage]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filteredPipelineRuns, page, rowsPerPage, order, orderById]);
 
-  const handleRequestSort = (
-    _event: React.MouseEvent<unknown>,
-    property: string,
-    id: string,
-  ) => {
-    const isAsc = orderBy === property && order === 'asc';
-    setOrder(isAsc ? 'desc' : 'asc');
-    setOrderBy(property);
-    setOrderById(id);
-  };
+  const handleRequestSort = React.useCallback(
+    (_event: React.MouseEvent<unknown>, property: string, id: string) => {
+      const isAsc = orderBy === property && order === 'asc';
+      setOrder(isAsc ? 'desc' : 'asc');
+      setOrderBy(property);
+      setOrderById(id);
+    },
+    [order, orderBy],
+  );
 
   const handleChangePage = (_event: unknown, newPage: number) => {
     setPage(newPage);


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/RHTAPBUGS-1306

**Description:**

Fixed sorting of the Tekton Pipelins runs Table.

This PR adds following changes:
- added dependencies while changes happen in pipelines runs table data, to make sure showing correct data
- made unique uid for mock data for dev mode

**Screenshots**:
![ScreenRecording2024-10-03at10 55 53AM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ee3c29d7-fcbc-4420-a301-0dff47f9ed05)


**How to test?:**

1. run yarn start in plugins/tekton folder to run the application in dev mode.