### PR TITLE
chore(release): revert unexpected downgrade of backstage-plugin-quay-common by MSR

### DIFF
--- a/plugins/quay-common/package.json
+++ b/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-quay-common",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
This reverts commit [561d19b](https://github.com/janus-idp/backstage-plugins/commit/561d19b088d574a2ab7a4e2238a038088e53594f).