### PR TITLE
[WIP] chore(janus-idp/cli): add --use-buildah flag to  command

### DIFF
--- a/.changeset/thirty-suits-draw.md
+++ b/.changeset/thirty-suits-draw.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": minor
+---
+
+adds --use-buildah flag to `package package-dynamic-plugins` command

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -183,7 +183,12 @@ export function registerScriptCommand(program: Command) {
     )
     .option(
       '--use-docker',
-      'By defult, the command uses podman to build the container image. Use this flag to use docker instead.',
+      'By default, the command uses podman to build the container image. Use this flag to use docker instead.',
+      false,
+    )
+    .option(
+      '--use-buildah',
+      'By default, the command uses podman to build the container image. Use this flag to use buildah instead.',
       false,
     )
     .option(

--- a/packages/cli/src/commands/package-dynamic-plugins/command.ts
+++ b/packages/cli/src/commands/package-dynamic-plugins/command.ts
@@ -13,15 +13,36 @@ import { paths } from '../../lib/paths';
 import { Task } from '../../lib/tasks';
 
 export async function command(opts: OptionValues): Promise<void> {
-  const { exportTo, forceExport, preserveTempDir, tag, useDocker, platform } =
-    opts;
+  const {
+    exportTo,
+    forceExport,
+    preserveTempDir,
+    tag,
+    useDocker,
+    useBuildah,
+    platform,
+  } = opts;
   if (!exportTo && !tag) {
     Task.error(
       `Neither ${chalk.white('--export-to')} or ${chalk.white('--tag')} was specified, either specify ${chalk.white('--export-to')} to export plugins to a directory or ${chalk.white('--tag')} to export plugins to a container image`,
     );
     return;
   }
-  const containerTool = useDocker ? 'docker' : 'podman';
+  if (useDocker && useBuildah) {
+    Task.error(
+      `Both ${chalk.white('--use-docker')} and ${chalk.white('--use-buildah')} were specified, please specify at most one`,
+    );
+    return;
+  }
+  let containerTool = 'podman';
+
+  if (useDocker) {
+    containerTool = 'docker';
+  }
+  if (useBuildah) {
+    containerTool = 'buildah';
+  }
+
   // check if the container tool is available, skip if just exporting the plugins to a directory
   if (!exportTo) {
     try {


### PR DESCRIPTION
adds `--use-buildah` flag to `package package-dynamic-plugins` command to make it possible to use buildah instead of podman. 