### PR TITLE
fix(cli): add @mui/utils to the webpack singleton configuration

### DIFF
--- a/.changeset/green-worms-glow.md
+++ b/.changeset/green-worms-glow.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": minor
+---
+
+add @mui/utils to the webpack singleton configuration

--- a/packages/cli/src/lib/bundler/scalprumConfig.ts
+++ b/packages/cli/src/lib/bundler/scalprumConfig.ts
@@ -10,6 +10,11 @@ import { BundlingPaths } from './paths';
 import { transforms } from './transforms';
 import { DynamicPluginOptions } from './types';
 
+const singletonAnyVersion = {
+  singleton: true,
+  requiredVersion: '*',
+};
+
 /**
  * TODO: Create a config API to configure and optimize dependency sharing
  * https://medium.com/@marvusm.mmi/webpack-module-federation-think-twice-before-sharing-a-dependency-18b3b0e352cb
@@ -18,81 +23,36 @@ export const sharedModules = {
   /**
    * Mandatory singleton packages for sharing
    */
-  react: {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  'react-dom': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  'react-router-dom': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  'react-router': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@backstage/version-bridge': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@backstage/core-app-api': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@backstage/core-plugin-api': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@backstage/frontend-plugin-api': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@scalprum/react-core': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@openshift/dynamic-plugin-sdk': {
-    singleton: true,
-    requiredVersion: '*',
-  },
+  react: singletonAnyVersion,
+  'react-dom': singletonAnyVersion,
+
+  'react-router-dom': singletonAnyVersion,
+  'react-router': singletonAnyVersion,
+
+  '@backstage/core-app-api': singletonAnyVersion,
+  '@backstage/core-plugin-api': singletonAnyVersion,
+  '@backstage/frontend-plugin-api': singletonAnyVersion,
+  '@backstage/version-bridge': singletonAnyVersion,
+
+  '@scalprum/react-core': singletonAnyVersion,
+  '@openshift/dynamic-plugin-sdk': singletonAnyVersion,
+
   /**
-   * The following two packages are required to be shared as singletons to enable UI theming
+   * The following two packages are required to be shared as singletons to enable MUI v4 theming
    */
-  '@material-ui/core/styles': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@material-ui/styles': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@mui/material': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@mui/system': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@mui/private-theming': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@mui/styled-engine': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@emotion/cache': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@emotion/react': {
-    singleton: true,
-    requiredVersion: '*',
-  },
+  '@material-ui/core/styles': singletonAnyVersion,
+  '@material-ui/styles': singletonAnyVersion,
+
+  /**
+   * And these for MUI v5 theming
+   */
+  '@mui/material': singletonAnyVersion,
+  '@mui/system': singletonAnyVersion,
+  '@mui/private-theming': singletonAnyVersion,
+  '@mui/styled-engine': singletonAnyVersion,
+  '@mui/utils': singletonAnyVersion,
+  '@emotion/cache': singletonAnyVersion,
+  '@emotion/react': singletonAnyVersion,
 };
 
 export async function createScalprumConfig(


### PR DESCRIPTION
The change looks a bit bigger because I extracted the configuration into a variable.

But actually, it just adds `@mui/utils` to the webpack federation configuration so that the app and the plugins share one version of that.

This might resolve some MUI v5 issues... Not 100% sure...

Because Backstage configures the class name generator from `@mui/material/className` like this:

https://github.com/backstage/backstage/blob/v1.35.0/packages/theme/src/unified/UnifiedThemeProvider.tsx#L49-L51

Which is then:

https://github.com/mui/material-ui/blob/v5.x/packages/mui-material/src/className/index.ts

=> https://github.com/mui/material-ui/blob/v5.x/packages/mui-utils/src/index.ts#L46

===> https://github.com/mui/material-ui/blob/v5.x/packages/mui-utils/src/ClassNameGenerator/ClassNameGenerator.ts