### PR TITLE
fix(cli): extend --ignore-version-check

### DIFF
--- a/.changeset/stale-penguins-tan.md
+++ b/.changeset/stale-penguins-tan.md
@@ -1,0 +1,7 @@
+---
+"@janus-idp/cli": patch
+---
+
+fix(cli): extend --ignore-version-check
+
+This change updates the cli's --ignore-version-check flag to also ignore the check performed on an embedded transitive dependencies that are moved to peer dependencies, when it is known that the mismatch is runtime compatible.

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-code.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-code.ts
@@ -168,14 +168,14 @@ export async function backend(
     embedModules({
       filter: filter,
       addDependency: (embeddedModule, dependencyName, newDependencyVersion) =>
-        addToDependenciesForModule(
-          {
+        addToDependenciesForModule({
+          dependency: {
             name: dependencyName,
             version: newDependencyVersion,
           },
-          dependenciesToAdd,
-          embeddedModule,
-        ),
+          dependencies: dependenciesToAdd,
+          module: embeddedModule,
+        }),
     }),
   );
 

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -221,11 +221,12 @@ throw new Error(
         if (embeddedPkg.peerDependencies) {
           Object.entries(embeddedPkg.peerDependencies).forEach(
             ([name, version]) => {
-              addToDependenciesForModule(
-                { name, version },
-                embeddedPeerDependencies,
-                embeddedPkg.name,
-              );
+              addToDependenciesForModule({
+                dependency: { name, version },
+                dependencies: embeddedPeerDependencies,
+                ignoreVersionCheck,
+                module: embeddedPkg.name,
+              });
             },
           );
         }

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-utils.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-utils.ts
@@ -23,11 +23,17 @@ import path from 'path';
 
 import { Task } from '../../lib/tasks';
 
-export function addToDependenciesForModule(
-  dependency: { name: string; version: string },
-  dependencies: { [key: string]: string },
-  module: string,
-): void {
+export function addToDependenciesForModule({
+  dependency,
+  dependencies,
+  ignoreVersionCheck = [],
+  module,
+}: {
+  dependency: { name: string; version: string };
+  dependencies: { [key: string]: string };
+  ignoreVersionCheck?: string[];
+  module: string;
+}): void {
   const existingDependencyVersion = dependencies[dependency.name];
   if (existingDependencyVersion === undefined) {
     dependencies[dependency.name] = dependency.version;
@@ -61,9 +67,15 @@ export function addToDependenciesForModule(
     );
     return;
   }
-  throw new Error(
-    `Several incompatible versions ('${existingDependencyVersion}', '${dependency.version}') of the same transitive dependency ('${dependency.name}') for embedded module ('${module}')`,
-  );
+  if (!ignoreVersionCheck.includes(dependency.name)) {
+    throw new Error(
+      `Several incompatible versions ('${existingDependencyVersion}', '${dependency.version}') of the same transitive dependency ('${dependency.name}') for embedded module ('${module}')`,
+    );
+  } else {
+    Task.log(
+      `Several incompatible versions ('${existingDependencyVersion}', '${dependency.version}') of the same transitive dependency ('${dependency.name}') for embedded module ('${module}') however this has been overridden to use '${dependency.version}'`,
+    );
+  }
 }
 
 export function addToMainDependencies(


### PR DESCRIPTION
This change updates the cli's --ignore-version-check flag to also ignore the check performed on a embedded transitive dependencies that are moved to peer dependencies, when it is known that the mismatch is runtime compatible.

Fixes [RHIDP-4505](https://issues.redhat.com/browse/RHIDP-4505)

@04kash @schultzp2020 FYI