### PR TITLE
fix(orchestrator): multiple bug fixes related to execution form

### DIFF
--- a/.changeset/warm-clouds-compete.md
+++ b/.changeset/warm-clouds-compete.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-plugin-orchestrator-form-react": patch
+"@janus-idp/backstage-plugin-orchestrator": patch
+---
+
+multiple bug fixes related to execution form

--- a/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
+++ b/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
@@ -24,15 +24,22 @@ const getNumSteps = (schema: JSONSchema7): number | undefined => {
 
 const SingleStepForm = ({
   schema,
-  formData,
-  onChange,
+  initialFormData,
+  onSubmit,
   uiSchema,
 }: {
   schema: JSONSchema7;
-  formData: JsonObject;
-  onChange: (formData: JsonObject) => void;
+  initialFormData?: JsonObject;
+  onSubmit: (formData: JsonObject) => void;
   uiSchema: UiSchema<JsonObject>;
 }) => {
+  const [_initialFormData, setInitialFormData]  = React.useState<JsonObject | undefined>(initialFormData) 
+  const _onSubmit = (formData: JsonObject) => {    
+    // Since the review step is outside of the MuiForm component in SingleStepForm, we need to load the current values when navigating back.    
+    setInitialFormData(formData);
+    onSubmit(formData);
+  }
+
   const steps = React.useMemo<OrchestratorFormStep[]>(() => {
     return [
       {
@@ -41,8 +48,8 @@ const SingleStepForm = ({
         content: (
           <OrchestratorFormWrapper
             schema={{ ...schema, title: '' }}
-            formData={formData}
-            onChange={onChange}
+            initialFormData={_initialFormData}
+            onSubmit={_onSubmit}
             uiSchema={uiSchema}
           >
             <OrchestratorFormToolbar />
@@ -50,7 +57,7 @@ const SingleStepForm = ({
         ),
       },
     ];
-  }, [schema, formData, onChange, uiSchema]);
+  }, [schema, _initialFormData, onSubmit, uiSchema]);
   return <OrchestratorFormStepper steps={steps} />;
 };
 
@@ -59,7 +66,7 @@ type OrchestratorFormProps = {
   isExecuting: boolean;
   handleExecute: (parameters: JsonObject) => Promise<void>;
   data?: JsonObject;
-  isDataReadonly?: boolean;
+  isDataReadonly?: boolean;  
 };
 
 const OrchestratorForm = ({
@@ -80,7 +87,7 @@ const OrchestratorForm = ({
     handleExecute(formData || {});
   }, [formData, handleExecute]);
 
-  const onChange = React.useCallback(
+  const onSubmit = React.useCallback(
     (_formData: JsonObject) => {
       setFormData(_formData);
     },
@@ -113,17 +120,17 @@ const OrchestratorForm = ({
         <OrchestratorFormWrapper
           schema={schema}
           numStepsInMultiStepSchema={numStepsInMultiStepSchema}
-          formData={formData}
-          onChange={onChange}
+          onSubmit={onSubmit}
           uiSchema={uiSchema}
+          initialFormData={data}
         >
           <Fragment />
         </OrchestratorFormWrapper> // it is required to pass the fragment so rjsf won't generate a Submit button
       ) : (
         <SingleStepForm
           schema={schema}
-          onChange={onChange}
-          formData={formData}
+          onSubmit={onSubmit}
+          initialFormData={data}          
           uiSchema={uiSchema}
         />
       )}

--- a/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
+++ b/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
@@ -75,7 +75,7 @@ export const ExecuteWorkflowPage = () => {
         const response = await orchestratorApi.executeWorkflow({
           workflowId,
           parameters,
-          businessKey: effectiveInstanceId,
+          businessKey: assessmentInstanceId,
         });
         navigate(instanceLink({ instanceId: response.data.id }));
       } catch (err) {
@@ -84,7 +84,7 @@ export const ExecuteWorkflowPage = () => {
         setIsExecuting(false);
       }
     },
-    [orchestratorApi, workflowId, navigate, instanceLink, effectiveInstanceId],
+    [orchestratorApi, workflowId, navigate, instanceLink, assessmentInstanceId],
   );
 
   const error = responseError || workflowNameError;


### PR DESCRIPTION
1. businessKey fixed to be only a parent assessment workflow, to avoid having workflow runs shown as assessed by themselves, and then rerun shows the inputs as readonly.
2. fixed rerendering of form on every change, which was caused by passing formData to decorator. This constant rerendering causes the form to be unusable. instead only the initial data should be passed to the decorator. 