### PR TITLE
chore(release): revert unexpected downgrade of `backstage-plugin-orchestrator-form-react` by MSR

### DIFF
--- a/plugins/orchestrator-form-react/CHANGELOG.md
+++ b/plugins/orchestrator-form-react/CHANGELOG.md
@@ -1,10 +1,5 @@
 ### Dependencies
 
-* **@janus-idp/backstage-plugin-orchestrator-common:** upgraded to 1.0.0
-* **@janus-idp/backstage-plugin-orchestrator-form-api:** upgraded to 1.0.0
-
-### Dependencies
-
 * **@janus-idp/backstage-plugin-orchestrator-common:** upgraded to 1.18.2
 
 ### Dependencies

--- a/plugins/orchestrator-form-react/package.json
+++ b/plugins/orchestrator-form-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-orchestrator-form-react",
   "description": "Web library for the orchestrator-form plugin",
-  "version": "1.0.0",
+  "version": "1.1.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -32,8 +32,8 @@
     "@backstage/core-components": "^0.14.9",
     "@backstage/core-plugin-api": "^1.9.3",
     "@backstage/types": "^1.1.1",
-    "@janus-idp/backstage-plugin-orchestrator-common": "1.0.0",
-    "@janus-idp/backstage-plugin-orchestrator-form-api": "1.0.0",
+    "@janus-idp/backstage-plugin-orchestrator-common": "1.18.2",
+    "@janus-idp/backstage-plugin-orchestrator-form-api": "1.1.0",
     "json-schema": "^0.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
The MSR release job seems to have failed after merging #2223 :
https://github.com/janus-idp/backstage-plugins/actions/runs/11159096004/job/31016793572

This reverts commit 5cf6602004c09b037d31aade078b45b3e02f0608, and should allow releasing the packages that have been updated recently (like `bulk-import-backend` and `bulk-import-common`).