### PR TITLE
fix(cli): allow mutable install for monorepo yarn.lock

### DIFF
--- a/.changeset/nine-peas-boil.md
+++ b/.changeset/nine-peas-boil.md
@@ -1,0 +1,7 @@
+---
+"@janus-idp/cli": patch
+---
+
+fix(cli): allow mutable install for monorepo yarn.lock
+
+This change updates the CLI to use `--no-immutable` when a plugin package or monorepo `yarn.lock` file is used during the `export-dynamic-plugin` command. Explicitly passing this flag avoids the default Yarn 3.x behavior of `--immutable` when the command is run in a CI environment.

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -320,7 +320,7 @@ ${
       ? `${yarn} install --production${
           yarnLockExists ? ' --frozen-lockfile' : ''
         }`
-      : `${yarn} install${yarnLockExists ? ' --immutable' : ''}`;
+      : `${yarn} install${yarnLockExists ? ' --immutable' : ' --no-immutable'}`;
 
     await Task.forCommand(yarnInstall, { cwd: target, optional: false });
     await fs.remove(paths.resolveTarget(targetRelativePath, '.yarn'));


### PR DESCRIPTION
This change updates the CLI to use `--no-immutable` when a plugin package or monorepo `yarn.lock` file is used during the `export-dynamic-plugin` command. Explicitly passing this flag avoids the default Yarn 3.x behavior of `--immutable` when the command is run in a CI environment.

@schultzp2020 @davidfestal fyi