### PR TITLE
chore: bump version to 3.3.5 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "private": true,
   "engines": {
     "node": "18 || 20"


### PR DESCRIPTION
This PR updates the version field in the package.json file from 3.3.4 to 3.3.5 to align with the latest release requirements.

Reason for the change: Ensure the repository reflects the correct semantic versioning for the upcoming release.
