### PR TITLE
fix(orchestrator): avoid empty links in workflow result

### DIFF
--- a/plugins/orchestrator/src/components/WorkflowResult.tsx
+++ b/plugins/orchestrator/src/components/WorkflowResult.tsx
@@ -234,16 +234,15 @@ const WorkflowOutputs = ({
         <Grid item md={12} key="__links" className={styles.links}>
           <AboutField label="Links">
             <List dense disablePadding>
-              {links.map(item => {
-                return (
-                  <ListItem disableGutters key={item.key}>
-                    {item.value && (
+              {links
+                .filter(item => item.value && item.key)
+                .map(item => {
+                  return (
+                    <ListItem disableGutters key={item.key}>
                       <Link to={item.value as string}>{item.key}</Link>
-                    )}
-                    {!item.value && VALUE_UNAVAILABLE}
-                  </ListItem>
-                );
-              })}
+                    </ListItem>
+                  );
+                })}
             </List>
           </AboutField>
         </Grid>


### PR DESCRIPTION
A link needs to contain both key and value to be rendered, otherwise its skipped on the Workflow result card.

Fixes: [FLPATH-1749](https://issues.redhat.com//browse/FLPATH-1749)