### PR TITLE
chore(release): 1.2.x : Sync kubernetes-action, feedback-backend, kiali-backend, orchestrator-backend  plugins

### DIFF
--- a/plugins/feedback-backend/CHANGELOG.md
+++ b/plugins/feedback-backend/CHANGELOG.md
@@ -1,3 +1,11 @@
+## @janus-idp/backstage-plugin-feedback-backend [1.3.8](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.3.7...@janus-idp/backstage-plugin-feedback-backend@1.3.8) (2024-06-05)
+
+
+
+### Dependencies
+
+* **@janus-idp/cli:** upgraded to 1.10.0
+
 ## @janus-idp/backstage-plugin-feedback-backend [1.3.7](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.3.6...@janus-idp/backstage-plugin-feedback-backend@1.3.7) (2024-06-04)
 
 ## @janus-idp/backstage-plugin-feedback-backend [1.3.6](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.3.5...@janus-idp/backstage-plugin-feedback-backend@1.3.6) (2024-06-04)

--- a/plugins/feedback-backend/CHANGELOG.md
+++ b/plugins/feedback-backend/CHANGELOG.md
@@ -1,3 +1,5 @@
+## @janus-idp/backstage-plugin-feedback-backend [1.3.7](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.3.6...@janus-idp/backstage-plugin-feedback-backend@1.3.7) (2024-06-04)
+
 ## @janus-idp/backstage-plugin-feedback-backend [1.3.6](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.3.5...@janus-idp/backstage-plugin-feedback-backend@1.3.6) (2024-06-04)
 
 ## @janus-idp/backstage-plugin-feedback-backend [1.3.5](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.3.4...@janus-idp/backstage-plugin-feedback-backend@1.3.5) (2024-06-03)

--- a/plugins/feedback-backend/CHANGELOG.md
+++ b/plugins/feedback-backend/CHANGELOG.md
@@ -1,3 +1,5 @@
+## @janus-idp/backstage-plugin-feedback-backend [1.3.6](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.3.5...@janus-idp/backstage-plugin-feedback-backend@1.3.6) (2024-06-04)
+
 ## @janus-idp/backstage-plugin-feedback-backend [1.3.5](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.3.4...@janus-idp/backstage-plugin-feedback-backend@1.3.5) (2024-06-03)
 
 

--- a/plugins/feedback-backend/dist-dynamic/package.json
+++ b/plugins/feedback-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-feedback-backend-dynamic",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/plugins/feedback-backend/dist-dynamic/package.json
+++ b/plugins/feedback-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-feedback-backend-dynamic",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -10,7 +10,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "supported-versions": "1.26.5"
   },
   "exports": {
     ".": {
@@ -45,13 +46,24 @@
     "alpha"
   ],
   "configSchema": "config.d.ts",
-  "repository": "github:janus-idp/backstage-plugins",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/janus-idp/backstage-plugins",
+    "directory": "plugins/feedback-backend"
+  },
   "keywords": [
+    "support:tech-preview",
+    "lifecycle:active",
     "backstage",
     "plugin"
   ],
-  "homepage": "https://janus-idp.io/",
+  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
+  "maintainers": [
+    "@janus-idp/maintainers-plugins",
+    "@janus-idp/devex-uxe"
+  ],
+  "author": "The Backstage Community",
   "bundleDependencies": true,
   "peerDependencies": {
     "@backstage/backend-common": "^0.21.7",

--- a/plugins/feedback-backend/dist-dynamic/package.json
+++ b/plugins/feedback-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-feedback-backend-dynamic",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/plugins/feedback-backend/package.json
+++ b/plugins/feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-feedback-backend",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/feedback-backend/package.json
+++ b/plugins/feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-feedback-backend",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/feedback-backend/package.json
+++ b/plugins/feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-feedback-backend",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -60,8 +60,8 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.4",
-    "@janus-idp/cli": "1.9.0",
-    "@types/nodemailer": "6.4.14",
+    "@janus-idp/cli": "1.10.0",
+    "@types/nodemailer": "6.4.15",
     "@types/supertest": "2.0.12",
     "msw": "1.3.2",
     "supertest": "6.2.4"

--- a/plugins/kiali-backend/CHANGELOG.md
+++ b/plugins/kiali-backend/CHANGELOG.md
@@ -1,3 +1,11 @@
+## @janus-idp/backstage-plugin-kiali-backend [1.10.21](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-kiali-backend@1.10.20...@janus-idp/backstage-plugin-kiali-backend@1.10.21) (2024-06-05)
+
+
+
+### Dependencies
+
+* **@janus-idp/cli:** upgraded to 1.10.0
+
 ## @janus-idp/backstage-plugin-kiali-backend [1.10.20](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-kiali-backend@1.10.19...@janus-idp/backstage-plugin-kiali-backend@1.10.20) (2024-06-04)
 
 ## @janus-idp/backstage-plugin-kiali-backend [1.10.19](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-kiali-backend@1.10.18...@janus-idp/backstage-plugin-kiali-backend@1.10.19) (2024-06-03)

--- a/plugins/kiali-backend/CHANGELOG.md
+++ b/plugins/kiali-backend/CHANGELOG.md
@@ -1,3 +1,5 @@
+## @janus-idp/backstage-plugin-kiali-backend [1.10.20](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-kiali-backend@1.10.19...@janus-idp/backstage-plugin-kiali-backend@1.10.20) (2024-06-04)
+
 ## @janus-idp/backstage-plugin-kiali-backend [1.10.19](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-kiali-backend@1.10.18...@janus-idp/backstage-plugin-kiali-backend@1.10.19) (2024-06-03)
 
 

--- a/plugins/kiali-backend/dist-dynamic/package.json
+++ b/plugins/kiali-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-kiali-backend-dynamic",
-  "version": "1.10.19",
+  "version": "1.10.20",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/plugins/kiali-backend/dist-dynamic/package.json
+++ b/plugins/kiali-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-kiali-backend-dynamic",
-  "version": "1.10.18",
+  "version": "1.10.19",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -10,7 +10,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "supported-versions": "1.26.5"
   },
   "exports": {
     ".": {
@@ -39,6 +40,22 @@
     "config.d.ts",
     "app-config.janus-idp.yaml",
     "alpha"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/janus-idp/backstage-plugins",
+    "directory": "plugins/kiali-backend"
+  },
+  "maintainers": [
+    "@janus-idp/maintainers-plugins",
+    "@janus-idp/kiali"
+  ],
+  "author": "The Backstage Community",
+  "homepage": "https://red.ht/rhdh",
+  "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
+  "keywords": [
+    "support:tech-preview",
+    "lifecycle:active"
   ],
   "bundleDependencies": true,
   "peerDependencies": {

--- a/plugins/kiali-backend/package.json
+++ b/plugins/kiali-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-kiali-backend",
-  "version": "1.10.20",
+  "version": "1.10.21",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -59,8 +59,8 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.26.4",
-    "@janus-idp/cli": "1.9.0",
-    "@types/express": "4.17.20",
+    "@janus-idp/cli": "1.10.0",
+    "@types/express": "4.17.21",
     "@types/supertest": "2.0.16",
     "msw": "1.3.2",
     "supertest": "6.3.4"

--- a/plugins/kiali-backend/package.json
+++ b/plugins/kiali-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-kiali-backend",
-  "version": "1.10.19",
+  "version": "1.10.20",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kubernetes-actions/CHANGELOG.md
+++ b/plugins/kubernetes-actions/CHANGELOG.md
@@ -1,3 +1,5 @@
+## @janus-idp/backstage-scaffolder-backend-module-kubernetes [1.4.12](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.4.11...@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.4.12) (2024-06-04)
+
 ## @janus-idp/backstage-scaffolder-backend-module-kubernetes [1.4.11](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.4.10...@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.4.11) (2024-06-03)
 
 

--- a/plugins/kubernetes-actions/CHANGELOG.md
+++ b/plugins/kubernetes-actions/CHANGELOG.md
@@ -1,3 +1,11 @@
+## @janus-idp/backstage-scaffolder-backend-module-kubernetes [1.4.13](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.4.12...@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.4.13) (2024-06-05)
+
+
+
+### Dependencies
+
+* **@janus-idp/cli:** upgraded to 1.10.0
+
 ## @janus-idp/backstage-scaffolder-backend-module-kubernetes [1.4.12](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.4.11...@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.4.12) (2024-06-04)
 
 ## @janus-idp/backstage-scaffolder-backend-module-kubernetes [1.4.11](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.4.10...@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.4.11) (2024-06-03)

--- a/plugins/kubernetes-actions/dist-dynamic/package.json
+++ b/plugins/kubernetes-actions/dist-dynamic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-scaffolder-backend-module-kubernetes-dynamic",
   "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -11,7 +11,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin-module"
+    "role": "backend-plugin-module",
+    "supported-versions": "1.26.5"
   },
   "exports": {
     ".": {
@@ -33,13 +34,23 @@
     "dist",
     "alpha"
   ],
-  "repository": "github:janus-idp/backstage-plugins",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/janus-idp/backstage-plugins",
+    "directory": "plugins/kubernetes-actions"
+  },
   "keywords": [
+    "support:tech-preview",
+    "lifecycle:active",
     "backstage",
     "backend-plugin-module"
   ],
-  "homepage": "https://janus-idp.io/",
+  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
+  "maintainers": [
+    "@janus-idp/maintainers-plugins"
+  ],
+  "author": "The Backstage Community",
   "bundleDependencies": true,
   "peerDependencies": {
     "@backstage/backend-dynamic-feature-service": "^0.2.9",

--- a/plugins/kubernetes-actions/dist-dynamic/package.json
+++ b/plugins/kubernetes-actions/dist-dynamic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-scaffolder-backend-module-kubernetes-dynamic",
   "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/plugins/kubernetes-actions/package.json
+++ b/plugins/kubernetes-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-scaffolder-backend-module-kubernetes",
   "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kubernetes-actions/package.json
+++ b/plugins/kubernetes-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janus-idp/backstage-scaffolder-backend-module-kubernetes",
   "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -52,7 +52,7 @@
     "@backstage/backend-common": "0.21.7",
     "@backstage/cli": "0.26.4",
     "@backstage/plugin-scaffolder-node-test-utils": "0.1.3",
-    "@janus-idp/cli": "1.9.0",
+    "@janus-idp/cli": "1.10.0",
     "msw": "1.3.3"
   },
   "files": [

--- a/plugins/orchestrator-backend/CHANGELOG.md
+++ b/plugins/orchestrator-backend/CHANGELOG.md
@@ -1,3 +1,11 @@
+## @janus-idp/backstage-plugin-orchestrator-backend [1.9.6](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-orchestrator-backend@1.9.5...@janus-idp/backstage-plugin-orchestrator-backend@1.9.6) (2024-06-05)
+
+
+
+### Dependencies
+
+* **@janus-idp/cli:** upgraded to 1.10.0
+
 ## @janus-idp/backstage-plugin-orchestrator-backend [1.9.5](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-orchestrator-backend@1.9.4...@janus-idp/backstage-plugin-orchestrator-backend@1.9.5) (2024-06-04)
 
 

--- a/plugins/orchestrator-backend/CHANGELOG.md
+++ b/plugins/orchestrator-backend/CHANGELOG.md
@@ -1,3 +1,11 @@
+## @janus-idp/backstage-plugin-orchestrator-backend [1.9.5](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-orchestrator-backend@1.9.4...@janus-idp/backstage-plugin-orchestrator-backend@1.9.5) (2024-06-04)
+
+
+
+### Dependencies
+
+* **@janus-idp/backstage-plugin-orchestrator-common:** upgraded to 1.8.1
+
 ## @janus-idp/backstage-plugin-orchestrator-backend [1.9.4](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-orchestrator-backend@1.9.3...@janus-idp/backstage-plugin-orchestrator-backend@1.9.4) (2024-06-03)
 
 

--- a/plugins/orchestrator-backend/dist-dynamic/package.json
+++ b/plugins/orchestrator-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-orchestrator-backend-dynamic",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",

--- a/plugins/orchestrator-backend/dist-dynamic/package.json
+++ b/plugins/orchestrator-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-orchestrator-backend-dynamic",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
@@ -10,7 +10,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "supported-versions": "1.26.5"
   },
   "exports": {
     ".": {
@@ -23,10 +24,16 @@
     },
     "./package.json": "./package.json"
   },
-  "homepage": "https://janus-idp.io/",
-  "repository": "github:janus-idp/backstage-plugins",
+  "homepage": "https://red.ht/rhdh",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/janus-idp/backstage-plugins",
+    "directory": "plugins/orchestrator-backend"
+  },
   "bugs": "https://github.com/janus-idp/backstage-plugins/issues",
   "keywords": [
+    "support:tech-preview",
+    "lifecycle:active",
     "backstage",
     "plugin",
     "orchestrator",
@@ -55,6 +62,11 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {},
+  "maintainers": [
+    "@janus-idp/maintainers-plugins",
+    "@janus-idp/orchestrator-codeowners"
+  ],
+  "author": "The Backstage Community",
   "bundleDependencies": true,
   "peerDependencies": {
     "@backstage/backend-app-api": "^0.7.2",

--- a/plugins/orchestrator-backend/package.json
+++ b/plugins/orchestrator-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-orchestrator-backend",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -83,7 +83,7 @@
     "@backstage/plugin-permission-node": "^0.7.27",
     "@backstage/plugin-auth-node": "^0.4.11",
     "@backstage/types": "^1.1.1",
-    "@janus-idp/backstage-plugin-orchestrator-common": "1.8.0",
+    "@janus-idp/backstage-plugin-orchestrator-common": "1.8.1",
     "@urql/core": "^4.1.4",
     "ajv-formats": "^2.1.1",
     "cloudevents": "^8.0.0",

--- a/plugins/orchestrator-backend/package.json
+++ b/plugins/orchestrator-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-orchestrator-backend",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -99,7 +99,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "0.3.7",
     "@backstage/cli": "0.26.4",
-    "@janus-idp/cli": "1.9.0",
+    "@janus-idp/cli": "1.10.0",
     "@types/express": "4.17.21",
     "@types/fs-extra": "11.0.4",
     "@types/json-schema": "7.0.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6243,6 +6243,90 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
+"@janus-idp/backstage-plugin-ocm-common@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@janus-idp/backstage-plugin-ocm-common/-/backstage-plugin-ocm-common-3.0.2.tgz#5236c866ff7ecffbc7ddb2ab4bd8a3f9de180b5e"
+  integrity sha512-h48XQuxIjkWFtwObkw9SK9M6vuOdssEFeM7vk150f8rIsYYl/QR2y27DcixsokvoWa5WzJl/Dli60eGmiVaO/w==
+  dependencies:
+    "@backstage/plugin-permission-common" "^0.7.13"
+
+"@janus-idp/backstage-plugin-orchestrator-common@1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@janus-idp/backstage-plugin-orchestrator-common/-/backstage-plugin-orchestrator-common-1.8.1.tgz#ac110baff2333e9bf29e5f3f5ba9472c1b300077"
+  integrity sha512-Y7+kgu7oJAuiOsAQymMtF234lS3VwWLaKPVnsXNzdefBSqF/t/ZZgcIFBCOdX8Kf6vNdBNUFKAfGLp/DnxyeUA==
+  dependencies:
+    "@backstage/plugin-permission-common" "^0.7.13"
+    "@backstage/types" "^1.1.1"
+    "@severlessworkflow/sdk-typescript" "^3.0.3"
+    js-yaml "^4.1.0"
+    json-schema "^0.4.0"
+
+"@janus-idp/cli@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@janus-idp/cli/-/cli-1.10.0.tgz#6126ab70af184c8fbc34785e3bb28f48e807fc8c"
+  integrity sha512-a/N1Fp5iTFNkPBhY8BBdJliNDwRITCIsLEJevIIWs3dz85thh19lBfUKMeElK+qXvInGpo9Qr9yxT0I5ndyWnw==
+  dependencies:
+    "@backstage/cli-common" "^0.1.13"
+    "@backstage/cli-node" "^0.2.5"
+    "@backstage/config" "^1.2.0"
+    "@backstage/config-loader" "^1.8.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/eslint-plugin" "^0.1.7"
+    "@backstage/types" "^1.1.1"
+    "@manypkg/get-packages" "^1.1.3"
+    "@openshift/dynamic-plugin-sdk-webpack" "^3.0.0"
+    "@pmmmwh/react-refresh-webpack-plugin" "^0.5.7"
+    "@rollup/plugin-commonjs" "^25.0.4"
+    "@rollup/plugin-json" "^6.0.0"
+    "@rollup/plugin-node-resolve" "^15.2.1"
+    "@rollup/plugin-yaml" "^4.0.0"
+    "@svgr/rollup" "^8.1.0"
+    "@svgr/webpack" "^6.5.1"
+    "@yarnpkg/lockfile" "^1.1.0"
+    "@yarnpkg/parsers" "^3.0.0-rc.4"
+    bfj "^8.0.0"
+    chalk "^4.0.0"
+    chokidar "^3.3.1"
+    codeowners "^5.1.1"
+    commander "^9.1.0"
+    css-loader "^6.5.1"
+    esbuild "^0.21.0"
+    esbuild-loader "^2.18.0"
+    eslint "^8.49.0"
+    eslint-config-prettier "^8.10.0"
+    eslint-webpack-plugin "^3.2.0"
+    express "^4.18.2"
+    fork-ts-checker-webpack-plugin "^7.0.0-alpha.8"
+    fs-extra "^10.1.0"
+    gitconfiglocal "2.1.0"
+    handlebars "^4.7.7"
+    html-webpack-plugin "^5.3.1"
+    inquirer "^8.2.0"
+    is-native-module "^1.1.3"
+    lodash "^4.17.21"
+    mini-css-extract-plugin "^2.4.2"
+    node-libs-browser "^2.2.1"
+    npm-packlist "^5.0.0"
+    ora "^5.3.0"
+    postcss "^8.2.13"
+    process "^0.11.10"
+    react-dev-utils "^12.0.0-next.60"
+    react-refresh "^0.14.0"
+    recursive-readdir "^2.2.2"
+    rollup "^2.78.0"
+    rollup-plugin-dts "^4.0.1"
+    rollup-plugin-esbuild "^4.7.2"
+    rollup-plugin-postcss "^4.0.0"
+    rollup-pluginutils "^2.8.2"
+    semver "^7.5.4"
+    style-loader "^3.3.1"
+    swc-loader "^0.2.3"
+    typescript-json-schema "^0.63.0"
+    webpack "^5.89.0"
+    webpack-dev-server "^4.15.1"
+    yml-loader "^2.1.0"
+    yn "^4.0.0"
+
 "@janus-idp/cli@1.8.7":
   version "1.8.7"
   resolved "https://registry.npmjs.org/@janus-idp/cli/-/cli-1.8.7.tgz#ded3ed8240730f6970087a9be4a6e67fb5e69a10"
@@ -14342,10 +14426,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.97.tgz#d7926a8030f0d714d555b4550c0cc7731495cfe5"
   integrity sha512-4muilE1Lbfn57unR+/nT9AFjWk0MtWi5muwCEJqnOvfRQDbSfLCUdN7vCIg8TYuaANfhLOV85ve+FNpiUsbSRg==
 
-"@types/nodemailer@6.4.14":
-  version "6.4.14"
-  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.14.tgz#5c81a5e856db7f8ede80013e6dbad7c5fb2283e2"
-  integrity sha512-fUWthHO9k9DSdPCSPRqcu6TWhYyxTBg382vlNIttSe9M7XfsT06y0f24KHXtbnijPGGRIcVvdKHTNikOI6qiHA==
+"@types/nodemailer@6.4.15":
+  version "6.4.15"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.15.tgz#494be695e11c438f7f5df738fb4ab740312a6ed2"
+  integrity sha512-0EBJxawVNjPkng1zm2vopRctuWVCxk34JcIlRuXSf54habUWdz1FB7wHDqOqvDa8Mtpt0Q3LTXQkAs2LNyK5jQ==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
These plugins need to be updated to the version that's aligned with 1.2.x

Need to make updates to Express (see 1.3 [PR](https://github.com/janus-idp/backstage-plugins/pull/2162/files#diff-b810b15125af407f9308629f2aaf637ba8a2715fcf0629784d237823254825f1))  which affects this list of plugins

June 5, janus-cli update to 1.10 seems to be the cut-off date