### PR TITLE
chore: drop support for node18 as of 1.4 (RHIDP-3372)

### DIFF
--- a/.github/workflows/pr-playwright.yaml
+++ b/.github/workflows/pr-playwright.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Determine changes
         id: scan
         env:
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install dependencies
         run: yarn
       - name: Install playwright


### PR DESCRIPTION
This is a follow-up on #2316: update Node.js to 20.x for the playwright GitHub workflow as well

/cc @nickboldt @albarbaro @nilgaar 