### PR TITLE
fix(cli): override manually added resolutions

### DIFF
--- a/.changeset/metal-plums-bow.md
+++ b/.changeset/metal-plums-bow.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+This change ensures the CLI properly updates any manually added resolutions a plugin has with the embedded version. This fixes cases where a plugin may be using resolutions for finer grained version control on packages the CLI would embed, such as native dependencies.

--- a/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend-embed-as-dependencies.ts
@@ -785,6 +785,9 @@ export function customizeForDynamicUse(options: {
     // See https://github.com/yarnpkg/yarn/issues/6373#issuecomment-760068356
     pkgToCustomize.devDependencies = {};
 
+    // additionalOverrides and additionalResolutions will override the
+    // current package.json entries for "overrides" and "resolutions"
+    // respectively
     const overrides = (pkgToCustomize as any).overrides || {};
     (pkgToCustomize as any).overrides = {
       // The following lines are a workaround for the fact that the @aws-sdk/util-utf8-browser package
@@ -795,8 +798,8 @@ export function customizeForDynamicUse(options: {
       '@aws-sdk/util-utf8-browser': {
         '@smithy/util-utf8': '^2.0.0',
       },
-      ...(options.additionalOverrides || {}),
       ...overrides,
+      ...(options.additionalOverrides || {}),
     };
     const resolutions = (pkgToCustomize as any).resolutions || {};
     (pkgToCustomize as any).resolutions = {
@@ -806,8 +809,8 @@ export function customizeForDynamicUse(options: {
       //
       // See https://github.com/aws/aws-sdk-js-v3/issues/5305.
       '@aws-sdk/util-utf8-browser': 'npm:@smithy/util-utf8@~2',
-      ...(options.additionalResolutions || {}),
       ...resolutions,
+      ...(options.additionalResolutions || {}),
     };
 
     if (options.after) {


### PR DESCRIPTION
This change ensures the CLI overrides any existing resolutions in a plugin's package.json to ensure the dynamic plugin's package.json properly refers to embedded packages.  This fixes cases where a plugin package is using resolutions for more control of the dependencies to support offline builds.

This fixes [RHIDP-6448](https://issues.redhat.com/browse/RHIDP-6448)