### PR TITLE
chore(release): revert the major update so that we can release under a patch

### DIFF
--- a/.changeset/odd-onions-sort.md
+++ b/.changeset/odd-onions-sort.md
@@ -1,0 +1,9 @@
+---
+'@janus-idp/backstage-plugin-keycloak-backend': patch
+---
+
+Provide keycloak-backend fixes:
+
+- avoid undefined values for keycloak group members
+- retrieve full list group members using pagination
+- revert unexpected major upgrade of the keycloak backend plugin

--- a/plugins/keycloak-backend/dist-dynamic/package.json
+++ b/plugins/keycloak-backend/dist-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-keycloak-backend-dynamic",
-  "version": "2.0.0",
+  "version": "1.13.3",
   "description": "A Backend backend plugin for Keycloak",
   "main": "./dist/index.cjs.js",
   "types": "src/index.ts",

--- a/plugins/keycloak-backend/package.json
+++ b/plugins/keycloak-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janus-idp/backstage-plugin-keycloak-backend",
-  "version": "2.0.0",
+  "version": "1.13.3",
   "description": "A Backend backend plugin for Keycloak",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Description

Looks like the keycloak plugin was released under a `major` update instead of a `patch`. This PR reverts back to the original version and adds a patch changeset so that we can release it properly.