### PR TITLE
fix: cli incompatibility with yarn v1

### DIFF
--- a/.changeset/plenty-masks-buy.md
+++ b/.changeset/plenty-masks-buy.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+Fix Yarn v1 incompatibility in the `export-dynamic-plugin` command

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -42,6 +42,7 @@ export async function backend(opts: OptionValues): Promise<string> {
   const targetRelativePath = 'dist-dynamic';
   const target = path.join(paths.targetDir, targetRelativePath);
   const yarn = 'yarn';
+  const yarnVersion = execSync(`${yarn} --version`).toString().trim();
 
   const pkgContent = await fs.readFile(
     paths.resolveTarget('package.json'),
@@ -151,12 +152,6 @@ throw new Error(
     [key: string]: string;
   } = {};
 
-  function embeddedPackageRelativePath(p: ResolvedEmbedded): string {
-    return path.join(
-      'embedded',
-      p.packageName.replace(/^@/, '').replace(/\//, '-'),
-    );
-  }
   for (const embedded of embeddedResolvedPackages) {
     const embeddedDestRelativeDir = embeddedPackageRelativePath(embedded);
     const embeddedDestDir = path.join(target, embeddedDestRelativeDir);
@@ -211,6 +206,7 @@ throw new Error(
     );
     await customizeForDynamicUse({
       embedded: embeddedResolvedPackages,
+      isYarnV1: yarnVersion.startsWith('1.'),
       monoRepoPackages,
       sharedPackages: sharedPackagesRules,
       overridding: {
@@ -277,6 +273,7 @@ throw new Error(
   );
   await customizeForDynamicUse({
     embedded: embeddedResolvedPackages,
+    isYarnV1: yarnVersion.startsWith('1.'),
     monoRepoPackages,
     sharedPackages: sharedPackagesRules,
     overridding: {
@@ -359,10 +356,9 @@ throw new Error(
   if (opts.install) {
     Task.log(`Installing private dependencies of the main package`);
 
-    const version = execSync(`${yarn} --version`).toString().trim();
     const logFile = 'yarn-install.log';
     const redirect = `> ${logFile}`;
-    const yarnInstall = version.startsWith('1.')
+    const yarnInstall = yarnVersion.startsWith('1.')
       ? `${yarn} install --production${
           yarnLockExists ? ' --frozen-lockfile' : ''
         } ${redirect}`
@@ -659,6 +655,7 @@ function checkWorkspacePackageVersion(
 
 export function customizeForDynamicUse(options: {
   embedded: ResolvedEmbedded[];
+  isYarnV1: boolean;
   monoRepoPackages: Packages | undefined;
   sharedPackages?: SharedPackagesRules | undefined;
   overridding?:
@@ -757,6 +754,23 @@ export function customizeForDynamicUse(options: {
           pkgToCustomize.peerDependencies[dep] =
             pkgToCustomize.dependencies[dep];
           delete pkgToCustomize.dependencies[dep];
+
+          continue;
+        }
+
+        // If yarn v1 => detect if the current dep is an embedded one,
+        // and if it is the case replace the version by the file protocol
+        // (like what we do for the resolutions).
+        if (options.isYarnV1) {
+          const embeddedDep = options.embedded.find(
+            e =>
+              e.packageName === dep &&
+              checkWorkspacePackageVersion(dependencyVersionSpec, e),
+          );
+          if (embeddedDep) {
+            pkgToCustomize.dependencies[dep] =
+              `file:./${embeddedPackageRelativePath(embeddedDep)}`;
+          }
         }
       }
     }
@@ -920,4 +934,11 @@ function validatePluginEntryPoints(target: string): string {
   }
 
   return '';
+}
+
+function embeddedPackageRelativePath(p: ResolvedEmbedded): string {
+  return path.join(
+    'embedded',
+    p.packageName.replace(/^@/, '').replace(/\//, '-'),
+  );
 }

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -758,7 +758,7 @@ export function customizeForDynamicUse(options: {
           continue;
         }
 
-        // If yarn v1 => detect if the current dep is an embedded one,
+        // If yarn v1, then detect if the current dep is an embedded one,
         // and if it is the case replace the version by the file protocol
         // (like what we do for the resolutions).
         if (options.isYarnV1) {

--- a/packages/cli/src/commands/export-dynamic-plugin/frontend.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/frontend.ts
@@ -112,6 +112,7 @@ export async function frontend(
     const monoRepoPackages = await getPackages(paths.targetDir);
     await customizeForDynamicUse({
       embedded: [],
+      isYarnV1: false,
       monoRepoPackages,
       overridding: {
         name: `${name}-dynamic`,


### PR DESCRIPTION
Yarn v1 support for file protocol used in conjunction with resolution is limited, so that in some cases the `export-dynamic-plugin` command may fail on `yarn v1`.

This PR  accommodates this limitation without changing the existing behavior and generated output for yarn v3.