### PR TITLE
chore: drop support for node18 as of 1.4 (RHIDP-3372)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20]
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20"
   },
   "scripts": {
     "preinstall": "npx only-allow yarn",


### PR DESCRIPTION
### What does this PR do?

chore: drop support for node18 as of 1.4 ([RHIDP-3372](https://issues.redhat.com//browse/RHIDP-3372))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.