### PR TITLE
chore: add deprecate note to nexus-repository-manager plugin

### DIFF
--- a/plugins/nexus-repository-manager/README.md
+++ b/plugins/nexus-repository-manager/README.md
@@ -1,3 +1,9 @@
+# ❗DEPRECATED❗
+
+This package has been deprecated.
+
+Please use the **[@backstage-community/plugin-nexus-repository-manager](https://www.npmjs.com/package/@backstage-community/plugin-nexus-repository-manager)** package instead.
+
 # Nexus Repository Manager plugin for Backstage
 
 The Nexus Repository Manager plugin displays the information about your build artifacts that are available in the Nexus Repository Manager in your Backstage application.

--- a/plugins/nexus-repository-manager/package.json
+++ b/plugins/nexus-repository-manager/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@janus-idp/backstage-plugin-nexus-repository-manager",
   "version": "1.10.2",
+  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Jira Issue: [RHIDP-3803](https://issues.redhat.com/browse/RHIDP-3803)

The `nexus-repository-manager` plugin has been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins/tree/main/workspaces/nexus-repository-manager/plugins) repository in support of our [sunsetting](https://issues.redhat.com/browse/RHIDP-3227) efforts.

This PR adds note about this plugin being deprecated and also setting the plugin to private in `package.json` to prevent publishing of deprecated plugin.