### PR TITLE
chore(release): 1.2.x - Sync OCM plugins with the latest 1.2 version in Showcase

### DIFF
--- a/plugins/ocm-backend/CHANGELOG.md
+++ b/plugins/ocm-backend/CHANGELOG.md
@@ -1,3 +1,11 @@
+## @janus-idp/backstage-plugin-ocm-backend [4.0.7](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-ocm-backend@4.0.6...@janus-idp/backstage-plugin-ocm-backend@4.0.7) (2024-06-04)
+
+
+
+### Dependencies
+
+* **@janus-idp/backstage-plugin-ocm-common:** upgraded to 3.0.2
+
 ## @janus-idp/backstage-plugin-ocm-backend [4.0.6](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-ocm-backend@4.0.5...@janus-idp/backstage-plugin-ocm-backend@4.0.6) (2024-06-03)
 
 

--- a/plugins/ocm-backend/CHANGELOG.md
+++ b/plugins/ocm-backend/CHANGELOG.md
@@ -1,3 +1,11 @@
+## @janus-idp/backstage-plugin-ocm-backend [4.0.8](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-ocm-backend@4.0.7...@janus-idp/backstage-plugin-ocm-backend@4.0.8) (2024-06-05)
+
+
+
+### Dependencies
+
+* **@janus-idp/cli:** upgraded to 1.10.0
+
 ## @janus-idp/backstage-plugin-ocm-backend [4.0.7](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-ocm-backend@4.0.6...@janus-idp/backstage-plugin-ocm-backend@4.0.7) (2024-06-04)
 
 

--- a/plugins/ocm-backend/dist-dynamic/package.json
+++ b/plugins/ocm-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-ocm-backend-dynamic",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/plugins/ocm-backend/dist-dynamic/package.json
+++ b/plugins/ocm-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-ocm-backend-dynamic",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -10,7 +10,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "supported-versions": "1.26.5"
   },
   "exports": {
     ".": {
@@ -42,13 +43,23 @@
     "app-config.janus-idp.yaml",
     "alpha"
   ],
-  "repository": "github:janus-idp/backstage-plugins",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/janus-idp/backstage-plugins",
+    "directory": "plugins/ocm-backend"
+  },
   "keywords": [
+    "support:production",
+    "lifecycle:active",
     "backstage",
     "plugin"
   ],
-  "homepage": "https://janus-idp.io/",
+  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
+  "maintainers": [
+    "@janus-idp/maintainers-plugins"
+  ],
+  "author": "Red Hat",
   "bundleDependencies": true,
   "peerDependencies": {
     "@backstage/backend-common": "^0.21.7",

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-ocm-backend",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -54,7 +54,7 @@
     "@backstage/errors": "^1.2.4",
     "@backstage/plugin-permission-common": "^0.7.13",
     "@backstage/plugin-permission-node": "^0.7.28",
-    "@janus-idp/backstage-plugin-ocm-common": "3.0.1",
+    "@janus-idp/backstage-plugin-ocm-common": "3.0.2",
     "@kubernetes/client-node": "^0.20.0",
     "express": "^4.18.2",
     "express-promise-router": "^4.1.1",

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-ocm-backend",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.4",
-    "@janus-idp/cli": "1.9.0",
+    "@janus-idp/cli": "1.10.0",
     "@backstage/plugin-auth-node": "0.4.12",
     "@backstage/plugin-catalog-backend": "1.21.1",
     "@backstage/plugin-permission-common": "0.7.13",


### PR DESCRIPTION
There were some updates that happened to the OCM plugin post 1.2 release that were not synced to the 1.2.x branch.  This PR cherry picks the changes from the 4.0.7 and 4.0.8 releases (plugin metadata and Janus CLI version update)