### PR TITLE
fix(cli): support single packages better

### DIFF
--- a/.changeset/red-meals-help.md
+++ b/.changeset/red-meals-help.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+fix(cli): support single packages better. This change fixes an issue in the `package-dynamic-plugins` command that prevents it from running properly in a single plugin project that does not have workspaces.

--- a/packages/cli/src/commands/package-dynamic-plugins/command.ts
+++ b/packages/cli/src/commands/package-dynamic-plugins/command.ts
@@ -41,9 +41,7 @@ export async function command(opts: OptionValues): Promise<void> {
     workspacePackageRole !== undefined
       ? PackageRoles.getRoleInfo(workspacePackageRole)
       : undefined;
-  const isMonoRepo =
-    typeof (workspacePackage.workspaces as PackageJson.WorkspaceConfig)
-      .packages !== 'undefined';
+  const isMonoRepo = typeof workspacePackage.workspaces !== 'undefined';
   // Find all plugin packages in the workspace
   const packages = isMonoRepo
     ? await discoverPluginPackages()


### PR DESCRIPTION
This change fixes an issue in the `package-dynamic-plugins` command that prevents it from running properly in a single plugin project which does not have workspaces.