### PR TITLE
chore(release): revert unexpected downgrade of `backstage-plugin-tekton-common` by MSR

### DIFF
--- a/plugins/tekton-common/package.json
+++ b/plugins/tekton-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-tekton-common",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
This reverts commit 36f1022e3c5148371eb9c9911771e760bef5963c.

MSR failure logs:
https://github.com/janus-idp/backstage-plugins/actions/runs/11179558039/job/31079453505
