### PR TITLE
feat(orchestrator): add filter by enum

### DIFF
--- a/.changeset/neat-pigs-lie.md
+++ b/.changeset/neat-pigs-lie.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-plugin-orchestrator-backend": minor
+"@janus-idp/backstage-plugin-orchestrator-common": minor
+---
+
+Add enum filters to orchestrator plugin

--- a/plugins/orchestrator-backend/src/helpers/filterBuilders.test.ts
+++ b/plugins/orchestrator-backend/src/helpers/filterBuilders.test.ts
@@ -2,6 +2,8 @@ import {
   FieldFilterOperatorEnum,
   Filter,
   IntrospectionField,
+  ProcessInstanceState,
+  ProcessInstanceStatusDTO,
   TypeKind,
   TypeName,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
@@ -49,7 +51,11 @@ describe('column filters', () => {
     emptyFilterTestCases.forEach(
       ({ name, introspectionFields, filter, expectedResult }) => {
         it(`${name}`, () => {
-          const result = buildFilterCondition(introspectionFields, filter);
+          const result = buildFilterCondition(
+            introspectionFields,
+            'ProcessInstance',
+            filter,
+          );
           expect(result).toBe(expectedResult);
         });
       },
@@ -247,7 +253,11 @@ describe('column filters', () => {
     stringTestCases.forEach(
       ({ name, introspectionFields, filter, expectedResult }) => {
         it(`${name}`, () => {
-          const result = buildFilterCondition(introspectionFields, filter);
+          const result = buildFilterCondition(
+            introspectionFields,
+            'ProcessInstance',
+            filter,
+          );
           expect(result).toBe(expectedResult);
         });
       },
@@ -334,7 +344,11 @@ describe('column filters', () => {
     idTestCases.forEach(
       ({ name, introspectionFields, filter, expectedResult }) => {
         it(`${name}`, () => {
-          const result = buildFilterCondition(introspectionFields, filter);
+          const result = buildFilterCondition(
+            introspectionFields,
+            'ProcessInstance',
+            filter,
+          );
           expect(result).toBe(expectedResult);
         });
       },
@@ -497,7 +511,40 @@ describe('column filters', () => {
     idTestCases.forEach(
       ({ name, introspectionFields, filter, expectedResult }) => {
         it(`${name}`, () => {
-          const result = buildFilterCondition(introspectionFields, filter);
+          const result = buildFilterCondition(
+            introspectionFields,
+            'ProcessInstance',
+            filter,
+          );
+          expect(result).toBe(expectedResult);
+        });
+      },
+    );
+  });
+  describe('enumArgument testcases', () => {
+    const idTestCases: FilterTestCase[] = [
+      {
+        name: 'returns correct filter for state enum field with equal operator',
+        introspectionFields: [
+          createIntrospectionField('state', TypeName.String),
+        ],
+        filter: createFieldFilter(
+          'state',
+          FieldFilterOperatorEnum.Eq,
+          ProcessInstanceStatusDTO.Completed,
+        ),
+        expectedResult: `state: {equal: ${ProcessInstanceState.Completed}}`,
+      },
+    ];
+
+    idTestCases.forEach(
+      ({ name, introspectionFields, filter, expectedResult }) => {
+        it(`${name}`, () => {
+          const result = buildFilterCondition(
+            introspectionFields,
+            'ProcessInstance',
+            filter,
+          );
           expect(result).toBe(expectedResult);
         });
       },

--- a/plugins/orchestrator-backend/src/service/DataIndexService.test.ts
+++ b/plugins/orchestrator-backend/src/service/DataIndexService.test.ts
@@ -3,6 +3,7 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { Client, OperationResult } from '@urql/core';
 
 import {
+  FieldFilter,
   FieldFilterOperatorEnum,
   LogicalFilter,
   NodeInstance,
@@ -349,6 +350,7 @@ describe('fetchWorkflowInfos', () => {
     expect(buildFilterConditionSpy).toHaveBeenCalledTimes(1);
     expect(buildFilterConditionSpy).toHaveBeenCalledWith(
       mockProcessDefinitionIntrospection,
+      'ProcessDefinition',
       logicalFilter,
     );
     expect(mockClient.query).toHaveBeenCalledTimes(2);
@@ -394,6 +396,7 @@ describe('fetchWorkflowInfos', () => {
     expect(buildFilterConditionSpy).toHaveBeenCalledTimes(1);
     expect(buildFilterConditionSpy).toHaveBeenCalledWith(
       mockProcessDefinitionIntrospection,
+      'ProcessDefinition',
       logicalFilter,
     );
     expect(mockClient.query).toHaveBeenCalledTimes(2);
@@ -448,6 +451,7 @@ describe('fetchWorkflowInfos', () => {
     expect(buildFilterConditionSpy).toHaveBeenCalledTimes(1);
     expect(buildFilterConditionSpy).toHaveBeenCalledWith(
       mockProcessDefinitionIntrospection,
+      'ProcessDefinition',
       logicalFilter,
     );
     expect(result).toBeDefined();
@@ -488,12 +492,12 @@ describe('fetchInstances', () => {
   const filterString =
     'or: {processId: {equal: "processId1"}, processName: {like: "processName%"}}';
 
-  const procName1Filter = {
+  const procName1Filter: FieldFilter = {
     field: 'processName',
     operator: FieldFilterOperatorEnum.Like,
     value: 'processName%',
   };
-  const procId1Filter = {
+  const procId1Filter: FieldFilter = {
     field: 'processId',
     operator: FieldFilterOperatorEnum.Eq,
     value: 'processId1',
@@ -678,6 +682,7 @@ describe('fetchInstances', () => {
     expect(buildFilterConditionSpy).toHaveBeenCalledTimes(1);
     expect(buildFilterConditionSpy).toHaveBeenCalledWith(
       mockProcessInstanceIntrospection,
+      'ProcessInstance',
       logicalFilter,
     );
     expect(mockClient.query).toHaveBeenCalledTimes(2);
@@ -714,6 +719,7 @@ describe('fetchInstances', () => {
     expect(buildFilterConditionSpy).toHaveBeenCalledTimes(1);
     expect(buildFilterConditionSpy).toHaveBeenCalledWith(
       mockProcessInstanceIntrospection,
+      'ProcessInstance',
       logicalFilter,
     );
     expect(mockClient.query).toHaveBeenCalledTimes(2);
@@ -755,6 +761,7 @@ describe('fetchInstances', () => {
     expect(buildFilterConditionSpy).toHaveBeenCalledTimes(1);
     expect(buildFilterConditionSpy).toHaveBeenCalledWith(
       mockProcessInstanceIntrospection,
+      'ProcessInstance',
       logicalFilter,
     );
     expect(mockClient.query).toHaveBeenCalledTimes(2);

--- a/plugins/orchestrator-backend/src/service/DataIndexService.ts
+++ b/plugins/orchestrator-backend/src/service/DataIndexService.ts
@@ -7,7 +7,6 @@ import {
   fromWorkflowSource,
   getWorkflowCategory,
   IntrospectionField,
-  IntrospectionQuery,
   parseWorkflowVariables,
   ProcessInstance,
   WorkflowDefinition,
@@ -111,42 +110,6 @@ export class DataIndexService {
       }
     }
     return pairs;
-  }
-
-  public async getSchemaTypes(type: string): Promise<IntrospectionQuery> {
-    const graphQlQuery = `query IntrospectionQuery {
-  __type(name: "${type}") {
-    name
-    kind
-    description
-    fields {
-      name
-      type {
-        kind
-        name
-        ofType {
-          kind
-          name
-          ofType {
-            kind
-            name
-          }
-        }
-      }
-    }
-  }
-}
-`;
-
-    const result = await this.client.query(graphQlQuery, {});
-
-    this.logger.debug(`Introspection query result: ${JSON.stringify(result)}`);
-
-    if (result.error) {
-      this.logger.error(`Error executing introspection query ${result.error}`);
-      throw result.error;
-    }
-    return result as unknown as IntrospectionQuery;
   }
 
   public async abortWorkflowInstance(instanceId: string): Promise<void> {

--- a/plugins/orchestrator-backend/src/service/DataIndexService.ts
+++ b/plugins/orchestrator-backend/src/service/DataIndexService.ts
@@ -78,6 +78,7 @@ export class DataIndexService {
         }
       }`;
   }
+
   public async inspectInputArgument(
     type: string,
   ): Promise<IntrospectionField[]> {
@@ -200,6 +201,7 @@ export class DataIndexService {
     const filterCondition = filter
       ? buildFilterCondition(
           await this.initInputProcessDefinitionArgs(),
+          'ProcessDefinition',
           filter,
         )
       : undefined;
@@ -247,9 +249,11 @@ export class DataIndexService {
     const definitionIdsCondition = definitionIds
       ? `processId: {in: ${JSON.stringify(definitionIds)}}`
       : undefined;
+    const type = 'ProcessInstance';
     const filterCondition = filter
       ? buildFilterCondition(
-          await this.inspectInputArgument('ProcessInstance'),
+          await this.inspectInputArgument(type),
+          type,
           filter,
         )
       : '';
@@ -315,6 +319,7 @@ export class DataIndexService {
     const filterCondition = filter
       ? buildFilterCondition(
           await this.inspectInputArgument('ProcessInstance'),
+          'ProcessInstance',
           filter,
         )
       : '';

--- a/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.test.ts
+++ b/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.test.ts
@@ -13,7 +13,7 @@ import {
   generateTestWorkflowOverview,
 } from '../test-utils';
 import {
-  getProcessInstancesDTOFromString,
+  getProcessInstancesStatusDTOFromString,
   mapToExecuteWorkflowResponseDTO,
   mapToProcessInstanceDTO,
   mapToWorkflowOverviewDTO,
@@ -58,7 +58,7 @@ describe('scenarios to verify mapToWorkflowOverviewDTO', () => {
     expect(result.format).toBe(overview.format);
     expect(result.lastTriggeredMs).toBe(overview.lastTriggeredMs);
     expect(result.lastRunStatus).toBe(
-      getProcessInstancesDTOFromString(overview.lastRunStatus),
+      getProcessInstancesStatusDTOFromString(overview.lastRunStatus),
     );
     expect(result.category).toBe('assessment');
     expect(result.avgDurationMs).toBe(overview.avgDurationMs);
@@ -102,7 +102,7 @@ describe('scenarios to verify mapToProcessInstanceDTO', () => {
     expect(result.end).toBeUndefined();
     expect(result.duration).toBeUndefined();
     expect(result.status).toEqual(
-      getProcessInstancesDTOFromString(processInstanceV1.state),
+      getProcessInstancesStatusDTOFromString(processInstanceV1.state),
     );
     expect(result.description).toEqual(processInstanceV1.description);
     expect(result.category).toEqual('infrastructure');
@@ -130,7 +130,7 @@ describe('scenarios to verify mapToProcessInstanceDTO', () => {
 
     expect(result).toBeDefined();
     expect(result.status).toEqual(
-      getProcessInstancesDTOFromString(processIntanceV1.state),
+      getProcessInstancesStatusDTOFromString(processIntanceV1.state),
     );
     expect(result.end).toEqual(processIntanceV1.end);
     expect(result.duration).toEqual(duration);

--- a/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.ts
+++ b/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.ts
@@ -35,7 +35,7 @@ export function mapToWorkflowOverviewDTO(
     description: overview.description,
     lastRunId: overview.lastRunId,
     lastRunStatus: overview.lastRunStatus
-      ? getProcessInstancesDTOFromString(overview.lastRunStatus)
+      ? getProcessInstancesStatusDTOFromString(overview.lastRunStatus)
       : undefined,
     lastTriggeredMs: overview.lastTriggeredMs,
     category: mapWorkflowCategoryDTOFromString(overview.category),
@@ -81,7 +81,7 @@ export function mapWorkflowCategoryDTO(
   return 'infrastructure';
 }
 
-export function getProcessInstancesDTOFromString(
+export function getProcessInstancesStatusDTOFromString(
   state?: string,
 ): ProcessInstanceStatusDTO {
   switch (state) {
@@ -135,7 +135,7 @@ export function mapToProcessInstanceDTO(
     duration: duration,
     // @ts-ignore
     workflowdata: variables?.workflowdata,
-    status: getProcessInstancesDTOFromString(processInstance.state),
+    status: getProcessInstancesStatusDTOFromString(processInstance.state),
     nodes: processInstance.nodes.map(mapToNodeInstanceDTO),
   };
 }

--- a/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.ts
+++ b/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.ts
@@ -104,6 +104,29 @@ export function getProcessInstancesStatusDTOFromString(
   }
 }
 
+export function getProcessInstanceStateFromStatusDTOString(
+  status?: ProcessInstanceStatusDTO,
+): string {
+  switch (status) {
+    case 'Active':
+      return ProcessInstanceState.Active.valueOf();
+    case 'Error':
+      return ProcessInstanceState.Error.valueOf();
+    case 'Completed':
+      return ProcessInstanceState.Completed.valueOf();
+    case 'Aborted':
+      return ProcessInstanceState.Aborted.valueOf();
+    case 'Suspended':
+      return ProcessInstanceState.Suspended.valueOf();
+    case 'Pending':
+      return ProcessInstanceState.Pending.valueOf();
+    default:
+      throw new Error(
+        `status ${status} is not one of the values of type ProcessInstanceState`,
+      );
+  }
+}
+
 export function mapToProcessInstanceDTO(
   processInstance: ProcessInstance,
 ): ProcessInstanceDTO {

--- a/plugins/orchestrator-common/src/generated/.METADATA.sha1
+++ b/plugins/orchestrator-common/src/generated/.METADATA.sha1
@@ -1,1 +1,1 @@
-3ddbf7d37a25ce03dc7f75dcfe7f7c6c3767b8a7
+702b0fdee7e88ecd0bf41de1cca2ccdcd2faa793

--- a/plugins/orchestrator-common/src/openapi/openapi.yaml
+++ b/plugins/orchestrator-common/src/openapi/openapi.yaml
@@ -692,6 +692,9 @@ components:
               LIKE,
               BETWEEN,
             ]
+        # The `value` field should be defined as follows. However, due to a bug (open since May 2023),
+        # https://github.com/OpenAPITools/openapi-generator/issues/15701
+        # using `oneOf` to specify enum values for a property in the schema doesn't generate the enums correctly.
         value:
           oneOf:
             - type: string
@@ -703,6 +706,11 @@ components:
                   - type: string
                   - type: number
                   - type: boolean
+        #     - type: string
+        #       enum:
+        #         - A
+        #         - B
+
     InputSchemaResponseDTO:
       type: object
       properties:


### PR DESCRIPTION
Add filter by enum.

At the moment, there is no an easy way to identify enumerators from the DataIndex GraphQL schema. 
Each enum needs to be manually supported. At this stage, the only supported enum is `status` from `ProcessInstanceDTO`
with operators `Equal` and `In` .

[FLPATH-1759](https://issues.redhat.com/browse/FLPATH-1759)