### PR TITLE
feat(janus-idp/cli): remove marketplace flag

### DIFF
--- a/.changeset/shiny-snakes-tan.md
+++ b/.changeset/shiny-snakes-tan.md
@@ -1,0 +1,7 @@
+---
+"@janus-idp/cli": major
+---
+
+changes to `package-dynamic-plugins` command:
+
+- Removed `-m` (`--marketplace`) flag. This flag will be replaced with more generic implementation see: https://issues.redhat.com/browse/RHIDP-5290

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -187,10 +187,6 @@ export function registerScriptCommand(program: Command) {
       false,
     )
     .option(
-      '-m, --marketplace-file <file>',
-      'Marketplace yaml file. This is a Plugin entity definition for Marketplace.',
-    )
-    .option(
       '--platform <platform>',
       'Platform to use when building the container image. Default is "linux/amd64". Can be set to "" to not set --platfrom flag in builder command.',
       'linux/amd64',

--- a/packages/cli/src/commands/package-dynamic-plugins/command.ts
+++ b/packages/cli/src/commands/package-dynamic-plugins/command.ts
@@ -13,15 +13,8 @@ import { paths } from '../../lib/paths';
 import { Task } from '../../lib/tasks';
 
 export async function command(opts: OptionValues): Promise<void> {
-  const {
-    exportTo,
-    forceExport,
-    preserveTempDir,
-    tag,
-    useDocker,
-    marketplaceFile,
-    platform,
-  } = opts;
+  const { exportTo, forceExport, preserveTempDir, tag, useDocker, platform } =
+    opts;
   if (!exportTo && !tag) {
     Task.error(
       `Neither ${chalk.white('--export-to')} or ${chalk.white('--tag')} was specified, either specify ${chalk.white('--export-to')} to export plugins to a directory or ${chalk.white('--tag')} to export plugins to a container image`,
@@ -38,19 +31,6 @@ export async function command(opts: OptionValues): Promise<void> {
         `Unable to find ${containerTool} command: ${e}\nMake sure that ${containerTool} is installed and available in your PATH.`,
       );
       return;
-    }
-  }
-  const maketplaceInfo: Object[] = [];
-  if (marketplaceFile) {
-    if (!fs.existsSync(marketplaceFile)) {
-      Task.error(`Marketplace file ${marketplaceFile} does not exist`);
-      return;
-    }
-    const yamlDocuments = YAML.parseAllDocuments(
-      fs.readFileSync(marketplaceFile).toLocaleString(),
-    );
-    for (const document of yamlDocuments) {
-      maketplaceInfo.push(document.toJS());
     }
   }
   const workspacePackage = (await fs.readJson(
@@ -226,17 +206,6 @@ export async function command(opts: OptionValues): Promise<void> {
       const flags = [
         `--annotation io.backstage.dynamic-packages='${Buffer.from(JSON.stringify(pluginRegistryMetadata)).toString('base64')}'`,
       ];
-
-      for (const pluginInfo of maketplaceInfo) {
-        const base64pluginInfo = Buffer.from(
-          JSON.stringify(pluginInfo),
-        ).toString('base64');
-        const pluginName = (pluginInfo as { metadata: { name: string } })
-          .metadata.name;
-        flags.push(
-          `--annotation io.backstage.marketplace/${pluginName}='${base64pluginInfo}'`,
-        );
-      }
       if (platform) {
         flags.push(`--platform ${platform}`);
       }


### PR DESCRIPTION
This removes `-m` (`--marketplace`) flag from `package-dynamic-plugins` command that was added in https://github.com/janus-idp/backstage-plugins/pull/2609

This is currently not used for anything. There will be new, more generic implementation added later on. More about that at https://issues.redhat.com/browse/RHIDP-5290