### PR TITLE
feat(lightspeed-backend): send conversation history to langchain streams

### DIFF
--- a/plugins/lightspeed-backend/src/handlers/chatHistory.ts
+++ b/plugins/lightspeed-backend/src/handlers/chatHistory.ts
@@ -14,19 +14,35 @@ export async function saveHistory(
   conversation_id: string,
   role: string,
   message: string,
+  timestamp?: number,
 ): Promise<void> {
   let newMessage: BaseMessage;
   switch (role) {
     case Roles.AIRole: {
-      newMessage = new AIMessage(message);
+      newMessage = new AIMessage({
+        content: message,
+        response_metadata: {
+          created_at: timestamp || Date.now(),
+        },
+      });
       break;
     }
     case Roles.HumanRole: {
-      newMessage = new HumanMessage(message);
+      newMessage = new HumanMessage({
+        content: message,
+        response_metadata: {
+          created_at: timestamp || Date.now(),
+        },
+      });
       break;
     }
     case Roles.SystemRole: {
-      newMessage = new SystemMessage(message);
+      newMessage = new SystemMessage({
+        content: message,
+        response_metadata: {
+          created_at: timestamp || Date.now(),
+        },
+      });
       break;
     }
     default:

--- a/plugins/lightspeed-backend/src/service/router.ts
+++ b/plugins/lightspeed-backend/src/service/router.ts
@@ -1,6 +1,6 @@
 import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 
-import { HumanMessage } from '@langchain/core/messages';
+import { BaseMessage, HumanMessage } from '@langchain/core/messages';
 import {
   ChatPromptTemplate,
   MessagesPlaceholder,
@@ -129,11 +129,35 @@ export async function createRouter(
           new MessagesPlaceholder('messages'),
         ]);
 
+        let conversationHistory: BaseMessage[] = [];
+        try {
+          conversationHistory = await loadHistory(
+            conversation_id,
+            DEFAULT_HISTORY_LENGTH,
+          );
+        } catch (error) {
+          logger.error(`${error}`);
+        }
+
         const chain = prompt.pipe(openAIApi);
         let content = '';
+        const userMessageTimestamp = Date.now();
+        let botMessageTimestamp;
         for await (const chunk of await chain.stream({
-          messages: [new HumanMessage(query)],
+          messages: [
+            ...conversationHistory,
+            new HumanMessage({
+              content: query,
+              response_metadata: {
+                created_at: userMessageTimestamp,
+              },
+            }),
+          ],
         })) {
+          if (!botMessageTimestamp) {
+            botMessageTimestamp = Date.now();
+          }
+          chunk.response_metadata.created_at = botMessageTimestamp;
           const data = {
             conversation_id: conversation_id,
             response: chunk,
@@ -144,8 +168,18 @@ export async function createRouter(
         }
         response.end();
 
-        await saveHistory(conversation_id, Roles.HumanRole, query);
-        await saveHistory(conversation_id, Roles.AIRole, content);
+        await saveHistory(
+          conversation_id,
+          Roles.HumanRole,
+          query,
+          userMessageTimestamp,
+        );
+        await saveHistory(
+          conversation_id,
+          Roles.AIRole,
+          content,
+          botMessageTimestamp,
+        );
       } catch (error) {
         const errormsg = `Error fetching completions from ${serverURL}: ${error}`;
         logger.error(errormsg);


### PR DESCRIPTION
This PR implements the following changes required for frontend.

1. sends the user conversation history from the store to the langchain stream method.
2. add message created timestamp. i.e `created_at` and `role` in  `response_metadata` object. 


![image](https://github.com/user-attachments/assets/56268b03-9d6b-4566-9ac9-5820ce2ba7ac)

---
**Unit tests:**

 POST /v1/query
     
      ✓ should not have any history for the initial conversation (25 ms)
      ✓ should call the stream with conversation history (17 ms)
      ✓ should contain ai and human message timestamp (218 ms)