### PR TITLE
fix(deps): update kubernetes-client version to fix a CVE

### DIFF
--- a/.changeset/spicy-pens-press.md
+++ b/.changeset/spicy-pens-press.md
@@ -1,0 +1,9 @@
+---
+"@janus-idp/backstage-scaffolder-backend-module-kubernetes": patch
+"@janus-idp/shared-react": patch
+"@janus-idp/backstage-plugin-ocm-backend": patch
+"@janus-idp/backstage-plugin-topology": patch
+"@janus-idp/backstage-plugin-tekton": patch
+---
+
+Fix CVE-2024-21534 by upgrading @kubernetes/client-node package to 0.22.1

--- a/plugins/kubernetes-actions/package.json
+++ b/plugins/kubernetes-actions/package.json
@@ -45,7 +45,7 @@
     "@backstage/backend-plugin-api": "^1.0.0",
     "@backstage/catalog-client": "^1.7.0",
     "@backstage/plugin-scaffolder-node": "^0.4.11",
-    "@kubernetes/client-node": "^0.20.0"
+    "@kubernetes/client-node": "^0.22.1"
   },
   "devDependencies": {
     "@backstage/catalog-model": "1.7.0",

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -58,7 +58,7 @@
     "@backstage/plugin-permission-common": "^0.8.1",
     "@backstage/plugin-permission-node": "^0.8.3",
     "@janus-idp/backstage-plugin-ocm-common": "*",
-    "@kubernetes/client-node": "^0.20.0",
+    "@kubernetes/client-node": "^0.22.1",
     "express": "^4.18.2",
     "semver": "^7.5.4"
   },

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -54,7 +54,6 @@
     "@backstage/catalog-model": "^1.7.0",
     "@backstage/errors": "^1.2.4",
     "@backstage/plugin-catalog-node": "^1.13.0",
-    "@backstage/plugin-kubernetes-common": "^0.8.3",
     "@backstage/plugin-permission-common": "^0.8.1",
     "@backstage/plugin-permission-node": "^0.8.3",
     "@janus-idp/backstage-plugin-ocm-common": "*",

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -31,8 +31,8 @@
   "scripts": {
     "build": "backstage-cli package build",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-kubernetes-common",
-    "export-dynamic:clean": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-kubernetes-common --clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin",
+    "export-dynamic:clean": "janus-cli package export-dynamic-plugin --clean",
     "lint:check": "backstage-cli package lint",
     "lint:fix": "backstage-cli package lint --fix",
     "postpack": "backstage-cli package postpack",

--- a/plugins/ocm-backend/src/constants.ts
+++ b/plugins/ocm-backend/src/constants.ts
@@ -1,2 +1,3 @@
 export const CONSOLE_CLAIM = 'consoleurl.cluster.open-cluster-management.io';
 export const HUB_CLUSTER_NAME_IN_OCM = 'local-cluster';
+export const ANNOTATION_KUBERNETES_API_SERVER = 'kubernetes.io/api-server';

--- a/plugins/ocm-backend/src/providers/ManagedClusterProvider.ts
+++ b/plugins/ocm-backend/src/providers/ManagedClusterProvider.ts
@@ -30,7 +30,6 @@ import type {
   EntityProvider,
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
-import { ANNOTATION_KUBERNETES_API_SERVER } from '@backstage/plugin-kubernetes-common';
 
 import { CustomObjectsApi } from '@kubernetes/client-node';
 
@@ -39,7 +38,11 @@ import {
   ANNOTATION_PROVIDER_ID,
 } from '@janus-idp/backstage-plugin-ocm-common';
 
-import { CONSOLE_CLAIM, HUB_CLUSTER_NAME_IN_OCM } from '../constants';
+import {
+  ANNOTATION_KUBERNETES_API_SERVER,
+  CONSOLE_CLAIM,
+  HUB_CLUSTER_NAME_IN_OCM,
+} from '../constants';
 import { readOcmConfigs } from '../helpers/config';
 import {
   getManagedCluster,

--- a/plugins/shared-react/package.json
+++ b/plugins/shared-react/package.json
@@ -40,7 +40,7 @@
     "@backstage/core-plugin-api": "^1.9.4",
     "@backstage/plugin-kubernetes-common": "^0.8.3",
     "@backstage/plugin-kubernetes-react": "^0.4.3",
-    "@kubernetes/client-node": "^0.20.0",
+    "@kubernetes/client-node": "^0.22.1",
     "@material-ui/core": "^4.12.4",
     "@mui/icons-material": "5.15.17",
     "classnames": "^2.3.2",

--- a/plugins/tekton/package.json
+++ b/plugins/tekton/package.json
@@ -52,7 +52,7 @@
     "@backstage/theme": "^0.5.7",
     "@janus-idp/backstage-plugin-tekton-common": "*",
     "@janus-idp/shared-react": "*",
-    "@kubernetes/client-node": "^0.20.0",
+    "@kubernetes/client-node": "^0.22.1",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.45",

--- a/plugins/topology/package.json
+++ b/plugins/topology/package.json
@@ -49,7 +49,7 @@
     "@backstage/theme": "^0.5.7",
     "@janus-idp/backstage-plugin-topology-common": "*",
     "@janus-idp/shared-react": "*",
-    "@kubernetes/client-node": "^0.20.0",
+    "@kubernetes/client-node": "^0.22.1",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.45",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8587,6 +8587,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/fs-minipass@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@isaacs/fs-minipass@npm:4.0.1"
+  dependencies:
+    minipass: ^7.0.4
+  checksum: 5d36d289960e886484362d9eb6a51d1ea28baed5f5d0140bbe62b99bac52eaf06cc01c2bc0d3575977962f84f6b2c4387b043ee632216643d4787b0999465bf2
+  languageName: node
+  linkType: hard
+
 "@isaacs/string-locale-compare@npm:^1.1.0":
   version: 1.1.0
   resolution: "@isaacs/string-locale-compare@npm:1.1.0"
@@ -9074,12 +9083,11 @@ __metadata:
     "@backstage/errors": ^1.2.4
     "@backstage/plugin-catalog-backend": 1.26.1
     "@backstage/plugin-catalog-node": ^1.13.0
-    "@backstage/plugin-kubernetes-common": ^0.8.3
     "@backstage/plugin-permission-common": ^0.8.1
     "@backstage/plugin-permission-node": ^0.8.3
     "@janus-idp/backstage-plugin-ocm-common": "*"
     "@janus-idp/cli": 1.16.0
-    "@kubernetes/client-node": ^0.20.0
+    "@kubernetes/client-node": ^0.22.1
     "@openapitools/openapi-generator-cli": 2.13.4
     "@types/express": 4.17.21
     "@types/supertest": 2.0.16
@@ -9569,7 +9577,7 @@ __metadata:
     "@janus-idp/backstage-plugin-tekton-common": "*"
     "@janus-idp/cli": 1.16.0
     "@janus-idp/shared-react": "*"
-    "@kubernetes/client-node": ^0.20.0
+    "@kubernetes/client-node": ^0.22.1
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.11.3
     "@material-ui/lab": ^4.0.0-alpha.45
@@ -9633,7 +9641,7 @@ __metadata:
     "@janus-idp/backstage-plugin-topology-common": "*"
     "@janus-idp/cli": 1.16.0
     "@janus-idp/shared-react": "*"
-    "@kubernetes/client-node": ^0.20.0
+    "@kubernetes/client-node": ^0.22.1
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.11.3
     "@material-ui/lab": ^4.0.0-alpha.45
@@ -9729,7 +9737,7 @@ __metadata:
     "@backstage/plugin-scaffolder-node": ^0.4.11
     "@backstage/plugin-scaffolder-node-test-utils": 0.1.12
     "@janus-idp/cli": 1.16.0
-    "@kubernetes/client-node": ^0.20.0
+    "@kubernetes/client-node": ^0.22.1
     msw: 1.3.3
     prettier: 3.3.3
   languageName: unknown
@@ -9970,7 +9978,7 @@ __metadata:
     "@backstage/plugin-kubernetes-common": ^0.8.3
     "@backstage/plugin-kubernetes-react": ^0.4.3
     "@backstage/test-utils": 1.6.0
-    "@kubernetes/client-node": ^0.20.0
+    "@kubernetes/client-node": ^0.22.1
     "@material-ui/core": ^4.12.4
     "@mui/icons-material": 5.15.17
     "@testing-library/jest-dom": 6.4.8
@@ -10320,7 +10328,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsep-plugin/regex@npm:^1.0.1":
+"@jsep-plugin/assignment@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@jsep-plugin/assignment@npm:1.2.1"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: d56fd7423c59dd269c50b0a9c22ec05f099a789ec8e8980f2307782f496ab3f0740151f1bdc7a1f3a8ee9085cdeb6f5b4def0d6b312e6b93ab160e6489b400f2
+  languageName: node
+  linkType: hard
+
+"@jsep-plugin/regex@npm:^1.0.1, @jsep-plugin/regex@npm:^1.0.3":
   version: 1.0.3
   resolution: "@jsep-plugin/regex@npm:1.0.3"
   peerDependencies:
@@ -10847,6 +10864,32 @@ __metadata:
     openid-client:
       optional: true
   checksum: c7c2ec9c597b5579ec452bcc13647feeaa3eaf93601afa5d9a4e06b5fe91d2cafa444a1da07b5330a7596f0e07e107d6abe4acabc5998f7bedf43cd0ab8bf343
+  languageName: node
+  linkType: hard
+
+"@kubernetes/client-node@npm:^0.22.1":
+  version: 0.22.1
+  resolution: "@kubernetes/client-node@npm:0.22.1"
+  dependencies:
+    "@types/js-yaml": ^4.0.1
+    "@types/node": ^22.0.0
+    "@types/request": ^2.47.1
+    "@types/ws": ^8.5.3
+    byline: ^5.0.0
+    isomorphic-ws: ^5.0.0
+    js-yaml: ^4.1.0
+    jsonpath-plus: ^10.0.0
+    openid-client: ^5.3.0
+    request: ^2.88.0
+    rfc4648: ^1.3.0
+    stream-buffers: ^3.0.2
+    tar: ^7.0.0
+    tslib: ^2.4.1
+    ws: ^8.18.0
+  dependenciesMeta:
+    openid-client:
+      optional: true
+  checksum: 501377ad70681df9e30885cf18e40f9b16fd452bc50d9a46688a6f667a2a7f490238269e528b1f1804a6eaf4347f8edda57e5129b1a28a52915fe7898ea84329
   languageName: node
   linkType: hard
 
@@ -19642,6 +19685,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^22.0.0":
+  version: 22.7.8
+  resolution: "@types/node@npm:22.7.8"
+  dependencies:
+    undici-types: ~6.19.2
+  checksum: c1dd36bd0bf82588e61f82edb29a792f21ce902f90cc5485591f9fd60cec3ea9172e044bf7b1c0849e7cf3a5a01da39516db260cb65cb0b94904010e00634a1c
+  languageName: node
+  linkType: hard
+
 "@types/normalize-package-data@npm:^2.4.0":
   version: 2.4.4
   resolution: "@types/normalize-package-data@npm:2.4.4"
@@ -23332,6 +23384,13 @@ __metadata:
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
   checksum: c57cf9dd0791e2f18a5ee9c1a299ae6e801ff58fee96dc8bfd0dcb4738a6ce58dd252a3605b1c93c6418fe4f9d5093b28ffbf4d66648cb2a9c67eaef9679be2f
+  languageName: node
+  linkType: hard
+
+"chownr@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chownr@npm:3.0.0"
+  checksum: fd73a4bab48b79e66903fe1cafbdc208956f41ea4f856df883d0c7277b7ab29fd33ee65f93b2ec9192fc0169238f2f8307b7735d27c155821d886b84aa97aa8d
   languageName: node
   linkType: hard
 
@@ -29648,7 +29707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.0.0, glob@npm:^10.2.2, glob@npm:^10.2.7, glob@npm:^10.3.10, glob@npm:^10.4.1":
+"glob@npm:^10.0.0, glob@npm:^10.2.2, glob@npm:^10.2.7, glob@npm:^10.3.10, glob@npm:^10.3.7, glob@npm:^10.4.1":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:
@@ -33018,7 +33077,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsep@npm:^1.1.2, jsep@npm:^1.2.0":
+"jsep@npm:^1.1.2, jsep@npm:^1.2.0, jsep@npm:^1.3.9":
   version: 1.3.9
   resolution: "jsep@npm:1.3.9"
   checksum: d1f3e2cc00209f67a989b73c2a89d2ccbea908d950ec959e2448c6449b134c6367b47eef4e1292767cb490f0b5b72e7309080b93ee4c7398684df2514dbd33a3
@@ -33263,6 +33322,20 @@ __metadata:
   version: 7.1.0
   resolution: "jsonpath-plus@npm:7.1.0"
   checksum: a4005dc860c6b7e339229842537ceb6eb839d87a3447f989792b9c64f2564bbbd40663515f9481fb5a1b6cb0f988afba5b0b150e0285c463b794a45ed1aaf555
+  languageName: node
+  linkType: hard
+
+"jsonpath-plus@npm:^10.0.0":
+  version: 10.1.0
+  resolution: "jsonpath-plus@npm:10.1.0"
+  dependencies:
+    "@jsep-plugin/assignment": ^1.2.1
+    "@jsep-plugin/regex": ^1.0.3
+    jsep: ^1.3.9
+  bin:
+    jsonpath: bin/jsonpath-cli.js
+    jsonpath-plus: bin/jsonpath-cli.js
+  checksum: 9369a9466e3bb3eca064debe3fd87d9cf791b9c8a23be7c00902497cd8f9dd632290d471e3c7bb09da0aa92626204f9c9a27c429940802bc5046cc8c87f3c596
   languageName: node
   linkType: hard
 
@@ -36497,7 +36570,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.1.2":
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
   checksum: 2bfd325b95c555f2b4d2814d49325691c7bee937d753814861b0b49d5edcda55cbbf22b6b6a60bb91eddac8668771f03c5ff647dcd9d0f798e9548b9cdc46ee3
@@ -36511,6 +36584,16 @@ __metadata:
     minipass: ^3.0.0
     yallist: ^4.0.0
   checksum: f1fdeac0b07cf8f30fcf12f4b586795b97be856edea22b5e9072707be51fc95d41487faec3f265b42973a304fe3a64acd91a44a3826a963e37b37bafde0212c3
+  languageName: node
+  linkType: hard
+
+"minizlib@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "minizlib@npm:3.0.1"
+  dependencies:
+    minipass: ^7.0.4
+    rimraf: ^5.0.5
+  checksum: da0a53899252380475240c587e52c824f8998d9720982ba5c4693c68e89230718884a209858c156c6e08d51aad35700a3589987e540593c36f6713fe30cd7338
   languageName: node
   linkType: hard
 
@@ -36547,6 +36630,15 @@ __metadata:
   bin:
     mkdirp: dist/cjs/src/bin.js
   checksum: 8a1d09ffac585e55f41c54f445051f5bc33a7de99b952bb04c576cafdf1a67bb4bae8cb93736f7da6838771fbf75bc630430a3a59e1252047d2278690bd150ee
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mkdirp@npm:3.0.1"
+  bin:
+    mkdirp: dist/cjs/src/bin.js
+  checksum: 972deb188e8fb55547f1e58d66bd6b4a3623bf0c7137802582602d73e6480c1c2268dcbafbfb1be466e00cc7e56ac514d7fd9334b7cf33e3e2ab547c16f83a8d
   languageName: node
   linkType: hard
 
@@ -42652,6 +42744,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rimraf@npm:^5.0.5":
+  version: 5.0.10
+  resolution: "rimraf@npm:5.0.10"
+  dependencies:
+    glob: ^10.3.7
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: 50e27388dd2b3fa6677385fc1e2966e9157c89c86853b96d02e6915663a96b7ff4d590e14f6f70e90f9b554093aa5dbc05ac3012876be558c06a65437337bc05
+  languageName: node
+  linkType: hard
+
 "rimraf@npm:~2.6.2":
   version: 2.6.3
   resolution: "rimraf@npm:2.6.3"
@@ -45172,6 +45275,20 @@ __metadata:
     mkdirp: ^1.0.3
     yallist: ^4.0.0
   checksum: f1322768c9741a25356c11373bce918483f40fa9a25c69c59410c8a1247632487edef5fe76c5f12ac51a6356d2f1829e96d2bc34098668a2fc34d76050ac2b6c
+  languageName: node
+  linkType: hard
+
+"tar@npm:^7.0.0":
+  version: 7.4.3
+  resolution: "tar@npm:7.4.3"
+  dependencies:
+    "@isaacs/fs-minipass": ^4.0.0
+    chownr: ^3.0.0
+    minipass: ^7.1.2
+    minizlib: ^3.0.1
+    mkdirp: ^3.0.1
+    yallist: ^5.0.0
+  checksum: 8485350c0688331c94493031f417df069b778aadb25598abdad51862e007c39d1dd5310702c7be4a6784731a174799d8885d2fde0484269aea205b724d7b2ffa
   languageName: node
   linkType: hard
 
@@ -48965,6 +49082,13 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  languageName: node
+  linkType: hard
+
+"yallist@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "yallist@npm:5.0.0"
+  checksum: eba51182400b9f35b017daa7f419f434424410691bbc5de4f4240cc830fdef906b504424992700dc047f16b4d99100a6f8b8b11175c193f38008e9c96322b6a5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/RHIDP-4441

This upgrades the following packages

- ocm-backend
- shared-react
- kubernetes-action
- topology
- tekton


Note: 1.3.x fix for Argocd will be contributed from backstage/community-plugin.

Fix CVE

[CVE-2024-21534
](https://bugzilla.redhat.com/show_bug.cgi?id=2317968)