### PR TITLE
feat(cli): add flags to handle native deps

### DIFF
--- a/.changeset/long-pants-allow.md
+++ b/.changeset/long-pants-allow.md
@@ -1,0 +1,9 @@
+---
+"@janus-idp/cli": patch
+---
+
+This change adds two new flags to handle native module dependencies.
+
+- `--allow-native-package [package-name...]`: flag to selectively allow native packages when exporting a dynamic plugin and allowing it's installation into the exported dynamic plugin.
+
+- `--suppress-native-package [package-name..]`: flag which replaces the native package with an empty package during export, preventing the native package's inclusion into the exported dynamic plugin's private dependencies.

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -56,7 +56,10 @@ export async function backend(opts: OptionValues): Promise<string> {
     );
   }
 
+  const derivedPackageName = `${pkg.name}-dynamic`;
   const packagesToEmbed = (opts.embedPackage || []) as string[];
+  const allowNative = (opts.allowNativePackage || []) as string[];
+  const suppressNative = (opts.suppressNativePackage || []) as string[];
   const monoRepoPackages = await getPackages(paths.targetDir);
   const embeddedResolvedPackages = await searchEmbedded(
     pkg,
@@ -118,6 +121,30 @@ ${
     : ''
 }`,
   );
+
+  if (suppressNative.length > 0) {
+    for (const toSuppress of suppressNative) {
+      await fs.mkdirs(path.join(target, 'embedded', toSuppress));
+      await fs.writeFile(
+        path.join(target, 'embedded', toSuppress, 'package.json'),
+        JSON.stringify(
+          {
+            name: toSuppress,
+            main: 'index.js',
+          },
+          undefined,
+          2,
+        ),
+      );
+      await fs.writeFile(
+        path.join(target, 'embedded', toSuppress, 'index.js'),
+        `
+throw new Error(
+  'The package "${toSuppress}" has been marked as a native module and removed from this dynamic plugin package "${derivedPackageName}"'
+);`,
+      );
+    }
+  }
 
   const embeddedPeerDependencies: {
     [key: string]: string;
@@ -247,7 +274,7 @@ ${
     monoRepoPackages,
     sharedPackages: sharedPackagesRules,
     overridding: {
-      name: `${pkg.name}-dynamic`,
+      name: derivedPackageName,
       bundleDependencies: true,
       // We remove scripts, because they do not make sense for this derived package.
       // They even bring errors, especially the pre-pack and post-pack ones:
@@ -256,7 +283,14 @@ ${
       // which are related to the packaging of the original static package.
       scripts: {},
     },
-    additionalResolutions: embeddedDependenciesResolutions,
+    additionalResolutions: {
+      ...embeddedDependenciesResolutions,
+      ...suppressNative
+        .map((nativePkg: string) => ({
+          [nativePkg]: path.join('file:./embedded', nativePkg),
+        }))
+        .reduce((prev, curr) => ({ ...prev, ...curr }), {}),
+    },
     after(mainPkg) {
       if (Object.keys(embeddedPeerDependencies).length === 0) {
         return;
@@ -407,9 +441,12 @@ ${
 
     // Check whether private dependencies contain native modules, and fail for now (not supported).
     const nativePackages: string[] = [];
-    for await (const n of gatherNativeModules(target)) {
-      nativePackages.push(n);
+    for await (const nativePkg of gatherNativeModules(target)) {
+      if (!allowNative.includes(nativePkg)) {
+        nativePackages.push(nativePkg);
+      }
     }
+
     if (nativePackages.length > 0) {
       throw new Error(
         `Dynamic plugins do not support native plugins. the following native modules have been transitively detected:${chalk.cyan(

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -106,6 +106,14 @@ export function registerScriptCommand(program: Command) {
       {},
     )
     .option(
+      '--allow-native-package [package-name...]',
+      'Optional list of native packages names that can be included in the exported plugin',
+    )
+    .option(
+      '--suppress-native-package [package-name...]',
+      'Optional list of native package names to be excluded from the exported plugin',
+    )
+    .option(
       '--no-install',
       'Do not run `yarn install` to fill the dynamic plugin `node_modules` folder (backend plugin only).',
     )


### PR DESCRIPTION
This change introduces two new flags to the CLI to handle transitive dependencies on packages containing native modules.  `--allow-native-package [package-name...]` to selectively allow native packages when exporting a dynamic plugin and allowing it's installation into the exported dynamic plugin and `--suppress-native-package [package-name..]` which replaces the native package with an empty package during export, preventing the native package's inclusion into the exported dynamic plugin's private dependencies.
