### PR TITLE
fix(rbac): refactor PluginPermissionMetadataCollector constructor

### DIFF
--- a/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoint.test.ts
@@ -19,12 +19,14 @@ describe('plugin-endpoint', () => {
 
   describe('Test list plugin policies', () => {
     it('should return empty plugin policies list', async () => {
-      const collector = new PluginPermissionMetadataCollector(
-        mockPluginEndpointDiscovery,
-        backendPluginIDsProviderMock,
-        mockServices.logger.mock(),
-        mockServices.rootConfig(),
-      );
+      const collector = new PluginPermissionMetadataCollector({
+        deps: {
+          discovery: mockPluginEndpointDiscovery,
+          pluginIdProvider: backendPluginIDsProviderMock,
+          logger: mockServices.logger.mock(),
+          config: mockServices.rootConfig(),
+        },
+      });
       const policiesMetadata = await collector.getPluginPolicies(
         mockServices.auth(),
       );
@@ -47,13 +49,15 @@ describe('plugin-endpoint', () => {
         },
       });
 
-      const collector = new PluginPermissionMetadataCollector(
-        mockPluginEndpointDiscovery,
-        backendPluginIDsProviderMock,
-        mockServices.logger.mock(),
-        mockServices.rootConfig(),
-        mockUrlReaderService,
-      );
+      const collector = new PluginPermissionMetadataCollector({
+        deps: {
+          discovery: mockPluginEndpointDiscovery,
+          pluginIdProvider: backendPluginIDsProviderMock,
+          logger: mockServices.logger.mock(),
+          config: mockServices.rootConfig(),
+        },
+        optional: { urlReader: mockUrlReaderService },
+      });
       const policiesMetadata = await collector.getPluginPolicies(
         mockServices.auth(),
       );
@@ -84,13 +88,15 @@ describe('plugin-endpoint', () => {
         },
       });
 
-      const collector = new PluginPermissionMetadataCollector(
-        mockPluginEndpointDiscovery,
-        backendPluginIDsProviderMock,
-        mockServices.logger.mock(),
-        mockServices.rootConfig(),
-        mockUrlReaderService,
-      );
+      const collector = new PluginPermissionMetadataCollector({
+        deps: {
+          discovery: mockPluginEndpointDiscovery,
+          pluginIdProvider: backendPluginIDsProviderMock,
+          logger: mockServices.logger.mock(),
+          config: mockServices.rootConfig(),
+        },
+        optional: { urlReader: mockUrlReaderService },
+      });
       const policiesMetadata = await collector.getPluginPolicies(
         mockServices.auth(),
       );
@@ -131,13 +137,15 @@ describe('plugin-endpoint', () => {
 
       const logger = mockServices.logger.mock();
       const errorSpy = jest.spyOn(logger, 'warn').mockClear();
-      const collector = new PluginPermissionMetadataCollector(
-        mockPluginEndpointDiscovery,
-        backendPluginIDsProviderMock,
-        logger,
-        mockServices.rootConfig(),
-        mockUrlReaderService,
-      );
+      const collector = new PluginPermissionMetadataCollector({
+        deps: {
+          discovery: mockPluginEndpointDiscovery,
+          pluginIdProvider: backendPluginIDsProviderMock,
+          logger,
+          config: mockServices.rootConfig(),
+        },
+        optional: { urlReader: mockUrlReaderService },
+      });
       const policiesMetadata = await collector.getPluginPolicies(
         mockServices.auth(),
       );
@@ -183,13 +191,15 @@ describe('plugin-endpoint', () => {
 
       const logger = mockServices.logger.mock();
       const errorSpy = jest.spyOn(logger, 'error').mockClear();
-      const collector = new PluginPermissionMetadataCollector(
-        mockPluginEndpointDiscovery,
-        backendPluginIDsProviderMock,
-        logger,
-        mockServices.rootConfig(),
-        mockUrlReaderService,
-      );
+      const collector = new PluginPermissionMetadataCollector({
+        deps: {
+          discovery: mockPluginEndpointDiscovery,
+          pluginIdProvider: backendPluginIDsProviderMock,
+          logger,
+          config: mockServices.rootConfig(),
+        },
+        optional: { urlReader: mockUrlReaderService },
+      });
 
       const policiesMetadata = await collector.getPluginPolicies(
         mockServices.auth(),
@@ -247,13 +257,15 @@ describe('plugin-endpoint', () => {
         .spyOn(mockServices.logger.mock(), 'error')
         .mockClear();
 
-      const collector = new PluginPermissionMetadataCollector(
-        mockPluginEndpointDiscovery,
-        backendPluginIDsProviderMock,
-        mockServices.logger.mock(),
-        mockServices.rootConfig(),
-        mockUrlReaderService,
-      );
+      const collector = new PluginPermissionMetadataCollector({
+        deps: {
+          discovery: mockPluginEndpointDiscovery,
+          pluginIdProvider: backendPluginIDsProviderMock,
+          logger: mockServices.logger.mock(),
+          config: mockServices.rootConfig(),
+        },
+        optional: { urlReader: mockUrlReaderService },
+      });
       const policiesMetadata = await collector.getPluginPolicies(
         mockServices.auth(),
       );
@@ -277,12 +289,14 @@ describe('plugin-endpoint', () => {
     it('should return empty condition rule list', async () => {
       backendPluginIDsProviderMock.getPluginIds.mockReturnValue([]);
 
-      const collector = new PluginPermissionMetadataCollector(
-        mockPluginEndpointDiscovery,
-        backendPluginIDsProviderMock,
-        mockServices.logger.mock(),
-        mockServices.rootConfig(),
-      );
+      const collector = new PluginPermissionMetadataCollector({
+        deps: {
+          discovery: mockPluginEndpointDiscovery,
+          pluginIdProvider: backendPluginIDsProviderMock,
+          logger: mockServices.logger.mock(),
+          config: mockServices.rootConfig(),
+        },
+      });
       const conditionRulesMetadata = await collector.getPluginConditionRules(
         mockServices.auth(),
       );
@@ -305,13 +319,15 @@ describe('plugin-endpoint', () => {
         },
       });
 
-      const collector = new PluginPermissionMetadataCollector(
-        mockPluginEndpointDiscovery,
-        backendPluginIDsProviderMock,
-        mockServices.logger.mock(),
-        mockServices.rootConfig(),
-        mockUrlReaderService,
-      );
+      const collector = new PluginPermissionMetadataCollector({
+        deps: {
+          discovery: mockPluginEndpointDiscovery,
+          pluginIdProvider: backendPluginIDsProviderMock,
+          logger: mockServices.logger.mock(),
+          config: mockServices.rootConfig(),
+        },
+        optional: { urlReader: mockUrlReaderService },
+      });
       const conditionRulesMetadata = await collector.getPluginConditionRules(
         mockServices.auth(),
       );
@@ -356,13 +372,15 @@ describe('plugin-endpoint', () => {
         },
       });
 
-      const collector = new PluginPermissionMetadataCollector(
-        mockPluginEndpointDiscovery,
-        backendPluginIDsProviderMock,
-        mockServices.logger.mock(),
-        mockServices.rootConfig(),
-        mockUrlReaderService,
-      );
+      const collector = new PluginPermissionMetadataCollector({
+        deps: {
+          discovery: mockPluginEndpointDiscovery,
+          pluginIdProvider: backendPluginIDsProviderMock,
+          logger: mockServices.logger.mock(),
+          config: mockServices.rootConfig(),
+        },
+        optional: { urlReader: mockUrlReaderService },
+      });
       const metadata = await collector.getMetadataByPluginId(
         'catalog',
         undefined,

--- a/plugins/rbac-backend/src/service/plugin-endpoints.ts
+++ b/plugins/rbac-backend/src/service/plugin-endpoints.ts
@@ -38,18 +38,30 @@ export type PluginMetadataResponseSerializedRule = {
 
 export class PluginPermissionMetadataCollector {
   private readonly pluginIds: string[];
+  private readonly discovery: DiscoveryService;
+  private readonly logger: LoggerService;
   private readonly urlReader: UrlReaderService;
 
-  constructor(
-    private readonly discovery: DiscoveryService,
-    private readonly pluginIdProvider: PluginIdProvider,
-    private readonly logger: LoggerService,
-    config: Config,
-    urlReader?: UrlReaderService,
-  ) {
-    this.pluginIds = this.pluginIdProvider.getPluginIds();
+  constructor({
+    deps,
+    optional,
+  }: {
+    deps: {
+      discovery: DiscoveryService;
+      pluginIdProvider: PluginIdProvider;
+      logger: LoggerService;
+      config: Config;
+    };
+    optional?: {
+      urlReader?: UrlReaderService;
+    };
+  }) {
+    const { discovery, pluginIdProvider, logger, config } = deps;
+    this.pluginIds = pluginIdProvider.getPluginIds();
+    this.discovery = discovery;
+    this.logger = logger;
     this.urlReader =
-      urlReader ??
+      optional?.urlReader ??
       UrlReaders.default({
         config,
         logger,

--- a/plugins/rbac-backend/src/service/policy-builder.test.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.test.ts
@@ -376,7 +376,7 @@ describe('PolicyBuilder', () => {
     expect(logger.info).toHaveBeenCalledWith('RBAC backend plugin was enabled');
     const pIdProvider = (
       PluginPermissionMetadataCollector as unknown as jest.Mock
-    ).mock.calls[0][1];
+    ).mock.calls[0][0].deps.pluginIdProvider;
     expect(pIdProvider.getPluginIds()).toEqual(['catalog']);
   });
 });

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -132,12 +132,14 @@ export class PolicyBuilder {
       };
     }
 
-    const pluginPermMetaData = new PluginPermissionMetadataCollector(
-      env.discovery,
-      pluginIdProvider,
-      env.logger,
-      env.config,
-    );
+    const pluginPermMetaData = new PluginPermissionMetadataCollector({
+      deps: {
+        discovery: env.discovery,
+        pluginIdProvider: pluginIdProvider,
+        logger: env.logger,
+        config: env.config,
+      },
+    });
 
     const options: RouterOptions = {
       config: env.config,


### PR DESCRIPTION
Triggered by [this disucssion](https://github.com/janus-idp/backstage-plugins/pull/2225/files/6c33a8607216c53648261ccf5285b92f9ac87b79#r1781671369) under [this PR](https://github.com/janus-idp/backstage-plugins/pull/2225) to migrate RBAC plugin to use the new backend.

This PR changes the constructor to use 2 objects as the arguments instead: `deps` for mandatory parameters and `optional` for optional ones.

Fixes [RHIDP-4318](https://issues.redhat.com/browse/RHIDP-4318)