### PR TITLE
fix: role retrieval bug in the `metadata` command, and introduce backstage `support-versions` check during export.

### DIFF
--- a/.changeset/giant-spies-tap.md
+++ b/.changeset/giant-spies-tap.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+Fix wrong role retrieval which could break the `metadata` command behavior.

--- a/.changeset/swift-plums-join.md
+++ b/.changeset/swift-plums-join.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+Check backstage the `support-versions` field value during export, and fix it if possible while emitting a warning.

--- a/packages/cli/src/commands/package-dynamic-plugins/command.ts
+++ b/packages/cli/src/commands/package-dynamic-plugins/command.ts
@@ -166,13 +166,13 @@ export async function command(opts: OptionValues): Promise<void> {
             );
           } catch (err) {
             Task.log(
-              `Encountered an error parsing configuration at ${pluginConfigPath}, no example configuration will be displayed`,
+              `Encountered an error parsing configuration at ${pluginConfigPath}, no example configuration will be displayed. The error was ${err}`,
             );
           }
         }
       } catch (err) {
         Task.log(
-          `Encountered an error copying static assets for plugin ${packageFilePath}, the plugin will not be packaged.  The error was ${err}`,
+          `Encountered an error copying static assets for plugin ${packageFilePath}, the plugin will not be packaged. The error was ${err}`,
         );
       }
     }
@@ -279,7 +279,7 @@ async function discoverPluginPackages() {
       packageJsonFilePaths.map(async packageFilePath => {
         const packageJson = (await fs.readJson(packageFilePath)) as PackageJson;
         const packageRole = PackageRoles.getRoleFromPackage(packageJson);
-        const packageRoleInfo = PackageRoles.getRoleInfo(packageRole || '');
+        const packageRoleInfo = PackageRoles.getRoleInfo(packageRole ?? '');
         const packageDirectory = path.dirname(packageFilePath);
         return {
           packageDirectory,

--- a/packages/cli/src/commands/package-dynamic-plugins/command.ts
+++ b/packages/cli/src/commands/package-dynamic-plugins/command.ts
@@ -37,7 +37,7 @@ export async function command(opts: OptionValues): Promise<void> {
     paths.resolveTarget('package.json'),
   )) as PackageJson;
   const workspacePackageRole =
-    PackageRoles.detectRoleFromPackage(workspacePackage);
+    PackageRoles.getRoleFromPackage(workspacePackage);
   const workspacePackageRoleInfo =
     workspacePackageRole !== undefined
       ? PackageRoles.getRoleInfo(workspacePackageRole)


### PR DESCRIPTION
Fix role retrieval bug in the `metadata` command, and introduce backstage `support-versions` check during export.