### PR TITLE
feat(orchestrator): add filter by IDArgument

### DIFF
--- a/plugins/orchestrator-backend/src/helpers/queryBuilder.ts
+++ b/plugins/orchestrator-backend/src/helpers/queryBuilder.ts
@@ -88,7 +88,9 @@ export function buildFilterCondition(
 
   if (filters.operator === FieldFilterOperatorEnum.IsNull) {
     let booleanValue = false;
-    if (typeof value === 'string') {
+    if (typeof value === 'boolean') {
+      booleanValue = value;
+    } else if (typeof value === 'string') {
       booleanValue = value.toLowerCase() === 'true';
     } else if (typeof value === 'number') {
       booleanValue = value === 1;

--- a/plugins/orchestrator-backend/src/service/DataIndexService.test.ts
+++ b/plugins/orchestrator-backend/src/service/DataIndexService.test.ts
@@ -472,22 +472,22 @@ describe('fetchInstances', () => {
   ];
 
   const filterString =
-    'or: {processId: {equal: "processId1"}, processId: {equal: "processId2"}}';
+    'or: {processId: {equal: "processId1"}, processName: {like: "processName%"}}';
 
+  const procName1Filter = {
+    field: 'processName',
+    operator: FieldFilterOperatorEnum.Like,
+    value: 'processName%',
+  };
   const procId1Filter = {
     field: 'processId',
     operator: FieldFilterOperatorEnum.Eq,
     value: 'processId1',
   };
-  const procId2Filter = {
-    field: 'processId',
-    operator: FieldFilterOperatorEnum.Eq,
-    value: 'processId2',
-  };
 
   const logicalFilter: LogicalFilter = {
     operator: 'OR',
-    filters: [procId1Filter, procId2Filter],
+    filters: [procId1Filter, procName1Filter],
   };
   const mockQueryResult = { ProcessInstances: mockProcessInstances };
 

--- a/plugins/orchestrator-backend/src/service/__fixtures__/mockProcessInstanceArgumentsData.ts
+++ b/plugins/orchestrator-backend/src/service/__fixtures__/mockProcessInstanceArgumentsData.ts
@@ -49,14 +49,14 @@ export const mockProcessInstanceArguments = {
           ofType: null,
         },
       },
-      // {
-      //   name: 'id',
-      //   type: {
-      //     kind: 'INPUT_OBJECT',
-      //     name: 'IdArgument',
-      //     ofType: null,
-      //   },
-      // },
+      {
+        name: 'id',
+        type: {
+          kind: 'INPUT_OBJECT',
+          name: 'IdArgument',
+          ofType: null,
+        },
+      },
       {
         name: 'processId',
         type: {
@@ -73,22 +73,22 @@ export const mockProcessInstanceArguments = {
           ofType: null,
         },
       },
-      // {
-      //   name: 'parentProcessInstanceId',
-      //   type: {
-      //     kind: 'INPUT_OBJECT',
-      //     name: 'IdArgument',
-      //     ofType: null,
-      //   },
-      // },
-      // {
-      //   name: 'rootProcessInstanceId',
-      //   type: {
-      //     kind: 'INPUT_OBJECT',
-      //     name: 'IdArgument',
-      //     ofType: null,
-      //   },
-      // },
+      {
+        name: 'parentProcessInstanceId',
+        type: {
+          kind: 'INPUT_OBJECT',
+          name: 'IdArgument',
+          ofType: null,
+        },
+      },
+      {
+        name: 'rootProcessInstanceId',
+        type: {
+          kind: 'INPUT_OBJECT',
+          name: 'IdArgument',
+          ofType: null,
+        },
+      },
       {
         name: 'rootProcessId',
         type: {
@@ -206,14 +206,14 @@ export const mockProcessInstanceArguments = {
 };
 
 export const mockProcessInstanceIntrospection: IntrospectionField[] = [
-  // {
-  //   name: 'id',
-  //   type: {
-  //     kind: TypeKind.InputObject,
-  //     name: TypeName.Id,
-  //     ofType: null,
-  //   },
-  // },
+  {
+    name: 'id',
+    type: {
+      kind: TypeKind.InputObject,
+      name: TypeName.Id,
+      ofType: null,
+    },
+  },
   {
     name: 'processId',
     type: {
@@ -230,22 +230,22 @@ export const mockProcessInstanceIntrospection: IntrospectionField[] = [
       ofType: null,
     },
   },
-  // {
-  //   name: 'parentProcessInstanceId',
-  //   type: {
-  //     kind: TypeKind.InputObject,
-  //     name: TypeName.Id,
-  //     ofType: null,
-  //   },
-  // },
-  // {
-  //   name: 'rootProcessInstanceId',
-  //   type: {
-  //     kind: TypeKind.InputObject,
-  //     name: TypeName.Id,
-  //     ofType: null,
-  //   },
-  // },
+  {
+    name: 'parentProcessInstanceId',
+    type: {
+      kind: TypeKind.InputObject,
+      name: TypeName.Id,
+      ofType: null,
+    },
+  },
+  {
+    name: 'rootProcessInstanceId',
+    type: {
+      kind: TypeKind.InputObject,
+      name: TypeName.Id,
+      ofType: null,
+    },
+  },
   {
     name: 'rootProcessId',
     type: {


### PR DESCRIPTION
Add the capability to filter by fields that are modelled as IDArgument in DataIndex.
Supported operator are EQ, IN and ISNull [1]

## Examples
### Equal operator
```bash
 curl --request POST \                                                                                                                                                                                                                                                                                                                                                 gloria@fedora
  --url http://localhost:7007/api/orchestrator/v2/workflows/instances \
  -H "Authorization: $token" \
  --header "Content-Type: application/json" \
  --data '{  
    "filters": { 
      "field": "id", 
      "operator": "EQ", 
      "value": "dcf9a3cf-3cab-47bf-b521-f5def87f0392" 
    }, 
    "paginationInfo": { 
      "offset": 0, 
      "pageSize": 10 
    } 
  } '
```

### IN Operator
```bash
curl --request POST \                                                                                                                                                                                                                                                                                                                                                 gloria@fedora
  --url http://localhost:7007/api/orchestrator/v2/workflows/instances \
  -H "Authorization: $token" \
  --header "Content-Type: application/json" \
  --data '{
    "filters": {
      "field": "id",
      "operator": "IN",
      "value": ["dcf9a3cf-3cab-47bf-b521-f5def87f0392", "AAAA"]
    },
    "paginationInfo": {
      "offset": 0,
      "pageSize": 10
    }
  }'

```

### Unsupported operator
```bash
curl --request POST \                                                                                                                                                                                                                                                                                                                                                 gloria@fedora
  --url http://localhost:7007/api/orchestrator/v2/workflows/instances \
  -H "Authorization: $token" \
  --header "Content-Type: application/json" \
  --data '{
    "filters": {
      "field": "id",
      "operator": "LIKE",
      "value": "dcf9a3cf-3cab-47bf-b521-f5def87f0392"
    },
    "paginationInfo": {
      "offset": 0,
      "pageSize": 10
    }
  }'```
throws 
```bash
{"error":{"name":"Error","message":"Unsupported field type IdArgument","stack":"Error: Unsupported field type IdArgument\n    at buildFilterCondition (/home/gloria/repos/backstage-plugins/plugins/orchestrator-backend/src/helpers/queryBuilder.ts:93:11)\n    at DataIndexService.fetchInstances (/home/gloria/repos/backstage-plugins/plugins/orchestrator-backend/src/service/DataIndexService.ts:290:29)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async OrchestratorService.fetchInstances (/home/gloria/repos/backstage-plugins/plugins/orchestrator-backend/src/service/OrchestratorService.ts:63:12)\n    at async V2.getInstances (/home/gloria/repos/backstage-plugins
```


## Fixes
[FLPATH-1758](https://issues.redhat.com/browse/FLPATH-1758)


[1] https://sonataflow.org/serverlessworkflow/main/data-index/data-index-core-concepts.html#data-index-ext-queries