### PR TITLE
feat(janus-idp/cli): package-dynamic-plugins default to linux/amd64 platform

### DIFF
--- a/.changeset/silly-nails-smell.md
+++ b/.changeset/silly-nails-smell.md
@@ -1,0 +1,7 @@
+---
+"@janus-idp/cli": minor
+---
+changes to package-dynamic-plugins command:
+
+- by default `--platform linux/amd64` is added to the command container build command
+- added a new flag `--platfrom` allow user to specify the platform for the container build command

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -190,6 +190,11 @@ export function registerScriptCommand(program: Command) {
       '-m, --marketplace-file <file>',
       'Marketplace yaml file. This is a Plugin entity definition for Marketplace.',
     )
+    .option(
+      '--platform <platform>',
+      'Platform to use when building the container image. Default is "linux/amd64". Can be set to "" to not set --platfrom flag in builder command.',
+      'linux/amd64',
+    )
     .action(
       lazy(() => import('./package-dynamic-plugins').then(m => m.command)),
     );

--- a/packages/cli/src/commands/package-dynamic-plugins/command.ts
+++ b/packages/cli/src/commands/package-dynamic-plugins/command.ts
@@ -20,6 +20,7 @@ export async function command(opts: OptionValues): Promise<void> {
     tag,
     useDocker,
     marketplaceFile,
+    platform,
   } = opts;
   if (!exportTo && !tag) {
     Task.error(
@@ -235,6 +236,9 @@ export async function command(opts: OptionValues): Promise<void> {
         flags.push(
           `--annotation io.backstage.marketplace/${pluginName}='${base64pluginInfo}'`,
         );
+      }
+      if (platform) {
+        flags.push(`--platform ${platform}`);
       }
       // run the command to generate the image
       Task.log(`Creating image using ${containerTool}`);


### PR DESCRIPTION
This also adds `--platfrom` flag that overrides the default `linux/amd64` platform

fixes https://issues.redhat.com/browse/RHIDP-5440