### PR TITLE
feat: checkPluginVersion.sh bump plugins for 1.5.0 release

### DIFF
--- a/.changeset/packages-cli.md
+++ b/.changeset/packages-cli.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/cli": minor
+---
+
+Bump packages/cli to 3.3.0 in main branch, in prep for release of 1.5.0
+

--- a/.changeset/plugins-audit-log-node.md
+++ b/.changeset/plugins-audit-log-node.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-plugin-audit-log-node": minor
+---
+
+Bump plugins/audit-log-node to 1.9.0 in main branch, in prep for release of 1.5.0
+

--- a/.changeset/plugins-shared-react.md
+++ b/.changeset/plugins-shared-react.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/shared-react": minor
+---
+
+Bump plugins/shared-react to 2.17.0 in main branch, in prep for release of 1.5.0
+

--- a/.changeset/plugins-web-terminal.md
+++ b/.changeset/plugins-web-terminal.md
@@ -1,0 +1,6 @@
+---
+"@janus-idp/backstage-plugin-web-terminal": minor
+---
+
+Bump plugins/web-terminal to 1.14.0 in main branch, in prep for release of 1.5.0
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "private": true,
   "engines": {
     "node": "20"

--- a/packages/cli/.versionhistory.md
+++ b/packages/cli/.versionhistory.md
@@ -1,3 +1,4 @@
 - Bumped to 1.8.0 in main branch for next release 1.2.0
 - Bumped to 1.14.0 in main branch for next release 1.3.0
 - Bumped to 1.19.0 in main branch, in prep for release of 1.4.0
+- Bumped to 3.3.0 in main branch, in prep for release of 1.5.0

--- a/plugins/audit-log-node/.versionhistory.md
+++ b/plugins/audit-log-node/.versionhistory.md
@@ -1,2 +1,3 @@
 - Bumped to 1.5.0 in main branch for next release 1.3.0
 - Bumped to 1.8.0 in main branch, in prep for release of 1.4.0
+- Bumped to 1.9.0 in main branch, in prep for release of 1.5.0

--- a/plugins/shared-react/.versionhistory.md
+++ b/plugins/shared-react/.versionhistory.md
@@ -1,3 +1,4 @@
 - Bumped to 2.6.0 in main branch for next release 1.2.0
 - Bumped to 2.11.0 in main branch for next release 1.3.0
 - Bumped to 2.14.0 in main branch, in prep for release of 1.4.0
+- Bumped to 2.17.0 in main branch, in prep for release of 1.5.0

--- a/plugins/web-terminal/.versionhistory.md
+++ b/plugins/web-terminal/.versionhistory.md
@@ -1,3 +1,4 @@
 - Bumped to 1.4.0 in main branch for next release 1.2.0
 - Bumped to 1.9.0 in main branch for next release 1.3.0
 - Bumped to 1.12.0 in main branch, in prep for release of 1.4.0
+- Bumped to 1.14.0 in main branch, in prep for release of 1.5.0


### PR DESCRIPTION
- **feat: checkPluginVersion.sh bump ./ to 3.6.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump packages/cli to 3.3.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/audit-log-node to 1.9.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/shared-react to 2.17.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  

- **feat: checkPluginVersion.sh bump plugins/web-terminal to 1.14.0 in main**
  Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
  