### PR TITLE
fix(cli): remove unnecessary singleton entries

### DIFF
--- a/.changeset/late-forks-decide.md
+++ b/.changeset/late-forks-decide.md
@@ -1,0 +1,5 @@
+---
+"@janus-idp/cli": minor
+---
+
+Remove backstage packages from the webpack singleton configuration.

--- a/packages/cli/src/lib/bundler/scalprumConfig.ts
+++ b/packages/cli/src/lib/bundler/scalprumConfig.ts
@@ -10,10 +10,6 @@ import { BundlingPaths } from './paths';
 import { transforms } from './transforms';
 import { DynamicPluginOptions } from './types';
 
-/**
- * TODO: Create a config API to configure and optimize dependency sharing
- * https://medium.com/@marvusm.mmi/webpack-module-federation-think-twice-before-sharing-a-dependency-18b3b0e352cb
- */
 export const sharedModules = {
   /**
    * Mandatory singleton packages for sharing
@@ -26,27 +22,11 @@ export const sharedModules = {
     singleton: true,
     requiredVersion: '*',
   },
-  'react-router-dom': {
-    singleton: true,
-    requiredVersion: '*',
-  },
   'react-router': {
     singleton: true,
     requiredVersion: '*',
   },
-  '@backstage/version-bridge': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@backstage/core-app-api': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@backstage/core-plugin-api': {
-    singleton: true,
-    requiredVersion: '*',
-  },
-  '@backstage/frontend-plugin-api': {
+  'react-router-dom': {
     singleton: true,
     requiredVersion: '*',
   },


### PR DESCRIPTION
This change removes a few entries for backstage libraries from the webpack singleton config, as these libraries can handle duplicate instances being loaded at runtime.  This change fixes [RHDHBUGS-2495](https://issues.redhat.com/browse/RHDHBUGS-2495).


A way to test this is to `yarn link` the `packages/cli` directory in your rhdh clone both at the root and in the `dynamic-plugins` folder, then rebuild rhdh and build/export the wrappers under `dynamic-plugins`