### PR TITLE
Update broken link for dynamic-plugin packaging

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,4 +29,4 @@ To try out the command locally, you can execute the following from the parent di
 
 ## Documentation
 
-- [Dynamic Plugins Documentation](https://github.com/janus-idp/backstage-showcase/blob/main/docs/dynamic-plugins.md#dynamic-plugins-support)
+- [Dynamic Plugins Documentation](https://github.com/janus-idp/backstage-showcase/blob/main/docs/dynamic-plugins/packaging-dynamic-plugins.md)


### PR DESCRIPTION
This PR updates the broken link for dynamic plugins packaging.
As the current link takes the user to a 404 page.

