### PR TITLE
fix(cli): redirect yarn install output

### DIFF
--- a/.changeset/rich-crews-provide.md
+++ b/.changeset/rich-crews-provide.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+fix(cli): redirect install output. This change updates the CLI so that stdout of the `yarn install` command is redirected to a file. This prevents a possible buffer overflow error that can occur but also gives the added benefit of making the install output available for troubleshooting should a dynamic plugin fail to export. On successful installation and plugin validation the yarn install log file will be removed.

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -350,11 +350,13 @@ throw new Error(
     Task.log(`Installing private dependencies of the main package`);
 
     const version = execSync(`${yarn} --version`).toString().trim();
+    const logFile = 'yarn-install.log';
+    const redirect = `> ${logFile}`;
     const yarnInstall = version.startsWith('1.')
       ? `${yarn} install --production${
           yarnLockExists ? ' --frozen-lockfile' : ''
-        }`
-      : `${yarn} install${yarnLockExists ? ' --immutable' : ' --no-immutable'}`;
+        } ${redirect}`
+      : `${yarn} install${yarnLockExists ? ' --immutable' : ' --no-immutable'} ${redirect}`;
 
     await Task.forCommand(yarnInstall, { cwd: target, optional: false });
     await fs.remove(paths.resolveTarget(targetRelativePath, '.yarn'));
@@ -461,6 +463,8 @@ throw new Error(
     if (validateEntryPointsError) {
       throw new Error(validateEntryPointsError);
     }
+    // everything is fine, remove the yarn install log
+    await fs.remove(paths.resolveTarget(targetRelativePath, logFile));
   }
   return target;
 }


### PR DESCRIPTION
This change updates the CLI so that stdout of the `yarn install` command is redirected to a file.  On successful completion of `yarn install` and validation of the exported dynamic plugin the output file will be removed, otherwise the output file will be available for troubleshooting.

This fixes [RHIDP-5136](https://issues.redhat.com/browse/RHIDP-5136)