### PR TITLE
chore: mark shared-react as deprecated as of 1.7.0

### DIFF
--- a/plugins/shared-react/README.md
+++ b/plugins/shared-react/README.md
@@ -1,6 +1,6 @@
 # ❗DEPRECATED❗
 
-This package is deprecated and no longer maintained. See https://issues.redhat.com/browse/RHIDP-5309 for tips/suggestions on how to migrate to something else.
+As of 2025/08/20, this package is deprecated and no longer maintained. See https://issues.redhat.com/browse/RHIDP-5309 for tips/suggestions on how to migrate to something else.
 
 ## Janus React Common
 

--- a/plugins/shared-react/README.md
+++ b/plugins/shared-react/README.md
@@ -1,7 +1,11 @@
-# Janus React Common
+# ❗DEPRECATED❗
+
+This package is deprecated and no longer maintained. See https://issues.redhat.com/browse/RHIDP-5309 for tips/suggestions on how to migrate to something else.
+
+## Janus React Common
 
 Shared code for utils, types, and React components for the Janus frontend plugins.
 
-## Version bump history
+### Version bump history
 
 - Bumped to 2.5.5 to re-release changes meant for 2.5.4, which failed due to timeout - see https://github.com/janus-idp/backstage-plugins/issues/1467


### PR DESCRIPTION
mark shared-react as deprecated as of 1.7.0