### PR TITLE
feat(cli): add deprecation warnings to package-dynamic-plugins and export-dynamic-plugin

### DIFF
--- a/.changeset/forty-numbers-serve.md
+++ b/.changeset/forty-numbers-serve.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": minor
+---
+
+add deprecation warnings to package-dynamic-plugins and export-dynamic-plugin and point to new rhdh-cli

--- a/packages/cli/MIGRATION.md
+++ b/packages/cli/MIGRATION.md
@@ -1,0 +1,71 @@
+# Migration Guide: @janus-idp/cli → @red-hat-developer-hub/cli
+
+⚠️ **The @janus-idp/cli is deprecated and will no longer receive updates.**
+
+This guide will help you migrate from the deprecated `@janus-idp/cli` to the new `@red-hat-developer-hub/cli`.
+
+## Overview
+
+The Red Hat Developer Hub team has introduced a new CLI tool that replaces the `@janus-idp/cli` with improved functionality and better maintainability. The new CLI offers more flexibility and ease of use for developing, packaging, and distributing dynamic plugins for Red Hat Developer Hub (RHDH).
+
+## Command Migration
+
+### Export Dynamic Plugin
+
+**Old Command:**
+```bash
+npx @janus-idp/cli package export-dynamic-plugin
+```
+
+**New Command:**
+```bash
+npx @red-hat-developer-hub/cli plugin export
+```
+
+### Package Dynamic Plugins
+
+**Old Command:**
+```bash
+npx @janus-idp/cli package package-dynamic-plugins
+```
+
+**New Command:**
+```bash
+npx @red-hat-developer-hub/cli plugin package
+```
+
+### NPM Scripts Example
+
+**Before:**
+```json
+{
+  "scripts": {
+    "export-dynamic": "@janus-idp/cli package export-dynamic-plugin",
+    "package-plugins": "@janus-idp/cli package package-dynamic-plugins"
+  }
+}
+```
+
+**After:**
+```json
+{
+  "scripts": {
+    "export-dynamic": "@red-hat-developer-hub/cli plugin export",
+    "package-plugins": "@red-hat-developer-hub/cli plugin package"
+  }
+}
+```
+
+## Support and Resources
+
+- **New CLI Repository**: https://github.com/redhat-developer/rhdh-cli
+- **Documentation**: Available in the new CLI repository
+- **Issues**: Report issues and bugs in Jira at https://issues.redhat.com/projects/RHIDP/summary
+
+## Getting Help
+
+If you encounter issues during migration:
+
+1. Check the new CLI documentation: https://github.com/redhat-developer/rhdh-cli
+2. Compare command options between old and new CLI using `--help`
+3. Open an issue in the new CLI repository if you find missing functionality

--- a/packages/cli/MIGRATION.md
+++ b/packages/cli/MIGRATION.md
@@ -13,11 +13,13 @@ The Red Hat Developer Hub team has introduced a new CLI tool that replaces the `
 ### Export Dynamic Plugin
 
 **Old Command:**
+
 ```bash
 npx @janus-idp/cli package export-dynamic-plugin
 ```
 
 **New Command:**
+
 ```bash
 npx @red-hat-developer-hub/cli plugin export
 ```
@@ -25,11 +27,13 @@ npx @red-hat-developer-hub/cli plugin export
 ### Package Dynamic Plugins
 
 **Old Command:**
+
 ```bash
 npx @janus-idp/cli package package-dynamic-plugins
 ```
 
 **New Command:**
+
 ```bash
 npx @red-hat-developer-hub/cli plugin package
 ```
@@ -37,6 +41,7 @@ npx @red-hat-developer-hub/cli plugin package
 ### NPM Scripts Example
 
 **Before:**
+
 ```json
 {
   "scripts": {
@@ -47,6 +52,7 @@ npx @red-hat-developer-hub/cli plugin package
 ```
 
 **After:**
+
 ```json
 {
   "scripts": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,17 +1,21 @@
 # @janus-idp/cli
 
-> [!WARNING]
+<!-- prettier formatting breaks GitHub Markdown callouts, so this block is ignored -->
+<!-- prettier-ignore-start -->
+> [!WARNING] 
 > **⚠️ DEPRECATION NOTICE**
-> 
+>
 > This CLI is **deprecated** and will no longer receive updates. Please migrate to the new **[@red-hat-developer-hub/cli](https://github.com/redhat-developer/rhdh-cli)**.
 >
 > **Command Migration:**
+>
 > - `npx @janus-idp/cli package export-dynamic-plugin` → `npx @red-hat-developer-hub/cli plugin export`
 > - `npx @janus-idp/cli package package-dynamic-plugins` → `npx @red-hat-developer-hub/cli plugin package`
 >
 > For more information, visit: https://github.com/redhat-developer/rhdh-cli
 >
 > **📖 [View Migration Guide](./MIGRATION.md)** - Step-by-step instructions for migrating to the new CLI
+<!-- prettier-ignore-end -->
 
 This package provides a CLI for developing and exporting Backstage plugins as dynamic plugins. It implements a few new commands on top of the @backstage/cli codebase:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,18 @@
 # @janus-idp/cli
 
+> [!WARNING]
+> **⚠️ DEPRECATION NOTICE**
+> 
+> This CLI is **deprecated** and will no longer receive updates. Please migrate to the new **[@red-hat-developer-hub/cli](https://github.com/redhat-developer/rhdh-cli)**.
+>
+> **Command Migration:**
+> - `npx @janus-idp/cli package export-dynamic-plugin` → `npx @red-hat-developer-hub/cli plugin export`
+> - `npx @janus-idp/cli package package-dynamic-plugins` → `npx @red-hat-developer-hub/cli plugin package`
+>
+> For more information, visit: https://github.com/redhat-developer/rhdh-cli
+>
+> **📖 [View Migration Guide](./MIGRATION.md)** - Step-by-step instructions for migrating to the new CLI
+
 This package provides a CLI for developing and exporting Backstage plugins as dynamic plugins. It implements a few new commands on top of the @backstage/cli codebase:
 
 - `package export-dynamic plugin` - Exports a Backstage plugin to a dynamic plugin package

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,7 @@
   "name": "@janus-idp/cli",
   "description": "CLI for developing Backstage plugins and apps",
   "version": "3.6.1",
+  "deprecated": "This package is deprecated and will no longer receive updates. Please migrate to @red-hat-developer-hub/cli. See https://github.com/redhat-developer/rhdh-cli for more information.",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/commands/export-dynamic-plugin/command.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/command.ts
@@ -34,9 +34,19 @@ export async function command(opts: OptionValues): Promise<void> {
   // Display deprecation warning for this specific command
   console.log();
   console.log(chalk.yellow('⚠️  COMMAND DEPRECATED'));
-  console.log(chalk.yellow('This command has been moved to the new @red-hat-developer-hub/cli'));
-  console.log(chalk.white('Please use: ') + chalk.green('npx @red-hat-developer-hub/cli plugin export'));
-  console.log(chalk.yellow('For more information: ') + chalk.cyan('https://github.com/redhat-developer/rhdh-cli'));
+  console.log(
+    chalk.yellow(
+      'This command has been moved to the new @red-hat-developer-hub/cli',
+    ),
+  );
+  console.log(
+    chalk.white('Please use: ') +
+      chalk.green('npx @red-hat-developer-hub/cli plugin export'),
+  );
+  console.log(
+    chalk.yellow('For more information: ') +
+      chalk.cyan('https://github.com/redhat-developer/rhdh-cli'),
+  );
   console.log();
 
   const rawPkg = await fs.readJson(paths.resolveTarget('package.json'));

--- a/packages/cli/src/commands/export-dynamic-plugin/command.ts
+++ b/packages/cli/src/commands/export-dynamic-plugin/command.ts
@@ -31,6 +31,14 @@ import { applyDevOptions } from './dev';
 import { frontend } from './frontend';
 
 export async function command(opts: OptionValues): Promise<void> {
+  // Display deprecation warning for this specific command
+  console.log();
+  console.log(chalk.yellow('⚠️  COMMAND DEPRECATED'));
+  console.log(chalk.yellow('This command has been moved to the new @red-hat-developer-hub/cli'));
+  console.log(chalk.white('Please use: ') + chalk.green('npx @red-hat-developer-hub/cli plugin export'));
+  console.log(chalk.yellow('For more information: ') + chalk.cyan('https://github.com/redhat-developer/rhdh-cli'));
+  console.log();
+
   const rawPkg = await fs.readJson(paths.resolveTarget('package.json'));
   const role = PackageRoles.getRoleFromPackage(rawPkg);
   if (!role) {

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -80,7 +80,7 @@ export function registerScriptCommand(program: Command) {
   command
     .command('export-dynamic-plugin')
     .description(
-      'Build and export a plugin package to be loaded as a dynamic plugin. The repackaged dynamic plugin is exported inside a ./dist-dynamic sub-folder.',
+      '[DEPRECATED] Build and export a plugin package to be loaded as a dynamic plugin. Use "npx @red-hat-developer-hub/cli plugin export" instead.',
     )
     .option('--minify', 'Minify the generated code (backend plugin only).')
     .option(
@@ -157,7 +157,7 @@ export function registerScriptCommand(program: Command) {
   command
     .command('package-dynamic-plugins')
     .description(
-      'Package up exported dynamic plugins as container image for deployment',
+             '[DEPRECATED] Package up exported dynamic plugins as container image for deployment. Use "npx @red-hat-developer-hub/cli plugin package" instead.',
     )
     .option(
       '--force-export',

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -157,7 +157,7 @@ export function registerScriptCommand(program: Command) {
   command
     .command('package-dynamic-plugins')
     .description(
-             '[DEPRECATED] Package up exported dynamic plugins as container image for deployment. Use "npx @red-hat-developer-hub/cli plugin package" instead.',
+      '[DEPRECATED] Package up exported dynamic plugins as container image for deployment. Use "npx @red-hat-developer-hub/cli plugin package" instead.',
     )
     .option(
       '--force-export',

--- a/packages/cli/src/commands/package-dynamic-plugins/command.ts
+++ b/packages/cli/src/commands/package-dynamic-plugins/command.ts
@@ -13,6 +13,14 @@ import { paths } from '../../lib/paths';
 import { Task } from '../../lib/tasks';
 
 export async function command(opts: OptionValues): Promise<void> {
+  // Display deprecation warning for this specific command
+  console.log();
+  console.log(chalk.yellow('⚠️  COMMAND DEPRECATED'));
+  console.log(chalk.yellow('This command has been moved to the new @red-hat-developer-hub/cli'));
+  console.log(chalk.white('Please use: ') + chalk.green('npx @red-hat-developer-hub/cli plugin package'));
+  console.log(chalk.yellow('For more information: ') + chalk.cyan('https://github.com/redhat-developer/rhdh-cli'));
+  console.log();
+
   const {
     exportTo,
     forceExport,

--- a/packages/cli/src/commands/package-dynamic-plugins/command.ts
+++ b/packages/cli/src/commands/package-dynamic-plugins/command.ts
@@ -16,9 +16,19 @@ export async function command(opts: OptionValues): Promise<void> {
   // Display deprecation warning for this specific command
   console.log();
   console.log(chalk.yellow('⚠️  COMMAND DEPRECATED'));
-  console.log(chalk.yellow('This command has been moved to the new @red-hat-developer-hub/cli'));
-  console.log(chalk.white('Please use: ') + chalk.green('npx @red-hat-developer-hub/cli plugin package'));
-  console.log(chalk.yellow('For more information: ') + chalk.cyan('https://github.com/redhat-developer/rhdh-cli'));
+  console.log(
+    chalk.yellow(
+      'This command has been moved to the new @red-hat-developer-hub/cli',
+    ),
+  );
+  console.log(
+    chalk.white('Please use: ') +
+      chalk.green('npx @red-hat-developer-hub/cli plugin package'),
+  );
+  console.log(
+    chalk.yellow('For more information: ') +
+      chalk.cyan('https://github.com/redhat-developer/rhdh-cli'),
+  );
   console.log();
 
   const {


### PR DESCRIPTION
- add deprecation warning to commands that were moved to a new [rhdh-cli](https://github.com/redhat-developer/rhdh-cli)
- add a quick migration guide
 
fixes: https://issues.redhat.com/browse/RHIDP-7062 