### PR TITLE
chore(release): revert unexpected downgrade of `backstage-plugin-tekton-common` by MSR

### DIFF
--- a/plugins/tekton-common/package.json
+++ b/plugins/tekton-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-tekton-common",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
The MSR release job seems to have failed after merging #2289 :
https://github.com/janus-idp/backstage-plugins/actions/runs/11160738980/job/31021831485

This reverts commit a0b89990cc6597b0b356e0679fec26981ed8872a.
