### PR TITLE
fix(ocm): fix unaligned status icon and message

### DIFF
--- a/.changeset/healthy-parrots-invite.md
+++ b/.changeset/healthy-parrots-invite.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/backstage-plugin-ocm": patch
+---
+
+fix unaligned status icon and message

--- a/plugins/ocm/src/components/ClusterStatusPage/ClusterStatusPage.tsx
+++ b/plugins/ocm/src/components/ClusterStatusPage/ClusterStatusPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import useDebounce from 'react-use/lib/useDebounce';
 
@@ -50,27 +50,21 @@ const useStyles = makeStyles(theme => ({
 
 const NodeChip = ({
   count,
-  indicator,
+  indicatorComponent: IndicatorComponent,
 }: {
   count: number;
-  indicator: ReactElement;
-}) => (
-  <>
-    {count > 0 ? (
-      <Chip
-        label={
-          <>
-            {indicator}
-            {count}
-          </>
-        }
-        variant="outlined"
-      />
-    ) : (
-      <></>
-    )}
-  </>
-);
+  indicatorComponent: React.FC<React.PropsWithChildren<{}>>;
+}) => {
+  if (!count) {
+    return null;
+  }
+  return (
+    <Chip
+      label={<IndicatorComponent>{count}</IndicatorComponent>}
+      variant="outlined"
+    />
+  );
+};
 
 const NodeChips = ({ nodes }: { nodes: ClusterNodesStatus[] }) => {
   const readyChipsNodes = nodes.filter(node => node.status === 'True').length;
@@ -85,11 +79,11 @@ const NodeChips = ({ nodes }: { nodes: ClusterNodesStatus[] }) => {
 
   return (
     <>
-      <NodeChip count={readyChipsNodes} indicator={<StatusOK />} />
-      <NodeChip count={notReadyNodesCount} indicator={<StatusError />} />
+      <NodeChip count={readyChipsNodes} indicatorComponent={StatusOK} />
+      <NodeChip count={notReadyNodesCount} indicatorComponent={StatusError} />
       <NodeChip
         count={nodes.length - readyChipsNodes - notReadyNodesCount}
-        indicator={<StatusAborted />}
+        indicatorComponent={StatusAborted}
       />
     </>
   );

--- a/plugins/ocm/src/components/common.tsx
+++ b/plugins/ocm/src/components/common.tsx
@@ -25,26 +25,11 @@ const useStyles = makeStyles({
 
 export const Status = ({ status }: { status: ClusterStatus }) => {
   if (!status) {
-    return (
-      <>
-        <StatusAborted />
-        Unknown
-      </>
-    );
+    return <StatusAborted>Unknown</StatusAborted>;
   } else if (status.available) {
-    return (
-      <>
-        <StatusOK />
-        Ready
-      </>
-    );
+    return <StatusOK>Ready</StatusOK>;
   }
-  return (
-    <>
-      <StatusError />
-      Not Ready
-    </>
-  );
+  return <StatusError>Not Ready</StatusError>;
 };
 
 export const Update = ({ data }: { data: versionDetails }) => {


### PR DESCRIPTION
Fixes: [RHIDP-4602](https://issues.redhat.com/browse/RHIDP-4602)

Fix a layout issue on the OCM ClusterStatusPage.

In 1.2 it looked like this:

![ocm-1 2](https://github.com/user-attachments/assets/48e36067-7d26-41f0-9265-f2516a72a6ff)

In 1.3 the icon was changed and wasn't aligned anymore;

![ocm-1 3](https://github.com/user-attachments/assets/afb98a14-bba1-4d84-9ec7-d66fb9ed5212)

With this change:

![fixed](https://github.com/user-attachments/assets/59172e10-2ddc-4ff7-b584-e36b8e192bfd)
