### PR TITLE
fix(cli): use cli directly as a fallback

### DIFF
--- a/.changeset/old-trees-tease.md
+++ b/.changeset/old-trees-tease.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+fix(cli): try using npx if a plugin package does not have an export-dynamic script


### PR DESCRIPTION
This commit changes the CLI to try generating a command to export a plugin package as a dynamic plugin if the plugin package doesn't have an export-dynamic script defined.

This fixes [RHIDP-4828](https://issues.redhat.com/browse/RHIDP-4828)