### PR TITLE
fix(keycloak-backend): delete unused dev dependencies and update test

### DIFF
--- a/plugins/keycloak-backend/package.json
+++ b/plugins/keycloak-backend/package.json
@@ -51,25 +51,15 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@backstage/backend-app-api": "0.8.0",
     "@backstage/backend-defaults": "0.3.3",
     "@backstage/backend-test-utils": "0.4.4",
     "@backstage/cli": "0.26.11",
-    "@backstage/config": "^1.2.0",
-    "@backstage/plugin-auth-node": "0.4.17",
+    "@backstage/config": "1.2.0",
     "@backstage/plugin-catalog-backend": "1.24.0",
-    "@backstage/plugin-permission-common": "0.8.0",
-    "@backstage/plugin-permission-node": "0.8.0",
     "@janus-idp/cli": "1.15.2",
     "@types/lodash": "4.17.5",
-    "@types/supertest": "2.0.16",
     "@types/uuid": "9.0.8",
-    "deepmerge": "4.3.1",
-    "express": "4.20.0",
-    "luxon": "3.4.4",
-    "msw": "1.3.3",
-    "opener": "1.5.2",
-    "supertest": "6.3.4"
+    "deepmerge": "4.3.1"
   },
   "files": [
     "dist",

--- a/plugins/keycloak-backend/src/extensions.ts
+++ b/plugins/keycloak-backend/src/extensions.ts
@@ -1,6 +1,6 @@
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
 
-import { GroupTransformer, UserTransformer } from './lib/types';
+import type { GroupTransformer, UserTransformer } from './lib/types';
 
 /**
  * An extension point that exposes the ability to implement user and group transformer functions for keycloak.

--- a/plugins/keycloak-backend/src/lib/config.test.ts
+++ b/plugins/keycloak-backend/src/lib/config.test.ts
@@ -1,4 +1,4 @@
-import { ConfigReader } from '@backstage/config';
+import { mockServices } from '@backstage/backend-test-utils';
 
 import deepmerge from 'deepmerge';
 
@@ -7,7 +7,7 @@ import { readProviderConfigs } from './config';
 
 describe('readProviderConfigs', () => {
   it('should return an empty array if no providers are configured', () => {
-    const config = new ConfigReader({});
+    const config = mockServices.rootConfig({ data: {} });
 
     const result = readProviderConfigs(config);
 
@@ -15,7 +15,7 @@ describe('readProviderConfigs', () => {
   });
 
   it('should return an array of provider configs', () => {
-    const config = new ConfigReader(CONFIG);
+    const config = mockServices.rootConfig({ data: CONFIG });
 
     const result = readProviderConfigs(config);
 
@@ -37,8 +37,8 @@ describe('readProviderConfigs', () => {
   });
 
   it('should return an array of provider configs with optional values', () => {
-    const config = new ConfigReader(
-      deepmerge(CONFIG, {
+    const config = mockServices.rootConfig({
+      data: deepmerge(CONFIG, {
         catalog: {
           providers: {
             keycloakOrg: {
@@ -61,7 +61,7 @@ describe('readProviderConfigs', () => {
           },
         },
       }),
-    );
+    });
 
     const result = readProviderConfigs(config);
 
@@ -88,8 +88,8 @@ describe('readProviderConfigs', () => {
   });
 
   it('should throw an error if clientId is provided without clientSecret', () => {
-    const config = new ConfigReader(
-      deepmerge(CONFIG, {
+    const config = mockServices.rootConfig({
+      data: deepmerge(CONFIG, {
         catalog: {
           providers: {
             keycloakOrg: {
@@ -100,7 +100,7 @@ describe('readProviderConfigs', () => {
           },
         },
       }),
-    );
+    });
 
     expect(() => readProviderConfigs(config)).toThrow(
       `clientSecret must be provided when clientId is defined.`,
@@ -108,8 +108,8 @@ describe('readProviderConfigs', () => {
   });
 
   it('should throw an error if clientSecret is provided without clientId', () => {
-    const config = new ConfigReader(
-      deepmerge(CONFIG, {
+    const config = mockServices.rootConfig({
+      data: deepmerge(CONFIG, {
         catalog: {
           providers: {
             keycloakOrg: {
@@ -120,7 +120,7 @@ describe('readProviderConfigs', () => {
           },
         },
       }),
-    );
+    });
 
     expect(() => readProviderConfigs(config)).toThrow(
       `clientId must be provided when clientSecret is defined.`,
@@ -128,8 +128,8 @@ describe('readProviderConfigs', () => {
   });
 
   it('should throw an error if username is provided without password', () => {
-    const config = new ConfigReader(
-      deepmerge(CONFIG, {
+    const config = mockServices.rootConfig({
+      data: deepmerge(CONFIG, {
         catalog: {
           providers: {
             keycloakOrg: {
@@ -140,7 +140,7 @@ describe('readProviderConfigs', () => {
           },
         },
       }),
-    );
+    });
 
     expect(() => readProviderConfigs(config)).toThrow(
       `password must be provided when username is defined.`,
@@ -148,8 +148,8 @@ describe('readProviderConfigs', () => {
   });
 
   it('should throw an error if password is provided without username', () => {
-    const config = new ConfigReader(
-      deepmerge(CONFIG, {
+    const config = mockServices.rootConfig({
+      data: deepmerge(CONFIG, {
         catalog: {
           providers: {
             keycloakOrg: {
@@ -160,7 +160,7 @@ describe('readProviderConfigs', () => {
           },
         },
       }),
-    );
+    });
 
     expect(() => readProviderConfigs(config)).toThrow(
       `username must be provided when password is defined.`,

--- a/plugins/keycloak-backend/src/lib/read.test.ts
+++ b/plugins/keycloak-backend/src/lib/read.test.ts
@@ -1,6 +1,6 @@
 import { mockServices } from '@backstage/backend-test-utils';
 
-import KeycloakAdminClient from '@keycloak/keycloak-admin-client';
+import type KeycloakAdminClient from '@keycloak/keycloak-admin-client';
 
 import {
   kGroups23orHigher,
@@ -22,7 +22,7 @@ import {
   readKeycloakRealm,
   traverseGroups,
 } from './read';
-import { GroupTransformer, UserTransformer } from './types';
+import type { GroupTransformer, UserTransformer } from './types';
 
 const config: KeycloakProviderConfig = {
   realm: 'myrealm',

--- a/plugins/keycloak-backend/src/lib/read.ts
+++ b/plugins/keycloak-backend/src/lib/read.ts
@@ -15,7 +15,7 @@
  */
 
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { GroupEntity, UserEntity } from '@backstage/catalog-model';
+import type { GroupEntity, UserEntity } from '@backstage/catalog-model';
 
 import KeycloakAdminClient from '@keycloak/keycloak-admin-client';
 import type GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation';

--- a/plugins/keycloak-backend/src/lib/read.ts
+++ b/plugins/keycloak-backend/src/lib/read.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { LoggerService } from '@backstage/backend-plugin-api';
+import type { LoggerService } from '@backstage/backend-plugin-api';
 import type { GroupEntity, UserEntity } from '@backstage/catalog-model';
 
-import KeycloakAdminClient from '@keycloak/keycloak-admin-client';
+import type KeycloakAdminClient from '@keycloak/keycloak-admin-client';
 import type GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation';
 import type UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation';
-import { Groups } from '@keycloak/keycloak-admin-client/lib/resources/groups';
-import { Users } from '@keycloak/keycloak-admin-client/lib/resources/users';
+import type { Groups } from '@keycloak/keycloak-admin-client/lib/resources/groups';
+import type { Users } from '@keycloak/keycloak-admin-client/lib/resources/users';
 
 import { KeycloakProviderConfig } from './config';
 import {

--- a/plugins/keycloak-backend/src/lib/transformers.ts
+++ b/plugins/keycloak-backend/src/lib/transformers.ts
@@ -1,4 +1,4 @@
-import { GroupTransformer, UserTransformer } from './types';
+import type { GroupTransformer, UserTransformer } from './types';
 
 export const noopGroupTransformer: GroupTransformer = async (
   entity,

--- a/plugins/keycloak-backend/src/lib/types.ts
+++ b/plugins/keycloak-backend/src/lib/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { GroupEntity, UserEntity } from '@backstage/catalog-model';
+import type { GroupEntity, UserEntity } from '@backstage/catalog-model';
 
 import GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation';
 import UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation';

--- a/plugins/keycloak-backend/src/lib/types.ts
+++ b/plugins/keycloak-backend/src/lib/types.ts
@@ -16,8 +16,8 @@
 
 import type { GroupEntity, UserEntity } from '@backstage/catalog-model';
 
-import GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation';
-import UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation';
+import type GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation';
+import type UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation';
 
 export interface GroupRepresentationWithParent extends GroupRepresentation {
   parentId?: string;

--- a/plugins/keycloak-backend/src/module/catalogModuleKeycloakEntityProvider.test.ts
+++ b/plugins/keycloak-backend/src/module/catalogModuleKeycloakEntityProvider.test.ts
@@ -17,7 +17,7 @@
 import type { SchedulerServiceTaskScheduleDefinition } from '@backstage/backend-plugin-api';
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import catalogPlugin from '@backstage/plugin-catalog-backend/alpha';
-import { EntityProvider } from '@backstage/plugin-catalog-node';
+import type { EntityProvider } from '@backstage/plugin-catalog-node';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 
 import { CONFIG } from '../../__fixtures__/helpers';

--- a/plugins/keycloak-backend/src/module/catalogModuleKeycloakEntityProvider.ts
+++ b/plugins/keycloak-backend/src/module/catalogModuleKeycloakEntityProvider.ts
@@ -22,7 +22,7 @@ import { InputError } from '@backstage/errors';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 
 import { keycloakTransformerExtensionPoint } from '../extensions';
-import { GroupTransformer, UserTransformer } from '../lib/types';
+import type { GroupTransformer, UserTransformer } from '../lib/types';
 import { KeycloakOrgEntityProvider } from '../providers';
 
 /**

--- a/plugins/keycloak-backend/src/providers/KeycloakOrgEntityProvider.test.ts
+++ b/plugins/keycloak-backend/src/providers/KeycloakOrgEntityProvider.test.ts
@@ -6,7 +6,7 @@ import type {
 } from '@backstage/backend-plugin-api';
 import { mockServices, ServiceMock } from '@backstage/backend-test-utils';
 import { ErrorLike } from '@backstage/errors';
-import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
+import type { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import type { JsonObject } from '@backstage/types';
 
 // @ts-ignore

--- a/plugins/keycloak-backend/src/providers/KeycloakOrgEntityProvider.ts
+++ b/plugins/keycloak-backend/src/providers/KeycloakOrgEntityProvider.ts
@@ -21,7 +21,7 @@ import type {
 import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
-  Entity,
+  type Entity,
 } from '@backstage/catalog-model';
 import type { Config } from '@backstage/config';
 import { InputError, isError, NotFoundError } from '@backstage/errors';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,21 +2397,21 @@
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.9.1"
 
-"@backstage/backend-app-api@0.8.0", "@backstage/backend-app-api@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@backstage/backend-app-api/-/backend-app-api-0.8.0.tgz#f90b101afb64daedb7e253ec1557eb42c7e00dd7"
-  integrity sha512-cxX8swAibofTPajFBsOmCo5Q7XowlOWiUA0zQR45fk+egXFzwpfW0Zj1UYhe2h410G5sLKEMtAvUHvyzczO7iw==
+"@backstage/backend-app-api@^0.7.9":
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-app-api/-/backend-app-api-0.7.9.tgz#33ea02fd7c10e8a0835b969bd8a3e2b47e7d8766"
+  integrity sha512-EFmvyJMbtvVFxvtpleDqiFS8si8yBQnhz4KaJ0GGhNSFb3C4yummcEbCGbx0xkK0ktxyIKKOSDP8T4acrvraZw==
   dependencies:
-    "@backstage/backend-common" "^0.23.3"
-    "@backstage/backend-plugin-api" "^0.7.0"
-    "@backstage/backend-tasks" "^0.5.27"
+    "@backstage/backend-common" "^0.23.2"
+    "@backstage/backend-plugin-api" "^0.6.21"
+    "@backstage/backend-tasks" "^0.5.26"
     "@backstage/cli-common" "^0.1.14"
-    "@backstage/cli-node" "^0.2.7"
+    "@backstage/cli-node" "^0.2.6"
     "@backstage/config" "^1.2.0"
     "@backstage/config-loader" "^1.8.1"
     "@backstage/errors" "^1.2.4"
-    "@backstage/plugin-auth-node" "^0.4.17"
-    "@backstage/plugin-permission-node" "^0.8.0"
+    "@backstage/plugin-auth-node" "^0.4.16"
+    "@backstage/plugin-permission-node" "^0.7.32"
     "@backstage/types" "^1.1.1"
     "@manypkg/get-packages" "^1.1.3"
     "@types/cors" "^2.8.6"
@@ -2441,21 +2441,21 @@
     winston "^3.2.1"
     winston-transport "^4.5.0"
 
-"@backstage/backend-app-api@^0.7.9":
-  version "0.7.9"
-  resolved "https://registry.yarnpkg.com/@backstage/backend-app-api/-/backend-app-api-0.7.9.tgz#33ea02fd7c10e8a0835b969bd8a3e2b47e7d8766"
-  integrity sha512-EFmvyJMbtvVFxvtpleDqiFS8si8yBQnhz4KaJ0GGhNSFb3C4yummcEbCGbx0xkK0ktxyIKKOSDP8T4acrvraZw==
+"@backstage/backend-app-api@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-app-api/-/backend-app-api-0.8.0.tgz#f90b101afb64daedb7e253ec1557eb42c7e00dd7"
+  integrity sha512-cxX8swAibofTPajFBsOmCo5Q7XowlOWiUA0zQR45fk+egXFzwpfW0Zj1UYhe2h410G5sLKEMtAvUHvyzczO7iw==
   dependencies:
-    "@backstage/backend-common" "^0.23.2"
-    "@backstage/backend-plugin-api" "^0.6.21"
-    "@backstage/backend-tasks" "^0.5.26"
+    "@backstage/backend-common" "^0.23.3"
+    "@backstage/backend-plugin-api" "^0.7.0"
+    "@backstage/backend-tasks" "^0.5.27"
     "@backstage/cli-common" "^0.1.14"
-    "@backstage/cli-node" "^0.2.6"
+    "@backstage/cli-node" "^0.2.7"
     "@backstage/config" "^1.2.0"
     "@backstage/config-loader" "^1.8.1"
     "@backstage/errors" "^1.2.4"
-    "@backstage/plugin-auth-node" "^0.4.16"
-    "@backstage/plugin-permission-node" "^0.7.32"
+    "@backstage/plugin-auth-node" "^0.4.17"
+    "@backstage/plugin-permission-node" "^0.8.0"
     "@backstage/types" "^1.1.1"
     "@manypkg/get-packages" "^1.1.3"
     "@types/cors" "^2.8.6"
@@ -3674,7 +3674,7 @@
     winston "^3.2.1"
     yn "^4.0.0"
 
-"@backstage/plugin-auth-node@0.4.17", "@backstage/plugin-auth-node@^0.4.16", "@backstage/plugin-auth-node@^0.4.17":
+"@backstage/plugin-auth-node@^0.4.16", "@backstage/plugin-auth-node@^0.4.17":
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-node/-/plugin-auth-node-0.4.17.tgz#1e890a31ba0795b0c51720282fc72c31c5b7cc2a"
   integrity sha512-nNZPWPRMCfU0LoxV15bfClPUfZ8XbnKDC4VTMRGyXo37FdRI9uNvrSrZm++e0QKCR/xGfab377SByp/9jITKmQ==
@@ -4161,10 +4161,10 @@
     yn "^4.0.0"
     zod "^3.22.4"
 
-"@backstage/plugin-permission-common@0.8.0", "@backstage/plugin-permission-common@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.8.0.tgz#13d29c146c50e9de1da47296c167ace9d1bc86f3"
-  integrity sha512-4c8QfjDKiTJbQfiG3DibUqUsclsi53kRk8GR9CwHl1Is2Xm98AkqXGWyknHGPQOvw4vJR19nqnj7w0XfhLK2Jw==
+"@backstage/plugin-permission-common@^0.7.14":
+  version "0.7.14"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.7.14.tgz#ecb12877c412ff271124af54fca46ec06d9c812f"
+  integrity sha512-fHbxhX9ZoT8bTVuGycfTeU/6TE2yjZ6YNvm/2ko1bcxGnvYe1p5Ug5JW+iWjDZS+F6F152tWzhRcg05wQlPNKQ==
   dependencies:
     "@backstage/config" "^1.2.0"
     "@backstage/errors" "^1.2.4"
@@ -4173,10 +4173,10 @@
     uuid "^9.0.0"
     zod "^3.22.4"
 
-"@backstage/plugin-permission-common@^0.7.14":
-  version "0.7.14"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.7.14.tgz#ecb12877c412ff271124af54fca46ec06d9c812f"
-  integrity sha512-fHbxhX9ZoT8bTVuGycfTeU/6TE2yjZ6YNvm/2ko1bcxGnvYe1p5Ug5JW+iWjDZS+F6F152tWzhRcg05wQlPNKQ==
+"@backstage/plugin-permission-common@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.8.0.tgz#13d29c146c50e9de1da47296c167ace9d1bc86f3"
+  integrity sha512-4c8QfjDKiTJbQfiG3DibUqUsclsi53kRk8GR9CwHl1Is2Xm98AkqXGWyknHGPQOvw4vJR19nqnj7w0XfhLK2Jw==
   dependencies:
     "@backstage/config" "^1.2.0"
     "@backstage/errors" "^1.2.4"
@@ -4198,23 +4198,6 @@
     zod "^3.22.4"
     zod-to-json-schema "^3.20.4"
 
-"@backstage/plugin-permission-node@0.8.0", "@backstage/plugin-permission-node@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-node/-/plugin-permission-node-0.8.0.tgz#726a7d5b60eb2212fb4e9b16bf890d7b0dcbe6bf"
-  integrity sha512-UFIPf97uAoVZk/1UagkDKUeNHWifkqVrkUjOT36uHWxRDqucRPrCNcgvpNrv/HdI1xbCmjSeXkyQt4OJDzWicg==
-  dependencies:
-    "@backstage/backend-common" "^0.23.3"
-    "@backstage/backend-plugin-api" "^0.7.0"
-    "@backstage/config" "^1.2.0"
-    "@backstage/errors" "^1.2.4"
-    "@backstage/plugin-auth-node" "^0.4.17"
-    "@backstage/plugin-permission-common" "^0.8.0"
-    "@types/express" "^4.17.6"
-    express "^4.17.1"
-    express-promise-router "^4.1.0"
-    zod "^3.22.4"
-    zod-to-json-schema "^3.20.4"
-
 "@backstage/plugin-permission-node@^0.7.32":
   version "0.7.32"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-node/-/plugin-permission-node-0.7.32.tgz#e462a4c8d6d8021ae5d8ff64bec84e176641fd77"
@@ -4226,6 +4209,23 @@
     "@backstage/errors" "^1.2.4"
     "@backstage/plugin-auth-node" "^0.4.16"
     "@backstage/plugin-permission-common" "^0.7.14"
+    "@types/express" "^4.17.6"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.20.4"
+
+"@backstage/plugin-permission-node@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-node/-/plugin-permission-node-0.8.0.tgz#726a7d5b60eb2212fb4e9b16bf890d7b0dcbe6bf"
+  integrity sha512-UFIPf97uAoVZk/1UagkDKUeNHWifkqVrkUjOT36uHWxRDqucRPrCNcgvpNrv/HdI1xbCmjSeXkyQt4OJDzWicg==
+  dependencies:
+    "@backstage/backend-common" "^0.23.3"
+    "@backstage/backend-plugin-api" "^0.7.0"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/plugin-auth-node" "^0.4.17"
+    "@backstage/plugin-permission-common" "^0.8.0"
     "@types/express" "^4.17.6"
     express "^4.17.1"
     express-promise-router "^4.1.0"
@@ -20280,43 +20280,6 @@ express-session@^1.17.1:
     safe-buffer "5.2.1"
     uid-safe "~2.1.5"
 
-express@4.20.0:
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.20.0.tgz#f1d08e591fcec770c07be4767af8eb9bcfd67c48"
-  integrity sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==
-  dependencies:
-    accepts "~1.3.8"
-    array-flatten "1.1.1"
-    body-parser "1.20.3"
-    content-disposition "0.5.4"
-    content-type "~1.0.4"
-    cookie "0.6.0"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "2.0.0"
-    encodeurl "~2.0.0"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "1.2.0"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    merge-descriptors "1.0.3"
-    methods "~1.1.2"
-    on-finished "2.4.1"
-    parseurl "~1.3.3"
-    path-to-regexp "0.1.10"
-    proxy-addr "~2.0.7"
-    qs "6.11.0"
-    range-parser "~1.2.1"
-    safe-buffer "5.2.1"
-    send "0.19.0"
-    serve-static "1.16.0"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    type-is "~1.6.18"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
-
 express@^4.17.1, express@^4.17.3, express@^4.18.2, express@^4.19.2:
   version "4.21.0"
   resolved "https://registry.yarnpkg.com/express/-/express-4.21.0.tgz#d57cb706d49623d4ac27833f1cbc466b668eb915"
@@ -20696,19 +20659,6 @@ filter-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
   integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
-
-finalhandler@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
-  integrity sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==
-  dependencies:
-    debug "2.6.9"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    on-finished "2.4.1"
-    parseurl "~1.3.3"
-    statuses "2.0.1"
-    unpipe "~1.0.0"
 
 finalhandler@1.3.1:
   version "1.3.1"
@@ -25159,7 +25109,7 @@ lunr@^2.3.9:
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
-luxon@3.4.4, luxon@^3.0.0, luxon@^3.2.1, luxon@^3.4.3, luxon@^3.4.4, luxon@~3.4.0:
+luxon@^3.0.0, luxon@^3.2.1, luxon@^3.4.3, luxon@^3.4.4, luxon@~3.4.0:
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.4.tgz#cf20dc27dc532ba41a169c43fdcc0063601577af"
   integrity sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==
@@ -27846,7 +27796,7 @@ openapi3-ts@^3.1.2:
   dependencies:
     yaml "^2.2.1"
 
-opener@1.5.2, opener@^1.5.2:
+opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
@@ -29479,13 +29429,6 @@ qrcode-terminal@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz#bb5b699ef7f9f0505092a3748be4464fe71b5819"
   integrity sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==
-
-qs@6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
-  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
-  dependencies:
-    side-channel "^1.0.4"
 
 qs@6.13.0, qs@^6.11.0, qs@^6.12.3:
   version "6.13.0"
@@ -31285,25 +31228,6 @@ semver@^7.3.8, semver@^7.6.0, semver@^7.6.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
-send@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
-  integrity sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==
-  dependencies:
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "1.2.0"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    mime "1.6.0"
-    ms "2.1.3"
-    on-finished "2.4.1"
-    range-parser "~1.2.1"
-    statuses "2.0.1"
-
 send@0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.19.0.tgz#bbc5a388c8ea6c048967049dbeac0e4a3f09d7f8"
@@ -31361,16 +31285,6 @@ serve-index@^1.9.1:
     http-errors "~1.6.2"
     mime-types "~2.1.17"
     parseurl "~1.3.2"
-
-serve-static@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.0.tgz#2bf4ed49f8af311b519c46f272bf6ac3baf38a92"
-  integrity sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==
-  dependencies:
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    parseurl "~1.3.3"
-    send "0.18.0"
 
 serve-static@1.16.2:
   version "1.16.2"


### PR DESCRIPTION
## General

- Delete unused dev dependencies
- Use `mockServices rootConfig` instead of `ConfigReader` in tests

## Related to

[RHIDP-4056](https://issues.redhat.com/browse/RHIDP-4056)