### PR TITLE
fix(cli): create appropriate plugin directory name

### DIFF
--- a/.changeset/rude-bobcats-shake.md
+++ b/.changeset/rude-bobcats-shake.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+This change fixes package-dynamic-plugin to transform any organization identifier into a flat file path when packaging dynamic plugins.

--- a/packages/cli/src/commands/package-dynamic-plugins/command.ts
+++ b/packages/cli/src/commands/package-dynamic-plugins/command.ts
@@ -114,7 +114,10 @@ export async function command(opts: OptionValues): Promise<void> {
       const pluginPackageJson = (await fs.readJson(
         path.join(distDynamicDirectory, 'package.json'),
       )) as PackageJson;
-      const packageName = pluginPackageJson.name!.replace(/-dynamic$/, '');
+      const packageName = pluginPackageJson
+        .name!.replace(/-dynamic$/, '')
+        .replace(/^@/, '')
+        .replace(/\//, '-');
       const targetDirectory = path.join(tmpDir, packageName);
       Task.log(`Copying '${distDynamicDirectory}' to '${targetDirectory}`);
       try {
@@ -125,6 +128,7 @@ export async function command(opts: OptionValues): Promise<void> {
           dereference: true,
         });
         const {
+          name,
           version,
           description,
           backstage,
@@ -138,7 +142,7 @@ export async function command(opts: OptionValues): Promise<void> {
         } = pluginPackageJson;
         pluginRegistryMetadata.push({
           [packageName]: {
-            name: packageName,
+            name,
             version,
             description,
             backstage,


### PR DESCRIPTION
This change restores the package-dynamic-plugin's conversion of the exported dynamic plugin's package name to a flat file path.

Fixes [RHIDP-6789](https://issues.redhat.com/browse/RHIDP-6789)