### PR TITLE
chore(release): include embedded folder for keycloak-backend

### DIFF
--- a/plugins/keycloak-backend/package.json
+++ b/plugins/keycloak-backend/package.json
@@ -68,6 +68,7 @@
   },
   "files": [
     "dist",
+    "embedded",
     "config.d.ts",
     "dist-dynamic/*.*",
     "dist-dynamic/dist/**",


### PR DESCRIPTION
###

Include embedded folder for keycloak-backend. Previous attempt was in the wrong place: https://github.com/janus-idp/backstage-plugins/pull/2353