### PR TITLE
fix(cli): adjust embedded module searching

### DIFF
--- a/.changeset/hungry-turtles-sin.md
+++ b/.changeset/hungry-turtles-sin.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+fix(cli): adjust embedded module searching. The CLI attempts a require call to detect built embedded packages, this change adjusts the directory this require is attempted from to be at the level of discovered package instead of the dynamic plugin package.

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -65,7 +65,7 @@ export async function backend(opts: OptionValues): Promise<string> {
     pkg,
     packagesToEmbed,
     monoRepoPackages,
-    createRequire(`${paths.targetDir}/package.json`),
+    createRequire(path.join(paths.targetDir, 'package.json')),
     [],
   );
   const embeddedPackages = embeddedResolvedPackages.map(e => e.packageName);
@@ -611,13 +611,13 @@ async function searchEmbedded(
             parentPackageName: pkg.name,
             alreadyPacked,
           });
-
+          // scan for embedded packages under the resolved package
           resolved.push(
             ...(await searchEmbedded(
               resolvedPackage,
               embedded,
               monoRepoPackages,
-              req,
+              createRequire(path.join(resolvedPackageDir, 'package.json')),
               [...alreadyResolved, ...resolved],
             )),
           );


### PR DESCRIPTION
This change adjusts the directory used when the CLI attempts a require call when discovering a built embedded package from using the dynamic plugin package to using the package of the discovered built embedded package.

This fixes [RHIDP-5014](https://issues.redhat.com/browse/RHIDP-5014)