### PR TITLE
fix: make plugin config schema generation compatible with upstream.

### DIFF
--- a/.changeset/odd-planes-reply.md
+++ b/.changeset/odd-planes-reply.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+Prepare for better compatibility with the upstream dynamic plugins support, by generating the config schema for backend plugins in both `dist/configSchema.json` (for backward compatibility with RHDH) and `dist/.config-schema.json` for consistency and compatibility with upstream.


### PR DESCRIPTION
Currently, for backend dynamic plugin packages, the config schema json file is generated in `dist/configSchema.json`.
It's unfortunate since, on the frontend side in the upcoming upstream dynamic frontend plugin support based on module federation, it would be generated in  `dist/.config-schema.json`, as it is for complete bundled apps (notice the added `.`there). And surely in the upstream dynamic plugins support we don't want to expect a different config schema file location for frontend & backend plugins.

This PRs prepares for better compatibility with upstream by generating the config schema in both `dist/configSchema.json` (for backward compatibility with RHDH) and `dist/.config-schema.json` for consistency and compatibility with upstream.