### PR TITLE
chore: add deprecate note for topology plugins

### DIFF
--- a/plugins/topology-common/README.md
+++ b/plugins/topology-common/README.md
@@ -1,0 +1,3 @@
+# Deprecated
+
+This package has been moved to the [backstage-community/plugins](https://github.com/backstage/community-plugins) repository. Migrate to using `@backstage-community/plugin-topology-common` instead.

--- a/plugins/topology/README.md
+++ b/plugins/topology/README.md
@@ -1,0 +1,3 @@
+# Deprecated
+
+This package has been moved to the [backstage-community/plugins](https://github.com/backstage/community-plugins) repository. Migrate to using `@backstage-community/plugin-topology` instead.


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHIDP-4257 