### PR TITLE
chore: add CODEOWNERS for /packages/cli 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,3 +43,7 @@ yarn.lock                    @janus-idp/maintainers-plugins
 /plugins/quay                               @janus-idp/rhtap
 /plugins/tekton                             @janus-idp/rhtap
 /plugins/argocd                             @janus-idp/rhtap
+
+
+# Dynamic plugins tooling
+/packages/cli                               @davidfestal @jesuino @gashcrumb @kadel


### PR DESCRIPTION
add packages/cli to CODEOWNERS