### PR TITLE
fix(orchestrator): pass also initial form data to custom decorator

### DIFF
--- a/.changeset/cyan-tigers-jam.md
+++ b/.changeset/cyan-tigers-jam.md
@@ -1,0 +1,7 @@
+---
+"@janus-idp/backstage-plugin-orchestrator-form-react": patch
+"@janus-idp/backstage-plugin-orchestrator-form-api": patch
+"@janus-idp/backstage-plugin-orchestrator": patch
+---
+
+pass also initial form data to custom decorator

--- a/plugins/orchestrator-form-api/src/api.ts
+++ b/plugins/orchestrator-form-api/src/api.ts
@@ -41,6 +41,7 @@ export interface OrchestratorFormApi {
   getFormDecorator(
     schema: JSONSchema7,
     uiSchema: UiSchema<JsonObject, JSONSchema7>,
+    initialFormData?: JsonObject
   ): OrchestratorFormDecorator;
 }
 

--- a/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
+++ b/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
@@ -135,16 +135,17 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
 const OrchestratorFormWrapper = ({
   schema,
   uiSchema,
+  formData,
   ...props
 }: OrchestratorFormWrapperProps) => {
   const formApi =
     useApiHolder().get(orchestratorFormApiRef) || defaultFormExtensionsApi;
   const NewComponent = React.useMemo(() => {
-    const formDecorator = formApi.getFormDecorator(schema, uiSchema);
+    const formDecorator = formApi.getFormDecorator(schema, uiSchema, formData);
     return formDecorator(FormComponent);
-  }, [schema, formApi, uiSchema]);
+  }, [schema, formApi, uiSchema, formData]);
   return (
-    <WrapperFormPropsContext.Provider value={{ schema, uiSchema, ...props }}>
+    <WrapperFormPropsContext.Provider value={{ schema, uiSchema, formData, ...props }}>
       <NewComponent />
     </WrapperFormPropsContext.Provider>
   );


### PR DESCRIPTION
backport https://github.com/janus-idp/backstage-plugins/pull/2562

The plugin containing the custom form decorator needs the initial form data to initialize the custom widgets correctly.
This change will enable resolving https://issues.redhat.com/browse/FLPATH-1878