### PR TITLE
fix(cli): add a flag to relax version checks

### DIFF
--- a/.changeset/dull-pillows-unite.md
+++ b/.changeset/dull-pillows-unite.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+fix(cli): add a flag to relax semver checks. This change updates the CLI to add an option to relax the semver checks on a per-package basis to cater for plugins where it is known there should be runtime compabability due to no interface changes.

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -60,6 +60,7 @@ export async function backend(opts: OptionValues): Promise<string> {
   const packagesToEmbed = (opts.embedPackage || []) as string[];
   const allowNative = (opts.allowNativePackage || []) as string[];
   const suppressNative = (opts.suppressNativePackage || []) as string[];
+  const ignoreVersionCheck = (opts.ignoreVersionCheck || []) as string[];
   const monoRepoPackages = await getPackages(paths.targetDir);
   const embeddedResolvedPackages = await searchEmbedded(
     pkg,
@@ -299,7 +300,11 @@ throw new Error(
         `Hoisting peer dependencies of embedded packages to the main package`,
       );
       const mainPeerDependencies = mainPkg.peerDependencies || {};
-      addToMainDependencies(embeddedPeerDependencies, mainPeerDependencies);
+      addToMainDependencies(
+        embeddedPeerDependencies,
+        mainPeerDependencies,
+        ignoreVersionCheck,
+      );
       if (Object.keys(mainPeerDependencies).length > 0) {
         mainPkg.peerDependencies = mainPeerDependencies;
       }

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -114,6 +114,10 @@ export function registerScriptCommand(program: Command) {
       'Optional list of native package names to be excluded from the exported plugin',
     )
     .option(
+      '--ignore-version-check [packageName...]',
+      'Optional list of package names to ignore when doing semver dependency checks',
+    )
+    .option(
       '--no-install',
       'Do not run `yarn install` to fill the dynamic plugin `node_modules` folder (backend plugin only).',
     )


### PR DESCRIPTION
This change adds an `--ignore-version-check` flag to the CLI to allow for selectively ignoring the semver check the CLI performs when evaluating the plugin package dependencies.  This can be used to work around issues where a plugin has not been updated for awhile but it is known to work because it relies on interfaces and functions that have not changed.

duplicate of https://github.com/janus-idp/backstage-plugins/pull/2586 because GitHub is being funny. 