### PR TITLE
chore: bump version of...

### DIFF
--- a/plugins/orchestrator-form-react/package.json
+++ b/plugins/orchestrator-form-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-orchestrator-form-react",
   "description": "Web library for the orchestrator-form plugin",
-  "version": "1.0.5",
+  "version": "1.0.15",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/orchestrator/package.json
+++ b/plugins/orchestrator/package.json
@@ -60,7 +60,7 @@
     "@backstage/types": "^1.1.1",
     "@janus-idp/backstage-plugin-orchestrator-common": "1.15.1",
     "@janus-idp/backstage-plugin-orchestrator-form-api": "1.0.1",
-    "@janus-idp/backstage-plugin-orchestrator-form-react": "1.0.4",
+    "@janus-idp/backstage-plugin-orchestrator-form-react": "1.0.15",
     "@kie-tools-core/editor": "^0.32.0",
     "@kie-tools-core/notifications": "^0.32.0",
     "@kie-tools-core/react-hooks": "^0.32.0",


### PR DESCRIPTION
### What does this PR do?

chore: bump version of orchestrator-form-react to 1.0.15 - a version greater than an existing released one (1.0.5 - 1.0.10) and which won't collide with main branch (1.1.5)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.