### PR TITLE
chore(release): only the release action should be gated to one at a time; PR build and test should be able to run in parallel across multiple PRs (RHIDP-4430)

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -6,9 +6,10 @@ env:
   TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
   TURBO_SCM_HEAD: ${{ github.sha }}
 
-concurrency:
-  group: push
-  cancel-in-progress: false
+# uncommment this to enforce only one action can run at a time
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -6,10 +6,11 @@ env:
   TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
   TURBO_SCM_HEAD: ${{ github.sha }}
 
-# uncommment this to enforce only one action can run at a time
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: false
+# enforce only one action can run at a time for a given PR, and
+# when updating a PR, actions in progress will be cancelled to start a fresh one
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -6,9 +6,10 @@ env:
   TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
   TURBO_SCM_HEAD: ${{ github.sha }}
 
-concurrency:
-  group: push
-  cancel-in-progress: false
+# uncommment this to enforce only one action can run at a time
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: false
 
 jobs:
   test:

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -6,10 +6,11 @@ env:
   TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
   TURBO_SCM_HEAD: ${{ github.sha }}
 
-# uncommment this to enforce only one action can run at a time
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: false
+# enforce only one action can run at a time for a given PR, and
+# when updating a PR, actions in progress will be cancelled to start a fresh one
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,8 +14,9 @@ on:
       - 1.2.x
       - release-[0-9].[0-9]*
 
+# enforce only one release action at a time
 concurrency:
-  group: push
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
### What does this PR do?

chore(release) only the release action should be gated to one at a time; PR build and test should be able to run in parallel across multiple PRs ([RHIDP-4430](https://issues.redhat.com//browse/RHIDP-4430))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.