### PR TITLE
fix(app): fix logo padding when using MUI v5 makeStyles

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -31,17 +31,17 @@ import LogoFull from './LogoFull';
 import LogoIcon from './LogoIcon';
 
 const useSidebarLogoStyles = makeStyles()({
-  root: {
+  sidebarLogo: {
     width: sidebarConfig.drawerWidthClosed,
     height: 3 * sidebarConfig.logoHeight,
     display: 'flex',
     flexFlow: 'row nowrap',
     alignItems: 'center',
     marginBottom: -14,
-  },
-  link: {
-    width: sidebarConfig.drawerWidthClosed,
-    marginLeft: 24,
+    '& > a': {
+      width: sidebarConfig.drawerWidthClosed,
+      marginLeft: 24,
+    },
   },
 });
 
@@ -50,8 +50,8 @@ const SidebarLogo = () => {
   const { isOpen } = useSidebarOpenState();
 
   return (
-    <div className={classes.root}>
-      <Link to="/" underline="none" className={classes.link} aria-label="Home">
+    <div className={classes.sidebarLogo}>
+      <Link to="/" underline="none" aria-label="Home">
         {isOpen ? <LogoFull /> : <LogoIcon />}
       </Link>
     </div>


### PR DESCRIPTION
**Fixes:**

[RHIDP-4662](https://issues.redhat.com/browse/RHIDP-4662)

Small change to fix the logo position after we updated the app to MUI v5 (long time ago):

**Before:**

![Screenshot from 2024-10-18 08-43-43](https://github.com/user-attachments/assets/a338bdda-b333-4552-bb98-09ef5ff56d17)

**After:**

![Screenshot from 2024-10-18 08-44-41](https://github.com/user-attachments/assets/4d6a553c-6b26-46fa-8313-e4c979cb6b32)
