### PR TITLE
feat: checkPluginVersion.sh bump plugins for 1.4.0 release

### DIFF
--- a/.changeset/packages-cli.md
+++ b/.changeset/packages-cli.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/cli": minor
+---
+
+Bump packages/cli to 1.19.0 in main branch, in prep for release of 1.4.0
+

--- a/.changeset/plugins-aap-backend.md
+++ b/.changeset/plugins-aap-backend.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-plugin-aap-backend": minor
+---
+
+Bump plugins/aap-backend to 2.3.0 in main branch, in prep for release of 1.4.0
+

--- a/.changeset/plugins-audit-log-node.md
+++ b/.changeset/plugins-audit-log-node.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-plugin-audit-log-node": minor
+---
+
+Bump plugins/audit-log-node to 1.8.0 in main branch, in prep for release of 1.4.0
+

--- a/.changeset/plugins-kiali-backend.md
+++ b/.changeset/plugins-kiali-backend.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-plugin-kiali-backend": minor
+---
+
+Bump plugins/kiali-backend to 1.21.0 in main branch, in prep for release of 1.4.0
+

--- a/.changeset/plugins-kiali.md
+++ b/.changeset/plugins-kiali.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-plugin-kiali": minor
+---
+
+Bump plugins/kiali to 1.35.0 in main branch, in prep for release of 1.4.0
+

--- a/.changeset/plugins-kubernetes-actions.md
+++ b/.changeset/plugins-kubernetes-actions.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-scaffolder-backend-module-kubernetes": minor
+---
+
+Bump plugins/kubernetes-actions to 2.3.0 in main branch, in prep for release of 1.4.0
+

--- a/.changeset/plugins-scaffolder-annotator-action.md
+++ b/.changeset/plugins-scaffolder-annotator-action.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-scaffolder-backend-module-annotator": minor
+---
+
+Bump plugins/scaffolder-annotator-action to 2.3.0 in main branch, in prep for release of 1.4.0
+

--- a/.changeset/plugins-shared-react.md
+++ b/.changeset/plugins-shared-react.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/shared-react": minor
+---
+
+Bump plugins/shared-react to 2.14.0 in main branch, in prep for release of 1.4.0
+

--- a/.changeset/plugins-web-terminal.md
+++ b/.changeset/plugins-web-terminal.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-plugin-web-terminal": minor
+---
+
+Bump plugins/web-terminal to 1.12.0 in main branch, in prep for release of 1.4.0
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "private": true,
   "engines": {
     "node": "20"

--- a/packages/cli/.versionhistory.md
+++ b/packages/cli/.versionhistory.md
@@ -1,2 +1,3 @@
 - Bumped to 1.8.0 in main branch for next release 1.2.0
 - Bumped to 1.14.0 in main branch for next release 1.3.0
+- Bumped to 1.19.0 in main branch, in prep for release of 1.4.0

--- a/plugins/aap-backend/.versionhistory.md
+++ b/plugins/aap-backend/.versionhistory.md
@@ -1,2 +1,3 @@
 - Bumped to 1.6.0 in main branch for next release 1.2.0
 - Bumped to 1.10.0 in main branch for next release 1.3.0
+- Bumped to 2.3.0 in main branch, in prep for release of 1.4.0

--- a/plugins/audit-log-node/.versionhistory.md
+++ b/plugins/audit-log-node/.versionhistory.md
@@ -1,1 +1,2 @@
 - Bumped to 1.5.0 in main branch for next release 1.3.0
+- Bumped to 1.8.0 in main branch, in prep for release of 1.4.0

--- a/plugins/kiali-backend/.versionhistory.md
+++ b/plugins/kiali-backend/.versionhistory.md
@@ -1,1 +1,2 @@
 - Bumped to 1.17.0 in main branch for next release 1.3.0
+- Bumped to 1.21.0 in main branch, in prep for release of 1.4.0

--- a/plugins/kiali/.versionhistory.md
+++ b/plugins/kiali/.versionhistory.md
@@ -1,1 +1,2 @@
 - Bumped to 1.31.0 in main branch for next release 1.3.0
+- Bumped to 1.35.0 in main branch, in prep for release of 1.4.0

--- a/plugins/kubernetes-actions/.versionhistory.md
+++ b/plugins/kubernetes-actions/.versionhistory.md
@@ -1,2 +1,3 @@
 - Bumped to 1.4.0 in main branch for next release 1.2.0
 - Bumped to 1.8.0 in main branch for next release 1.3.0
+- Bumped to 2.3.0 in main branch, in prep for release of 1.4.0

--- a/plugins/scaffolder-annotator-action/.versionhistory.md
+++ b/plugins/scaffolder-annotator-action/.versionhistory.md
@@ -1,1 +1,2 @@
 - Bumped to 1.4.0 in main branch for next release 1.3.0
+- Bumped to 2.3.0 in main branch, in prep for release of 1.4.0

--- a/plugins/shared-react/.versionhistory.md
+++ b/plugins/shared-react/.versionhistory.md
@@ -1,2 +1,3 @@
 - Bumped to 2.6.0 in main branch for next release 1.2.0
 - Bumped to 2.11.0 in main branch for next release 1.3.0
+- Bumped to 2.14.0 in main branch, in prep for release of 1.4.0

--- a/plugins/web-terminal/.versionhistory.md
+++ b/plugins/web-terminal/.versionhistory.md
@@ -1,2 +1,3 @@
 - Bumped to 1.4.0 in main branch for next release 1.2.0
 - Bumped to 1.9.0 in main branch for next release 1.3.0
+- Bumped to 1.12.0 in main branch, in prep for release of 1.4.0


### PR DESCRIPTION
- **feat: checkPluginVersion.sh bump ./ to 3.5.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump packages/cli to 1.19.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/aap-backend to 2.3.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/audit-log-node to 1.8.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/kiali to 1.35.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/kiali-backend to 1.21.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/kubernetes-actions to 2.3.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/scaffolder-annotator-action to 2.3.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/shared-react to 2.14.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/web-terminal to 1.12.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  