### PR TITLE
fix(shared-react): use minor version instead of major for next release

### DIFF
--- a/.changeset/silent-hounds-live.md
+++ b/.changeset/silent-hounds-live.md
@@ -1,5 +1,5 @@
 ---
-"@janus-idp/shared-react": major
+"@janus-idp/shared-react": minor
 ---
 
 Update @kubernetes/client-node for shared/react.


### PR DESCRIPTION
Use minor version instead of major for next shared-react release