### PR TITLE
fix(rbac): fix rbac-backend startup

### DIFF
--- a/.changeset/thirty-pets-buy.md
+++ b/.changeset/thirty-pets-buy.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/backstage-plugin-rbac-backend": patch
+---
+
+Fix broken plugin startup: don't attempt to store permission policies that are already stored.

--- a/plugins/rbac-backend/src/admin-permissions/admin-creation.test.ts
+++ b/plugins/rbac-backend/src/admin-permissions/admin-creation.test.ts
@@ -111,6 +111,28 @@ describe('Admin Creation', () => {
       expect(enfPermission).toEqual(permissions);
     });
 
+    it(`should not assign an admin to the permissions if permissions are already assigned`, async () => {
+      await expect(async () => {
+        await setAdminPermissions(enfDelegate, auditLoggerMock);
+      }).not.toThrow();
+    });
+
+    it(`should assign an admin to the new permission`, async () => {
+      const newDefaultPermission = [
+        adminRole,
+        'something-new',
+        'create',
+        'allow',
+      ];
+      await enfDelegate.addPolicy(newDefaultPermission);
+      await setAdminPermissions(enfDelegate, auditLoggerMock);
+      const enfPermission = await enfDelegate.getFilteredPolicy(
+        0,
+        ...newDefaultPermission,
+      );
+      expect(enfPermission.length).toEqual(1);
+    });
+
     it('should fail to build the admin permissions, problem with creating role metadata', async () => {
       roleMetadataStorageMock.findRoleMetadata = jest
         .fn()

--- a/plugins/rbac-backend/src/admin-permissions/admin-creation.ts
+++ b/plugins/rbac-backend/src/admin-permissions/admin-creation.ts
@@ -122,7 +122,13 @@ const addAdminPermissions = async (
   enf: EnforcerDelegate,
   auditLogger: AuditLogger,
 ) => {
-  await enf.addPolicies(policies);
+  const policiesToAdd: string[][] = [];
+  for (const policy of policies) {
+    if (!(await enf.hasPolicy(...policy))) {
+      policiesToAdd.push(policy);
+    }
+  }
+  await enf.addPolicies(policiesToAdd);
 
   await auditLogger.auditLog<PermissionAuditInfo>({
     actorId: RBAC_BACKEND,

--- a/plugins/rbac-backend/src/policies/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/policies/permission-policy.test.ts
@@ -2093,7 +2093,7 @@ function newConfig(
       permission: {
         rbac: {
           'policies-csv-file': permFile || csvPermFile,
-          policyFileReload: true,
+          policyFileReload: false,
           admin: {
             users: users || testUsers,
             superUsers: superUsers,


### PR DESCRIPTION
### What does this pull request do

Fix rbac-backend plugin startup.
Fix test warning/error related to activated file watchers. 

### What does this pull request fix:

Fixes https://issues.redhat.com/browse/RHIDP-4732