### PR TITLE
fix(cli): cater for new potential error

### DIFF
--- a/.changeset/purple-rabbits-roll.md
+++ b/.changeset/purple-rabbits-roll.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": patch
+---
+
+This change updates the CLI to cater for the way modules are handled by `require` in node v20.19.0, which fixes an error that can be thrown by the CLI when an es6 or typescript module is picked up by `require`.

--- a/packages/cli/src/commands/export-dynamic-plugin/backend.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/backend.ts
@@ -858,10 +858,12 @@ function validatePluginEntryPoints(target: string): string {
     try {
       return dynamicPluginRequire(modulePath);
     } catch (e) {
-      // Retry only if we failed with SyntaxError because the `ts` require extension was not there.
-      // Else we should throw.
+      // Retry only if we failed with SyntaxError or unsupported dir format
+      // because the `ts` require extension was not there.  Else we should
+      // throw.
       if (
-        e?.name !== SyntaxError.name ||
+        (e?.code !== 'ERR_UNSUPPORTED_DIR_IMPORT' &&
+          e?.name !== SyntaxError.name) ||
         dynamicPluginRequire.extensions['.ts'] !== undefined
       ) {
         throw e;


### PR DESCRIPTION
This change updates the existing condition where the CLI caters for when a package main script points to a .ts file.  This addresses an update to the default behavior for how modules are handled by `require`.

This fixes [RHIDP-6698](https://issues.redhat.com/browse/RHIDP-6698)