### PR TITLE
fix(cli): allow mutable install for monorepo yarn.lock with deprecated flags

### DIFF
--- a/.changeset/pretty-humans-pump.md
+++ b/.changeset/pretty-humans-pump.md
@@ -1,0 +1,7 @@
+---
+"@janus-idp/cli": patch
+---
+
+fix(cli): allow mutable install for monorepo yarn.lock with deprecated flags
+
+This change updates the CLI to use `--no-immutable` when a plugin package or monorepo `yarn.lock` file is used during the `export-dynamic-plugin` command with deprecated flags. Explicitly passing this flag avoids the default Yarn 3.x behavior of `--immutable` when the command is run in a CI environment.

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-code.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-code.ts
@@ -337,7 +337,7 @@ export async function backend(
       ? `${yarn} install --production${
           yarnLockExists ? ' --frozen-lockfile' : ''
         }`
-      : `${yarn} install${yarnLockExists ? ' --immutable' : ''}`;
+      : `${yarn} install${yarnLockExists ? ' --immutable' : ' --no-immutable'}`;
 
     await Task.forCommand(yarnInstall, { cwd: target, optional: false });
     await fs.remove(paths.resolveTarget('dist-dynamic', '.yarn'));


### PR DESCRIPTION
This change updates the CLI to use `--no-immutable` when a plugin package or monorepo `yarn.lock` file is used during the `export-dynamic-plugin` command with deprecated flags. Explicitly passing this flag avoids the default Yarn 3.x behavior of `--immutable` when the command is run in a CI environment.

Signed-off-by: Paul Schultz <pschultz@pobox.com>
