### PR TITLE
fix(cli): use the correct package name

### DIFF
--- a/.changeset/fresh-mirrors-help.md
+++ b/.changeset/fresh-mirrors-help.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+This change updates the package-dynamic-plugins command to use the exported plugin package name rather than deriving a package name from the base plugin package and package role. This change also ensures the exported plugin metadata is taken from the exported package instead of the original package. This change will potentially affect the final directory name of exported plugins.


### PR DESCRIPTION
This change ensures package-dynamic-plugin takes the package name as-is from the exported plugin package, rather than derive the name based on the original plugin package and role.  This change also ensures that plugin metadata comes from the exported package.  Finally this change removes some output that isn't necessary when detecting plugin configuration files.

Fixes [RHIDP-6652](https://issues.redhat.com/browse/RHIDP-6652)