### PR TITLE
fix(ocm-common): fix catalog info (duplicate)

### DIFF
--- a/plugins/ocm-common/catalog-info.yaml
+++ b/plugins/ocm-common/catalog-info.yaml
@@ -2,9 +2,9 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: janus-idp-ocm-backend
-  title: '@janus-idp/backstage-plugin-ocm-backend'
-  description: Open Cluster Management backend plugin for Backstage
+  name: janus-idp-ocm-common
+  title: '@janus-idp/backstage-plugin-ocm-common'
+  description: Open Cluster Management common package for Backstage
   annotations:
     backstage.io/source-location: url:https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm-backend
     backstage.io/view-url: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/ocm-backend/catalog-info.yaml


### PR DESCRIPTION
Fixes a copy and paste error that this two components has the same name:

https://github.com/janus-idp/backstage-plugins/blob/5a4c3df939db940ab91f065cde22b250fee4d6cf/plugins/ocm-backend/catalog-info.yaml#L5-L7

and

https://github.com/janus-idp/backstage-plugins/blob/5a4c3df939db940ab91f065cde22b250fee4d6cf/plugins/ocm-common/catalog-info.yaml#L5-L7

This should fix:

![image](https://github.com/user-attachments/assets/b1f75d6a-0e21-4ecb-8eac-8719a97e1054)