### PR TITLE
chore(deps): update @backstage/backend-defaults to fix Error: Unexpected plugin lifecycle service

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@backstage/backend-app-api": "1.0.0",
-    "@backstage/backend-defaults": "0.5.0",
+    "@backstage/backend-defaults": "0.5.2",
     "@backstage/backend-dynamic-feature-service": "0.4.1",
     "@backstage/backend-plugin-api": "1.0.0",
     "@backstage/cli-node": "0.2.8",

--- a/plugins/aap-backend/package.json
+++ b/plugins/aap-backend/package.json
@@ -44,7 +44,7 @@
     "@backstage/plugin-catalog-node": "^1.13.0"
   },
   "devDependencies": {
-    "@backstage/backend-defaults": "0.5.0",
+    "@backstage/backend-defaults": "0.5.2",
     "@backstage/backend-test-utils": "1.0.0",
     "@backstage/cli": "0.27.1",
     "@backstage/config": "1.2.0",

--- a/plugins/bulk-import-backend/package.json
+++ b/plugins/bulk-import-backend/package.json
@@ -43,7 +43,7 @@
     "openapi": "./scripts/openapi.sh"
   },
   "dependencies": {
-    "@backstage/backend-defaults": "^0.5.0",
+    "@backstage/backend-defaults": "0.5.2",
     "@backstage/backend-plugin-api": "^1.0.0",
     "@backstage/errors": "^1.2.4",
     "@backstage/integration": "^1.15.0",

--- a/plugins/keycloak-backend/package.json
+++ b/plugins/keycloak-backend/package.json
@@ -52,7 +52,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@backstage/backend-defaults": "0.5.0",
+    "@backstage/backend-defaults": "0.5.2",
     "@backstage/backend-test-utils": "1.0.0",
     "@backstage/cli": "0.27.1",
     "@backstage/config": "1.2.0",

--- a/plugins/kiali-backend/package.json
+++ b/plugins/kiali-backend/package.json
@@ -42,7 +42,7 @@
   },
   "configSchema": "config.d.ts",
   "dependencies": {
-    "@backstage/backend-defaults": "^0.5.0",
+    "@backstage/backend-defaults": "0.5.2",
     "@backstage/backend-plugin-api": "^1.0.0",
     "@backstage/catalog-client": "^1.7.0",
     "@backstage/catalog-model": "^1.7.0",

--- a/plugins/lightspeed-backend/package.json
+++ b/plugins/lightspeed-backend/package.json
@@ -41,7 +41,7 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage/backend-defaults": "^0.5.0",
+    "@backstage/backend-defaults": "0.5.2",
     "@backstage/backend-plugin-api": "^1.0.0",
     "@langchain/core": "^0.2.30",
     "@langchain/openai": "^0.2.8",

--- a/plugins/matomo-backend/package.json
+++ b/plugins/matomo-backend/package.json
@@ -42,7 +42,7 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage/backend-defaults": "^0.5.0",
+    "@backstage/backend-defaults": "0.5.2",
     "@backstage/backend-plugin-api": "^1.0.0",
     "@backstage/config": "^1.2.0",
     "@types/express": "4.17.20",

--- a/plugins/ocm-backend/package.json
+++ b/plugins/ocm-backend/package.json
@@ -45,7 +45,7 @@
   },
   "configSchema": "config.d.ts",
   "dependencies": {
-    "@backstage/backend-defaults": "^0.5.0",
+    "@backstage/backend-defaults": "0.5.2",
     "@backstage/backend-openapi-utils": "^0.1.18",
     "@backstage/backend-plugin-api": "^1.0.0",
     "@backstage/catalog-model": "^1.7.0",

--- a/plugins/orchestrator-backend/package.json
+++ b/plugins/orchestrator-backend/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.25.0",
-    "@backstage/backend-defaults": "^0.5.0",
+    "@backstage/backend-defaults": "0.5.2",
     "@backstage/backend-plugin-api": "^1.0.0",
     "@backstage/backend-tasks": "^0.6.1",
     "@backstage/catalog-client": "^1.7.0",

--- a/plugins/rbac-backend/package.json
+++ b/plugins/rbac-backend/package.json
@@ -34,7 +34,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-defaults": "^0.5.0",
+    "@backstage/backend-defaults": "0.5.2",
     "@backstage/backend-plugin-api": "^1.0.0",
     "@backstage/catalog-client": "^1.7.0",
     "@backstage/catalog-model": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,85 +3038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@npm:0.5.0":
-  version: 0.5.0
-  resolution: "@backstage/backend-defaults@npm:0.5.0"
-  dependencies:
-    "@aws-sdk/abort-controller": ^3.347.0
-    "@aws-sdk/client-codecommit": ^3.350.0
-    "@aws-sdk/client-s3": ^3.350.0
-    "@aws-sdk/credential-providers": ^3.350.0
-    "@aws-sdk/types": ^3.347.0
-    "@backstage/backend-app-api": ^1.0.0
-    "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-dev-utils": ^0.1.5
-    "@backstage/backend-plugin-api": ^1.0.0
-    "@backstage/cli-common": ^0.1.14
-    "@backstage/cli-node": ^0.2.8
-    "@backstage/config": ^1.2.0
-    "@backstage/config-loader": ^1.9.1
-    "@backstage/errors": ^1.2.4
-    "@backstage/integration": ^1.15.0
-    "@backstage/integration-aws-node": ^0.1.12
-    "@backstage/plugin-auth-node": ^0.5.2
-    "@backstage/plugin-events-node": ^0.4.0
-    "@backstage/plugin-permission-node": ^0.8.3
-    "@backstage/types": ^1.1.1
-    "@google-cloud/storage": ^7.0.0
-    "@keyv/memcache": ^1.3.5
-    "@keyv/redis": ^2.5.3
-    "@manypkg/get-packages": ^1.1.3
-    "@octokit/rest": ^19.0.3
-    "@opentelemetry/api": ^1.3.0
-    "@types/cors": ^2.8.6
-    "@types/express": ^4.17.6
-    archiver: ^7.0.0
-    base64-stream: ^1.0.0
-    better-sqlite3: ^11.0.0
-    compression: ^1.7.4
-    concat-stream: ^2.0.0
-    cookie: ^0.6.0
-    cors: ^2.8.5
-    cron: ^3.0.0
-    express: ^4.17.1
-    express-promise-router: ^4.1.0
-    fs-extra: ^11.2.0
-    git-url-parse: ^14.0.0
-    helmet: ^6.0.0
-    isomorphic-git: ^1.23.0
-    jose: ^5.0.0
-    keyv: ^4.5.2
-    knex: ^3.0.0
-    lodash: ^4.17.21
-    logform: ^2.3.2
-    luxon: ^3.0.0
-    minimatch: ^9.0.0
-    minimist: ^1.2.5
-    morgan: ^1.10.0
-    mysql2: ^3.0.0
-    node-fetch: ^2.7.0
-    node-forge: ^1.3.1
-    p-limit: ^3.1.0
-    path-to-regexp: ^8.0.0
-    pg: ^8.11.3
-    pg-connection-string: ^2.3.0
-    pg-format: ^1.0.4
-    raw-body: ^2.4.1
-    selfsigned: ^2.0.0
-    stoppable: ^1.1.0
-    tar: ^6.1.12
-    triple-beam: ^1.4.1
-    uuid: ^9.0.0
-    winston: ^3.2.1
-    winston-transport: ^4.5.0
-    yauzl: ^3.0.0
-    yn: ^4.0.0
-    zod: ^3.22.4
-  checksum: ff0b20ca44fe3412d031676768d31598dc64a2bef5ca654ded3d533ab692030d38ea28ba64c25ae9cb63615ce391322f8a929df57dd1a51890bcadd5fd61f308
-  languageName: node
-  linkType: hard
-
-"@backstage/backend-defaults@npm:^0.5.0, @backstage/backend-defaults@npm:^0.5.2":
+"@backstage/backend-defaults@npm:0.5.2, @backstage/backend-defaults@npm:^0.5.0, @backstage/backend-defaults@npm:^0.5.2":
   version: 0.5.2
   resolution: "@backstage/backend-defaults@npm:0.5.2"
   dependencies:
@@ -8627,7 +8549,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@janus-idp/backstage-plugin-aap-backend@workspace:plugins/aap-backend"
   dependencies:
-    "@backstage/backend-defaults": 0.5.0
+    "@backstage/backend-defaults": 0.5.2
     "@backstage/backend-plugin-api": ^1.0.0
     "@backstage/backend-test-utils": 1.0.0
     "@backstage/catalog-model": ^1.7.0
@@ -8721,7 +8643,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@janus-idp/backstage-plugin-bulk-import-backend@workspace:plugins/bulk-import-backend"
   dependencies:
-    "@backstage/backend-defaults": ^0.5.0
+    "@backstage/backend-defaults": 0.5.2
     "@backstage/backend-plugin-api": ^1.0.0
     "@backstage/backend-test-utils": 1.0.0
     "@backstage/catalog-client": 1.7.0
@@ -8846,7 +8768,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@janus-idp/backstage-plugin-keycloak-backend@workspace:plugins/keycloak-backend"
   dependencies:
-    "@backstage/backend-defaults": 0.5.0
+    "@backstage/backend-defaults": 0.5.2
     "@backstage/backend-plugin-api": ^1.0.0
     "@backstage/backend-test-utils": 1.0.0
     "@backstage/catalog-model": ^1.7.0
@@ -8871,7 +8793,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@janus-idp/backstage-plugin-kiali-backend@workspace:plugins/kiali-backend"
   dependencies:
-    "@backstage/backend-defaults": ^0.5.0
+    "@backstage/backend-defaults": 0.5.2
     "@backstage/backend-plugin-api": ^1.0.0
     "@backstage/backend-test-utils": 1.0.0
     "@backstage/catalog-client": ^1.7.0
@@ -8955,7 +8877,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@janus-idp/backstage-plugin-lightspeed-backend@workspace:plugins/lightspeed-backend"
   dependencies:
-    "@backstage/backend-defaults": ^0.5.0
+    "@backstage/backend-defaults": 0.5.2
     "@backstage/backend-plugin-api": ^1.0.0
     "@backstage/backend-test-utils": 1.0.0
     "@backstage/cli": 0.27.1
@@ -9007,7 +8929,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@janus-idp/backstage-plugin-matomo-backend@workspace:plugins/matomo-backend"
   dependencies:
-    "@backstage/backend-defaults": ^0.5.0
+    "@backstage/backend-defaults": 0.5.2
     "@backstage/backend-plugin-api": ^1.0.0
     "@backstage/cli": 0.27.1
     "@backstage/config": ^1.2.0
@@ -9059,7 +8981,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@janus-idp/backstage-plugin-ocm-backend@workspace:plugins/ocm-backend"
   dependencies:
-    "@backstage/backend-defaults": ^0.5.0
+    "@backstage/backend-defaults": 0.5.2
     "@backstage/backend-dynamic-feature-service": 0.4.1
     "@backstage/backend-openapi-utils": ^0.1.18
     "@backstage/backend-plugin-api": ^1.0.0
@@ -9141,7 +9063,7 @@ __metadata:
   resolution: "@janus-idp/backstage-plugin-orchestrator-backend@workspace:plugins/orchestrator-backend"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-defaults": ^0.5.0
+    "@backstage/backend-defaults": 0.5.2
     "@backstage/backend-plugin-api": ^1.0.0
     "@backstage/backend-tasks": ^0.6.1
     "@backstage/backend-test-utils": 1.0.0
@@ -9386,7 +9308,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@janus-idp/backstage-plugin-rbac-backend@workspace:plugins/rbac-backend"
   dependencies:
-    "@backstage/backend-defaults": ^0.5.0
+    "@backstage/backend-defaults": 0.5.2
     "@backstage/backend-plugin-api": ^1.0.0
     "@backstage/backend-test-utils": 1.0.0
     "@backstage/catalog-client": ^1.7.0
@@ -22088,7 +22010,7 @@ __metadata:
   resolution: "backend@workspace:packages/backend"
   dependencies:
     "@backstage/backend-app-api": 1.0.0
-    "@backstage/backend-defaults": 0.5.0
+    "@backstage/backend-defaults": 0.5.2
     "@backstage/backend-dynamic-feature-service": 0.4.1
     "@backstage/backend-plugin-api": 1.0.0
     "@backstage/cli": 0.27.1


### PR DESCRIPTION
This upgrade of `@backstage/backend-defaults` is aligned with Backstage 1.32 dependency rule:

```
    "@backstage/backend-defaults": "^0.5.2",
```

/cc @schultzp2020 @debsmita1 