### PR TITLE
chore: remove audit-log-node changeset to fix release workflow

### DIFF
--- a/.changeset/plugins-audit-log-node.md
+++ b/.changeset/plugins-audit-log-node.md
@@ -1,6 +1,0 @@
----
-"@janus-idp/backstage-plugin-audit-log-node": minor
----
-
-Bump plugins/audit-log-node to 1.9.0 in main branch, in prep for release of 1.5.0
-


### PR DESCRIPTION
Since the `audit-log-node` plugin was [removed from the repository](https://github.com/janus-idp/backstage-plugins/pull/2641), [this changeset](https://github.com/janus-idp/backstage-plugins/blob/main/.changeset/plugins-audit-log-node.md) needs to be deleted as well. The release workflow is attempting to release this non-existent package because of the changeset, which is causing [the workflow to fail](https://github.com/janus-idp/backstage-plugins/actions/runs/13707841310/job/38337388474).